### PR TITLE
feat(evaluation): add evaluator registry and evaluate_profile

### DIFF
--- a/src/qallm/evaluation.py
+++ b/src/qallm/evaluation.py
@@ -1,0 +1,471 @@
+"""Evaluator resolver and profile evaluation for QALLM.
+
+This module turns a declarative :class:`qallm.profiles.QualityProfile` into
+a concrete verdict. It does three things:
+
+  * Maintains a registry of evaluator functions, each addressed by a stable
+    string id (for example ``"radon.mi"``) referenced from a profile.
+  * Resolves an evaluator id to a callable.
+  * Walks a profile's dimensions and indicators, runs each evaluator
+    against a code unit, and returns a typed :class:`ProfileVerdict`.
+
+Design notes
+------------
+
+Evaluators have the signature ``(source: str, context: dict) -> float | None``.
+A return value of ``None`` means the evaluator declined to produce a value
+for this input (for example, the reproducibility evaluator without a
+project root). The indicator is then marked ``SKIPPED`` in the verdict
+rather than failing.
+
+The built-in evaluators that wrap Radon and Bandit shell out using the
+same commands and flags as :mod:`qallm.analysis.metrics`, so static
+results are consistent between the legacy ``StaticAnalyzer`` and the new
+profile-based path.
+
+Verification-backed evaluators (``qallm.verification.pass_rate``,
+``qallm.verification.bugs``) are registered as deferred stubs. They
+require a running verification session, which is expensive and out of
+scope for this PR. They return ``None`` so the indicators are recorded
+as ``SKIPPED`` until a follow-up wires the orchestrator into the
+evaluator path.
+
+References
+----------
+
+EVERSE Research Software Quality Dimensions:
+    https://everse.software/RSQKit/quality_dimensions
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from enum import Enum
+from pathlib import Path
+from typing import Any, Callable
+
+from qallm.profiles import (
+    Comparator,
+    DimensionSpec,
+    QualityDimension,
+    QualityIndicator,
+    QualityProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Result types
+# ---------------------------------------------------------------------------
+
+
+class IndicatorStatus(str, Enum):
+    """Outcome of evaluating one indicator."""
+
+    PASS = "pass"
+    FAIL = "fail"
+    SKIPPED = "skipped"
+    ERROR = "error"
+
+
+@dataclass
+class IndicatorResult:
+    """The result of evaluating one indicator."""
+
+    name: str
+    evaluator: str
+    threshold: float
+    comparator: str
+    measured: float | None
+    status: IndicatorStatus
+    detail: str = ""
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "evaluator": self.evaluator,
+            "threshold": self.threshold,
+            "comparator": self.comparator,
+            "measured": self.measured,
+            "status": self.status.value,
+            "detail": self.detail,
+        }
+
+
+@dataclass
+class DimensionResult:
+    """The roll-up across all indicators of one dimension."""
+
+    dimension: QualityDimension
+    indicators: list[IndicatorResult] = field(default_factory=list)
+
+    @property
+    def status(self) -> IndicatorStatus:
+        """Dimension status is the worst non-skipped indicator status.
+
+        If every indicator was skipped, the dimension is SKIPPED. If any
+        errored, the dimension is ERROR. Otherwise, FAIL if any failed,
+        else PASS.
+        """
+        statuses = [ind.status for ind in self.indicators]
+        if not statuses:
+            return IndicatorStatus.SKIPPED
+        if all(s is IndicatorStatus.SKIPPED for s in statuses):
+            return IndicatorStatus.SKIPPED
+        if any(s is IndicatorStatus.ERROR for s in statuses):
+            return IndicatorStatus.ERROR
+        if any(s is IndicatorStatus.FAIL for s in statuses):
+            return IndicatorStatus.FAIL
+        return IndicatorStatus.PASS
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dimension": self.dimension.value,
+            "status": self.status.value,
+            "indicators": [i.to_dict() for i in self.indicators],
+        }
+
+
+@dataclass
+class ProfileVerdict:
+    """The result of evaluating a full :class:`QualityProfile`."""
+
+    profile_id: str
+    dimensions: list[DimensionResult] = field(default_factory=list)
+
+    @property
+    def status(self) -> IndicatorStatus:
+        """Overall status follows the same worst-of rule as dimensions."""
+        statuses = [d.status for d in self.dimensions]
+        if not statuses:
+            return IndicatorStatus.SKIPPED
+        if all(s is IndicatorStatus.SKIPPED for s in statuses):
+            return IndicatorStatus.SKIPPED
+        if any(s is IndicatorStatus.ERROR for s in statuses):
+            return IndicatorStatus.ERROR
+        if any(s is IndicatorStatus.FAIL for s in statuses):
+            return IndicatorStatus.FAIL
+        return IndicatorStatus.PASS
+
+    def get_dimension(
+        self, dimension: QualityDimension
+    ) -> DimensionResult | None:
+        for d in self.dimensions:
+            if d.dimension is dimension:
+                return d
+        return None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "profile_id": self.profile_id,
+            "status": self.status.value,
+            "dimensions": [d.to_dict() for d in self.dimensions],
+        }
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+# An evaluator takes the source string and a context dict, and returns a
+# float (the measured value) or None (declined / not applicable).
+EvaluatorFn = Callable[[str, dict[str, Any]], float | None]
+
+
+_REGISTRY: dict[str, EvaluatorFn] = {}
+
+
+def register(evaluator_id: str, fn: EvaluatorFn) -> None:
+    """Register an evaluator function under a stable string id.
+
+    Overwrites any previous registration. Used both for built-ins (below)
+    and for tests that want to inject a stub.
+    """
+    _REGISTRY[evaluator_id] = fn
+
+
+def resolve(evaluator_id: str) -> EvaluatorFn:
+    """Look up an evaluator by id.
+
+    Raises:
+        KeyError: if no evaluator is registered under ``evaluator_id``.
+    """
+    try:
+        return _REGISTRY[evaluator_id]
+    except KeyError as exc:
+        known = ", ".join(sorted(_REGISTRY)) or "(none)"
+        raise KeyError(
+            f"Unknown evaluator '{evaluator_id}'. Registered evaluators: "
+            f"{known}."
+        ) from exc
+
+
+def registered_evaluators() -> list[str]:
+    """Return the ids of all registered evaluators, sorted."""
+    return sorted(_REGISTRY)
+
+
+# ---------------------------------------------------------------------------
+# Built-in evaluators
+# ---------------------------------------------------------------------------
+
+
+def _radon_mi(source: str, context: dict[str, Any]) -> float | None:
+    """Maintainability Index via Radon. Returns a float on the 0 to 100 scale."""
+    if not source.strip():
+        return None
+    try:
+        result = subprocess.run(
+            ["radon", "mi", "-j", "-"],
+            input=source,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        data = json.loads(result.stdout)
+        val = next(iter(data.values()))
+        if isinstance(val, dict) and "mi" in val:
+            return float(val["mi"])
+        if isinstance(val, (int, float)):
+            return float(val)
+    except (json.JSONDecodeError, StopIteration, ValueError, TypeError):
+        return None
+    return None
+
+
+def _radon_cc(source: str, context: dict[str, Any]) -> float | None:
+    """Average cyclomatic complexity per function via Radon."""
+    if not source.strip():
+        return None
+    try:
+        result = subprocess.run(
+            ["radon", "cc", "-j", "-"],
+            input=source,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if result.returncode != 0 or not result.stdout.strip():
+        return None
+    try:
+        data = json.loads(result.stdout)
+        blocks = next(iter(data.values()))
+        if not blocks:
+            # No functions defined; treat as zero complexity, not skipped.
+            return 0.0
+        return sum(b.get("complexity", 0) for b in blocks) / len(blocks)
+    except (json.JSONDecodeError, StopIteration, ZeroDivisionError, TypeError):
+        return None
+
+
+def _bandit_high(source: str, context: dict[str, Any]) -> float | None:
+    """Count of HIGH-severity Bandit findings on the source."""
+    if not source.strip():
+        return None
+    try:
+        result = subprocess.run(
+            ["bandit", "-r", "-f", "json", "-q", "-"],
+            input=source,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (subprocess.TimeoutExpired, FileNotFoundError):
+        return None
+    if not result.stdout.strip():
+        return None
+    try:
+        data = json.loads(result.stdout)
+        results = data.get("results", [])
+        return float(
+            sum(1 for r in results if r.get("issue_severity") == "HIGH")
+        )
+    except (json.JSONDecodeError, TypeError):
+        return None
+
+
+_MANIFEST_NAMES = ("requirements.txt", "environment.yml", "pyproject.toml")
+
+
+def _repro_manifest(source: str, context: dict[str, Any]) -> float | None:
+    """1.0 if a recognised environment manifest exists under ``project_root``.
+
+    Returns ``None`` if no project root is supplied: reproducibility is a
+    property of a project, not of a snippet, and we'd rather skip than
+    fabricate.
+    """
+    root = context.get("project_root")
+    if root is None:
+        return None
+    root_path = Path(root)
+    if not root_path.exists():
+        return None
+    for name in _MANIFEST_NAMES:
+        if (root_path / name).exists():
+            return 1.0
+    return 0.0
+
+
+def _repro_determinism(source: str, context: dict[str, Any]) -> float | None:
+    """Determinism check is sandbox-backed; skipped at the evaluator level.
+
+    The verification sandbox already runs each test session once.
+    Determinism would require a second run and a comparison. That is not
+    free, and we don't want plain profile evaluation to silently invoke
+    it. Returns ``None`` so the indicator is reported as SKIPPED until
+    a follow-up wires this in explicitly.
+    """
+    return None
+
+
+def _verification_pass_rate(source: str, context: dict[str, Any]) -> float | None:
+    """Reliability indicator backed by the verification loop. Deferred."""
+    # Profiles can reference verification-backed indicators, but evaluating
+    # them requires a verification session, which is expensive and stateful.
+    # A follow-up commit will wire the orchestrator into the evaluator
+    # path so that callers opting into verification get a real number.
+    return None
+
+
+def _verification_bugs(source: str, context: dict[str, Any]) -> float | None:
+    """Reliability indicator backed by the verification loop. Deferred."""
+    return None
+
+
+def _register_builtins() -> None:
+    register("radon.mi", _radon_mi)
+    register("radon.cc", _radon_cc)
+    register("bandit.high", _bandit_high)
+    register("qallm.repro.manifest", _repro_manifest)
+    register("qallm.repro.determinism", _repro_determinism)
+    register("qallm.verification.pass_rate", _verification_pass_rate)
+    register("qallm.verification.bugs", _verification_bugs)
+
+
+_register_builtins()
+
+
+# ---------------------------------------------------------------------------
+# Profile evaluation
+# ---------------------------------------------------------------------------
+
+
+def _evaluate_indicator(
+    indicator: QualityIndicator, source: str, context: dict[str, Any]
+) -> IndicatorResult:
+    """Run one indicator's evaluator, return a typed result.
+
+    Any exception inside the evaluator is captured and reported as ERROR
+    rather than propagated, because a single broken evaluator should not
+    take down a profile evaluation.
+    """
+    try:
+        fn = resolve(indicator.evaluator)
+    except KeyError as exc:
+        return IndicatorResult(
+            name=indicator.name,
+            evaluator=indicator.evaluator,
+            threshold=indicator.threshold,
+            comparator=indicator.comparator.value,
+            measured=None,
+            status=IndicatorStatus.ERROR,
+            detail=str(exc),
+        )
+
+    try:
+        measured = fn(source, context)
+    except Exception as exc:  # noqa: BLE001 - we want to capture all failures
+        return IndicatorResult(
+            name=indicator.name,
+            evaluator=indicator.evaluator,
+            threshold=indicator.threshold,
+            comparator=indicator.comparator.value,
+            measured=None,
+            status=IndicatorStatus.ERROR,
+            detail=f"{type(exc).__name__}: {exc}",
+        )
+
+    if measured is None:
+        return IndicatorResult(
+            name=indicator.name,
+            evaluator=indicator.evaluator,
+            threshold=indicator.threshold,
+            comparator=indicator.comparator.value,
+            measured=None,
+            status=IndicatorStatus.SKIPPED,
+            detail="Evaluator declined to produce a value for this input.",
+        )
+
+    passed = indicator.passes(measured)
+    return IndicatorResult(
+        name=indicator.name,
+        evaluator=indicator.evaluator,
+        threshold=indicator.threshold,
+        comparator=indicator.comparator.value,
+        measured=float(measured),
+        status=IndicatorStatus.PASS if passed else IndicatorStatus.FAIL,
+        detail="",
+    )
+
+
+def _evaluate_dimension(
+    spec: DimensionSpec, source: str, context: dict[str, Any]
+) -> DimensionResult:
+    return DimensionResult(
+        dimension=spec.dimension,
+        indicators=[
+            _evaluate_indicator(ind, source, context) for ind in spec.indicators
+        ],
+    )
+
+
+def evaluate_profile(
+    profile: QualityProfile,
+    source: str,
+    *,
+    context: dict[str, Any] | None = None,
+) -> ProfileVerdict:
+    """Run every indicator in ``profile`` against ``source``.
+
+    Args:
+        profile: The :class:`QualityProfile` to evaluate.
+        source: Python source code as a string.
+        context: Optional context bag passed to each evaluator. Recognised
+            keys include ``project_root`` (path-like) for reproducibility
+            evaluators. Extra keys are ignored by evaluators that don't
+            need them.
+
+    Returns:
+        A :class:`ProfileVerdict` whose ``status`` is the worst-of across
+        all non-skipped dimensions.
+    """
+    ctx: dict[str, Any] = dict(context or {})
+    return ProfileVerdict(
+        profile_id=profile.profile_id,
+        dimensions=[
+            _evaluate_dimension(spec, source, ctx) for spec in profile.dimensions
+        ],
+    )
+
+
+__all__ = [
+    "DimensionResult",
+    "EvaluatorFn",
+    "IndicatorResult",
+    "IndicatorStatus",
+    "ProfileVerdict",
+    "evaluate_profile",
+    "register",
+    "registered_evaluators",
+    "resolve",
+]

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -1,0 +1,436 @@
+"""Tests for qallm.evaluation.
+
+Coverage targets:
+
+  * Registry: known/unknown lookups, error message includes registered ids.
+  * Built-in evaluators on real sample sources (skipped cleanly if the
+    underlying tool is missing).
+  * ``evaluate_profile`` walking the default profile end-to-end with a
+    real source and a stubbed registry.
+  * Indicator outcomes: PASS, FAIL, SKIPPED, ERROR.
+  * Dimension and verdict roll-up rules (worst-of, all-skipped, any-error).
+  * JSON serialisation.
+
+Tests use a fresh in-memory registry per case where they need isolation,
+restoring the original registrations after the test runs.
+"""
+
+from __future__ import annotations
+
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from qallm import evaluation
+from qallm.evaluation import (
+    DimensionResult,
+    IndicatorResult,
+    IndicatorStatus,
+    ProfileVerdict,
+    evaluate_profile,
+    register,
+    registered_evaluators,
+    resolve,
+)
+from qallm.profiles import (
+    IMPLEMENTATION_DEFAULT,
+    Comparator,
+    DimensionSpec,
+    QualityDimension,
+    QualityIndicator,
+    QualityProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def preserve_registry():
+    """Snapshot the evaluator registry and restore it after the test."""
+    snapshot = dict(evaluation._REGISTRY)
+    yield
+    evaluation._REGISTRY.clear()
+    evaluation._REGISTRY.update(snapshot)
+
+
+@pytest.fixture
+def simple_clean_source() -> str:
+    return (
+        "def add(a, b):\n"
+        "    \"\"\"Return the sum of two numbers.\"\"\"\n"
+        "    return a + b\n"
+    )
+
+
+@pytest.fixture
+def temp_project_with_manifest():
+    """A scratch directory containing a requirements.txt."""
+    root = Path(tempfile.mkdtemp(prefix="qallm-eval-"))
+    (root / "requirements.txt").write_text("radon\nbandit\n")
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+@pytest.fixture
+def temp_project_without_manifest():
+    root = Path(tempfile.mkdtemp(prefix="qallm-eval-"))
+    yield root
+    shutil.rmtree(root, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+
+def test_builtins_are_registered():
+    ids = registered_evaluators()
+    assert "radon.mi" in ids
+    assert "radon.cc" in ids
+    assert "bandit.high" in ids
+    assert "qallm.repro.manifest" in ids
+
+
+def test_resolve_returns_callable_for_known_id():
+    fn = resolve("radon.mi")
+    assert callable(fn)
+
+
+def test_resolve_raises_with_helpful_message_for_unknown_id():
+    with pytest.raises(KeyError) as info:
+        resolve("does.not.exist")
+    msg = str(info.value)
+    assert "does.not.exist" in msg
+    assert "radon.mi" in msg
+
+
+def test_register_overwrites_previous(preserve_registry):
+    register("test.dummy", lambda src, ctx: 1.0)
+    assert resolve("test.dummy")("", {}) == 1.0
+    register("test.dummy", lambda src, ctx: 2.0)
+    assert resolve("test.dummy")("", {}) == 2.0
+
+
+# ---------------------------------------------------------------------------
+# Built-in evaluators
+# ---------------------------------------------------------------------------
+
+
+def _radon_available() -> bool:
+    return shutil.which("radon") is not None
+
+
+def _bandit_available() -> bool:
+    return shutil.which("bandit") is not None
+
+
+@pytest.mark.skipif(not _radon_available(), reason="radon not installed")
+def test_radon_mi_returns_float_on_real_source(simple_clean_source):
+    fn = resolve("radon.mi")
+    value = fn(simple_clean_source, {})
+    assert value is not None
+    assert 0.0 <= float(value) <= 100.0
+
+
+@pytest.mark.skipif(not _radon_available(), reason="radon not installed")
+def test_radon_cc_returns_float_on_real_source(simple_clean_source):
+    fn = resolve("radon.cc")
+    value = fn(simple_clean_source, {})
+    assert value is not None
+    assert float(value) >= 0.0
+
+
+def test_radon_mi_returns_none_on_empty_source():
+    assert resolve("radon.mi")("", {}) is None
+    assert resolve("radon.mi")("   \n  ", {}) is None
+
+
+@pytest.mark.skipif(not _bandit_available(), reason="bandit not installed")
+def test_bandit_high_returns_count_for_safe_source(simple_clean_source):
+    value = resolve("bandit.high")(simple_clean_source, {})
+    # Clean source should have zero HIGH findings.
+    assert value == 0.0
+
+
+def test_repro_manifest_finds_requirements_txt(temp_project_with_manifest):
+    fn = resolve("qallm.repro.manifest")
+    value = fn("", {"project_root": str(temp_project_with_manifest)})
+    assert value == 1.0
+
+
+def test_repro_manifest_returns_zero_when_no_manifest_present(
+    temp_project_without_manifest,
+):
+    fn = resolve("qallm.repro.manifest")
+    value = fn("", {"project_root": str(temp_project_without_manifest)})
+    assert value == 0.0
+
+
+def test_repro_manifest_returns_none_without_project_root():
+    fn = resolve("qallm.repro.manifest")
+    assert fn("anything", {}) is None
+
+
+def test_verification_evaluators_are_deferred():
+    # Reliability indicators are registered, but in v1 they decline to
+    # produce a value here; they require an orchestrator-driven session.
+    assert resolve("qallm.verification.pass_rate")("source", {}) is None
+    assert resolve("qallm.verification.bugs")("source", {}) is None
+
+
+# ---------------------------------------------------------------------------
+# evaluate_profile end-to-end with stubs
+# ---------------------------------------------------------------------------
+
+
+def _stub_profile() -> QualityProfile:
+    return QualityProfile(
+        profile_id="stub_profile",
+        lifecycle_stage=IMPLEMENTATION_DEFAULT.lifecycle_stage,
+        dimensions=(
+            DimensionSpec(
+                dimension=QualityDimension.MAINTAINABILITY,
+                repair_prompt_id="stub_repair",
+                indicators=(
+                    QualityIndicator(
+                        name="stub_passing",
+                        evaluator="stub.passing",
+                        threshold=10.0,
+                        comparator=Comparator.GE,
+                    ),
+                ),
+            ),
+            DimensionSpec(
+                dimension=QualityDimension.SECURITY,
+                repair_prompt_id="stub_repair",
+                indicators=(
+                    QualityIndicator(
+                        name="stub_failing",
+                        evaluator="stub.failing",
+                        threshold=0.0,
+                        comparator=Comparator.LE,
+                    ),
+                ),
+            ),
+        ),
+    )
+
+
+def test_evaluate_profile_with_stub_evaluators_produces_typed_results(
+    preserve_registry,
+):
+    register("stub.passing", lambda src, ctx: 42.0)
+    register("stub.failing", lambda src, ctx: 5.0)
+
+    verdict = evaluate_profile(_stub_profile(), "irrelevant source")
+
+    assert verdict.profile_id == "stub_profile"
+    maint = verdict.get_dimension(QualityDimension.MAINTAINABILITY)
+    sec = verdict.get_dimension(QualityDimension.SECURITY)
+    assert maint is not None and sec is not None
+
+    [m_ind] = maint.indicators
+    [s_ind] = sec.indicators
+    assert m_ind.status is IndicatorStatus.PASS
+    assert m_ind.measured == 42.0
+    assert s_ind.status is IndicatorStatus.FAIL
+    assert s_ind.measured == 5.0
+
+
+def test_evaluate_profile_skips_indicator_when_evaluator_returns_none(
+    preserve_registry,
+):
+    register("stub.passing", lambda src, ctx: None)
+    register("stub.failing", lambda src, ctx: 0.0)
+
+    verdict = evaluate_profile(_stub_profile(), "src")
+
+    maint = verdict.get_dimension(QualityDimension.MAINTAINABILITY)
+    [m_ind] = maint.indicators
+    assert m_ind.status is IndicatorStatus.SKIPPED
+    assert m_ind.measured is None
+
+
+def test_evaluate_profile_marks_indicator_as_error_when_evaluator_raises(
+    preserve_registry,
+):
+    def boom(src, ctx):
+        raise RuntimeError("boom")
+
+    register("stub.passing", boom)
+    register("stub.failing", lambda src, ctx: 0.0)
+
+    verdict = evaluate_profile(_stub_profile(), "src")
+    maint = verdict.get_dimension(QualityDimension.MAINTAINABILITY)
+    [m_ind] = maint.indicators
+    assert m_ind.status is IndicatorStatus.ERROR
+    assert "RuntimeError" in m_ind.detail
+    assert "boom" in m_ind.detail
+
+
+def test_evaluate_profile_marks_indicator_as_error_when_evaluator_unknown(
+    preserve_registry,
+):
+    # Build a profile pointing to an unregistered evaluator id.
+    profile = QualityProfile(
+        profile_id="bad",
+        lifecycle_stage=IMPLEMENTATION_DEFAULT.lifecycle_stage,
+        dimensions=(
+            DimensionSpec(
+                dimension=QualityDimension.MAINTAINABILITY,
+                repair_prompt_id="x",
+                indicators=(
+                    QualityIndicator(
+                        name="ghost",
+                        evaluator="not.registered",
+                        threshold=0.0,
+                        comparator=Comparator.GE,
+                    ),
+                ),
+            ),
+        ),
+    )
+    verdict = evaluate_profile(profile, "src")
+    [dim] = verdict.dimensions
+    [ind] = dim.indicators
+    assert ind.status is IndicatorStatus.ERROR
+    assert "not.registered" in ind.detail
+
+
+# ---------------------------------------------------------------------------
+# Roll-up rules
+# ---------------------------------------------------------------------------
+
+
+def _indicator(status: IndicatorStatus) -> IndicatorResult:
+    return IndicatorResult(
+        name="x",
+        evaluator="x",
+        threshold=0.0,
+        comparator="ge",
+        measured=0.0,
+        status=status,
+    )
+
+
+def test_dimension_status_is_skipped_when_all_indicators_skipped():
+    d = DimensionResult(
+        dimension=QualityDimension.MAINTAINABILITY,
+        indicators=[_indicator(IndicatorStatus.SKIPPED) for _ in range(3)],
+    )
+    assert d.status is IndicatorStatus.SKIPPED
+
+
+def test_dimension_status_is_error_if_any_indicator_errored():
+    d = DimensionResult(
+        dimension=QualityDimension.MAINTAINABILITY,
+        indicators=[
+            _indicator(IndicatorStatus.PASS),
+            _indicator(IndicatorStatus.ERROR),
+            _indicator(IndicatorStatus.PASS),
+        ],
+    )
+    assert d.status is IndicatorStatus.ERROR
+
+
+def test_dimension_status_is_fail_if_any_indicator_failed_and_no_errors():
+    d = DimensionResult(
+        dimension=QualityDimension.MAINTAINABILITY,
+        indicators=[
+            _indicator(IndicatorStatus.PASS),
+            _indicator(IndicatorStatus.FAIL),
+        ],
+    )
+    assert d.status is IndicatorStatus.FAIL
+
+
+def test_dimension_status_is_pass_when_only_pass_or_skipped():
+    d = DimensionResult(
+        dimension=QualityDimension.MAINTAINABILITY,
+        indicators=[
+            _indicator(IndicatorStatus.PASS),
+            _indicator(IndicatorStatus.SKIPPED),
+        ],
+    )
+    assert d.status is IndicatorStatus.PASS
+
+
+def test_verdict_status_aggregates_across_dimensions():
+    verdict = ProfileVerdict(
+        profile_id="p",
+        dimensions=[
+            DimensionResult(
+                dimension=QualityDimension.MAINTAINABILITY,
+                indicators=[_indicator(IndicatorStatus.PASS)],
+            ),
+            DimensionResult(
+                dimension=QualityDimension.SECURITY,
+                indicators=[_indicator(IndicatorStatus.FAIL)],
+            ),
+        ],
+    )
+    assert verdict.status is IndicatorStatus.FAIL
+
+
+# ---------------------------------------------------------------------------
+# Serialisation
+# ---------------------------------------------------------------------------
+
+
+def test_verdict_roundtrips_through_json(preserve_registry):
+    register("stub.passing", lambda src, ctx: 1.0)
+    register("stub.failing", lambda src, ctx: 0.0)
+    verdict = evaluate_profile(_stub_profile(), "src")
+
+    payload = verdict.to_dict()
+    text = json.dumps(payload)
+    loaded = json.loads(text)
+
+    assert loaded["profile_id"] == "stub_profile"
+    assert loaded["status"] in {"pass", "fail", "skipped", "error"}
+    assert {d["dimension"] for d in loaded["dimensions"]} == {
+        "Maintainability",
+        "Security",
+    }
+
+
+# ---------------------------------------------------------------------------
+# Full default profile run
+# ---------------------------------------------------------------------------
+
+
+def test_evaluate_default_profile_on_real_source_does_not_crash(
+    simple_clean_source, temp_project_with_manifest
+):
+    """Smoke test: run the real default profile against a real snippet.
+
+    Indicators backed by missing tools (e.g. radon if not installed) will
+    be SKIPPED rather than ERRORed because the built-in evaluators catch
+    FileNotFoundError. This test exercises the full code path.
+    """
+    verdict = evaluate_profile(
+        IMPLEMENTATION_DEFAULT,
+        simple_clean_source,
+        context={"project_root": str(temp_project_with_manifest)},
+    )
+    # All four EVERSE dimensions appear in the verdict.
+    dims = {d.dimension for d in verdict.dimensions}
+    assert dims == {
+        QualityDimension.MAINTAINABILITY,
+        QualityDimension.SECURITY,
+        QualityDimension.RELIABILITY,
+        QualityDimension.REPRODUCIBILITY,
+    }
+    # Reliability is fully deferred in v1, so its dimension status is SKIPPED.
+    rel = verdict.get_dimension(QualityDimension.RELIABILITY)
+    assert rel.status is IndicatorStatus.SKIPPED
+    # Reproducibility has one passing indicator (manifest exists) and one
+    # skipped (determinism). Worst non-skipped is PASS.
+    repro = verdict.get_dimension(QualityDimension.REPRODUCIBILITY)
+    assert repro.status is IndicatorStatus.PASS


### PR DESCRIPTION
Introduces qallm.evaluation with an evaluator registry, seven built-in evaluators (Radon MI/CC, Bandit HIGH, repro manifest, plus deferred stubs for determinism and verification-backed reliability indicators), and evaluate_profile producing a typed ProfileVerdict. Errors and skipped indicators are captured, not raised. 23 unit tests.