### PR TITLE
feat(evaluation): wire reliability indicators to verification session…

### DIFF
--- a/docs/workflow-design.md
+++ b/docs/workflow-design.md
@@ -317,7 +317,7 @@ For implementation, the workflow maps onto the modules already in place, plus th
 | Static analysis            | `qallm.analysis`                                                      | Working.                          |
 | Verification (RL loop)     | `qallm.verification`                                                  | Working.                          |
 | Test suite persistence     | `qallm.verification.test_persistence`                                 | Built (PR feature/test-stability). 250 lines plus 22 tests. Section 4.5. |
-| Profile evaluation         | `qallm.profiles` + `qallm.evaluation`                                 | Working; reliability stubs only. Framework-agnostic by design. |
+| Profile evaluation         | `qallm.profiles` + `qallm.evaluation`                                 | Working; reliability indicators wired in NEW-03. Framework-agnostic by design. |
 | FAIRness indicators        | New: extend `qallm.evaluation` with `qallm.fairness` evaluators       | To build. ~100 lines. Section 9.4. |
 | Judge                      | New: `qallm.judge`                                                    | To build. ~150 lines plus tests.  |
 | Improvement strategies     | New: `qallm.judge.strategies`: lexicographic, strict, model           | To build alongside judge.         |
@@ -334,7 +334,7 @@ All design questions are resolved. The implementation roadmap below is the basis
 
 1. ~~Extend verification for test-suite persistence per section 4.5.~~ **Done.** Two-axis configurable strategy (`test_stability` x `generation_policy`) with three meaningful modes. New `qallm.verification.test_persistence` module, 250 lines plus 22 tests. CLI flags `--test-stability` and `--generation-policy`. `summary.json` records the mode. Section 4.5.
 2. Build the judge module (`qallm.judge`) with the three improvement strategies. 150 lines plus tests.
-3. Wire reliability indicators in `qallm.evaluation` to actual verification output. No more stubs.
+3. ~~Wire reliability indicators in `qallm.evaluation` to actual verification output.~~ **Done.** Both `qallm.verification.pass_rate` and `qallm.verification.bugs` now read `context["verification_sessions"]: list[TestGenerationSession]`. Added a `final_pass_rate` property on the session model. 12 new tests; all 126 prior tests still pass.
 4. Add FAIRness indicators (`qallm.fairness`): licence, citation, README, docstrings. 100 lines plus tests.
 5. Add budget enforcement in the orchestrator: rounds, tokens, time, cost. Cost requires a price table in `qallm.config`. 50 plus 80 lines.
 6. Extend the orchestrator loop per section 3. 100 lines.

--- a/src/qallm/evaluation.py
+++ b/src/qallm/evaluation.py
@@ -24,11 +24,11 @@ results are consistent between the legacy ``StaticAnalyzer`` and the new
 profile-based path.
 
 Verification-backed evaluators (``qallm.verification.pass_rate``,
-``qallm.verification.bugs``) are registered as deferred stubs. They
-require a running verification session, which is expensive and out of
-scope for this PR. They return ``None`` so the indicators are recorded
-as ``SKIPPED`` until a follow-up wires the orchestrator into the
-evaluator path.
+``qallm.verification.bugs``) read a list of
+:class:`~qallm.verification.models.TestGenerationSession` instances from
+the evaluation context under the key ``"verification_sessions"``.
+Callers that have not run verification can omit the key, in which case
+the indicators are reported as ``SKIPPED``.
 
 References
 ----------
@@ -329,17 +329,41 @@ def _repro_determinism(source: str, context: dict[str, Any]) -> float | None:
 
 
 def _verification_pass_rate(source: str, context: dict[str, Any]) -> float | None:
-    """Reliability indicator backed by the verification loop. Deferred."""
-    # Profiles can reference verification-backed indicators, but evaluating
-    # them requires a verification session, which is expensive and stateful.
-    # A follow-up commit will wire the orchestrator into the evaluator
-    # path so that callers opting into verification get a real number.
-    return None
+    """Reliability indicator: average test pass rate across function sessions.
+
+    Reads ``context["verification_sessions"]`` (a list of
+    :class:`TestGenerationSession`). Returns the mean of each session's
+    ``final_pass_rate``, skipping sessions whose pass rate is undefined
+    (no rounds or zero passed+failed tests).
+
+    Returns ``None`` if the context has no sessions key, or if every session
+    has an undefined pass rate. This is consistent with the SKIPPED semantics
+    elsewhere in the module.
+    """
+    sessions = context.get("verification_sessions")
+    if not sessions:
+        return None
+    rates = [
+        s.final_pass_rate for s in sessions if s.final_pass_rate is not None
+    ]
+    if not rates:
+        return None
+    return sum(rates) / len(rates)
 
 
 def _verification_bugs(source: str, context: dict[str, Any]) -> float | None:
-    """Reliability indicator backed by the verification loop. Deferred."""
-    return None
+    """Reliability indicator: total bugs caught across function sessions.
+
+    Reads ``context["verification_sessions"]`` (a list of
+    :class:`TestGenerationSession`). Returns the sum of each session's
+    ``final_bugs`` as a float. Returns ``None`` only if there is no
+    sessions key at all; an empty list yields ``0.0`` because "we ran
+    verification and found no bugs" is a meaningful zero, not a SKIP.
+    """
+    sessions = context.get("verification_sessions")
+    if sessions is None:
+        return None
+    return float(sum(s.final_bugs for s in sessions))
 
 
 def _register_builtins() -> None:

--- a/src/qallm/verification/models.py
+++ b/src/qallm/verification/models.py
@@ -146,6 +146,8 @@ class TestGenerationSession:
     Stored as JSON for reproducibility and learning curve analysis.
     """
 
+    __test__ = False  # pytest: this is a data class, not a test class
+
     function_name: str
     source_code: str
     oracle: OracleType
@@ -166,6 +168,25 @@ class TestGenerationSession:
         if not self.rounds:
             return 0
         return self.rounds[-1].cumulative_bugs
+
+    @property
+    def final_pass_rate(self) -> float | None:
+        """Fraction of tests that passed in the latest round.
+
+        Returns ``None`` if there are no rounds, or if the latest round ran
+        zero tests (so the ratio is undefined). Errors do not count as failed
+        tests: pass_rate is ``passed / (passed + failed)``, excluding errored
+        and skipped tests, because we want a clean reliability signal.
+        """
+        if not self.rounds:
+            return None
+        latest = self.rounds[-1].execution
+        if latest is None:
+            return None
+        denom = latest.passed + latest.failed
+        if denom == 0:
+            return None
+        return latest.passed / denom
 
     @property
     def learning_curve(self) -> list[float]:

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -177,11 +177,212 @@ def test_repro_manifest_returns_none_without_project_root():
     assert fn("anything", {}) is None
 
 
-def test_verification_evaluators_are_deferred():
-    # Reliability indicators are registered, but in v1 they decline to
-    # produce a value here; they require an orchestrator-driven session.
+def test_verification_evaluators_skip_without_sessions():
+    # Reliability indicators are registered. They require a list of
+    # verification sessions in the context; without it, they decline to
+    # produce a value (SKIPPED), which is what we want.
     assert resolve("qallm.verification.pass_rate")("source", {}) is None
     assert resolve("qallm.verification.bugs")("source", {}) is None
+
+
+# ---------------------------------------------------------------------------
+# Verification-backed evaluators: pass_rate and bugs
+# ---------------------------------------------------------------------------
+
+
+def _make_session(
+    *,
+    function_name: str = "f",
+    passed: int = 0,
+    failed: int = 0,
+    errors: int = 0,
+    final_bugs: int = 0,
+):
+    """Build a TestGenerationSession with one round whose execution result has
+    the given counts. final_bugs sets the cumulative_bugs on that round.
+    """
+    from qallm.verification.models import (
+        ExecutionResult,
+        GeneratedTest,
+        RewardBreakdown,
+        RoundResult,
+        TestGenerationSession,
+    )
+
+    execution = ExecutionResult(
+        passed=passed,
+        failed=failed,
+        errors=errors,
+        total=passed + failed + errors,
+    )
+    generated = GeneratedTest(
+        function_name=function_name,
+        oracle="crash",
+        test_code="def test_x(): pass",
+        is_valid=True,
+        generation_error=None,
+        model="stub",
+        provider="stub",
+        input_tokens=0,
+        output_tokens=0,
+    )
+    reward = RewardBreakdown(total=0.0)
+    round_result = RoundResult(
+        round_number=1,
+        generated_test=generated,
+        execution=execution,
+        reward=reward,
+        cumulative_coverage=100.0,
+        cumulative_bugs=final_bugs,
+    )
+    session = TestGenerationSession(
+        function_name=function_name,
+        source_code="def f(): pass",
+        oracle="crash",
+        model="stub",
+        total_rounds=1,
+    )
+    session.rounds.append(round_result)
+    return session
+
+
+class TestVerificationPassRate:
+    """Behaviour of the qallm.verification.pass_rate evaluator."""
+
+    def test_returns_none_without_sessions_key(self):
+        fn = resolve("qallm.verification.pass_rate")
+        assert fn("src", {}) is None
+
+    def test_returns_none_for_empty_sessions_list(self):
+        fn = resolve("qallm.verification.pass_rate")
+        assert fn("src", {"verification_sessions": []}) is None
+
+    def test_single_session_all_passing(self):
+        fn = resolve("qallm.verification.pass_rate")
+        sessions = [_make_session(passed=10, failed=0)]
+        assert fn("src", {"verification_sessions": sessions}) == 1.0
+
+    def test_single_session_half_passing(self):
+        fn = resolve("qallm.verification.pass_rate")
+        sessions = [_make_session(passed=5, failed=5)]
+        assert fn("src", {"verification_sessions": sessions}) == 0.5
+
+    def test_errors_excluded_from_denominator(self):
+        # Five passed, zero failed, two errored => pass rate is 5/5 = 1.0.
+        # Errors are infrastructure failures, not test results, and shouldn't
+        # be punished as 'not passing'.
+        fn = resolve("qallm.verification.pass_rate")
+        sessions = [_make_session(passed=5, failed=0, errors=2)]
+        assert fn("src", {"verification_sessions": sessions}) == 1.0
+
+    def test_multi_session_averages(self):
+        # Two functions, one perfect, one 50%. Mean is 0.75.
+        fn = resolve("qallm.verification.pass_rate")
+        sessions = [
+            _make_session(function_name="f", passed=10, failed=0),
+            _make_session(function_name="g", passed=5, failed=5),
+        ]
+        assert fn("src", {"verification_sessions": sessions}) == 0.75
+
+    def test_skips_undefined_sessions(self):
+        # If one session has 0 passed + 0 failed (only errors), its rate is
+        # undefined and should be excluded from the average rather than
+        # counted as zero.
+        fn = resolve("qallm.verification.pass_rate")
+        sessions = [
+            _make_session(function_name="f", passed=10, failed=0),
+            _make_session(function_name="g", passed=0, failed=0, errors=3),
+        ]
+        # Only the first session contributes: rate is 1.0.
+        assert fn("src", {"verification_sessions": sessions}) == 1.0
+
+
+class TestVerificationBugs:
+    """Behaviour of the qallm.verification.bugs evaluator."""
+
+    def test_returns_none_without_sessions_key(self):
+        fn = resolve("qallm.verification.bugs")
+        assert fn("src", {}) is None
+
+    def test_empty_list_is_zero(self):
+        # An empty list means 'we ran verification on nothing' which is a
+        # meaningful 0, not a SKIP.
+        fn = resolve("qallm.verification.bugs")
+        assert fn("src", {"verification_sessions": []}) == 0.0
+
+    def test_sums_across_sessions(self):
+        fn = resolve("qallm.verification.bugs")
+        sessions = [
+            _make_session(function_name="f", final_bugs=2),
+            _make_session(function_name="g", final_bugs=3),
+        ]
+        assert fn("src", {"verification_sessions": sessions}) == 5.0
+
+
+class TestFinalPassRateProperty:
+    """The TestGenerationSession.final_pass_rate property added for NEW-03."""
+
+    def test_no_rounds_returns_none(self):
+        from qallm.verification.models import TestGenerationSession
+
+        session = TestGenerationSession(
+            function_name="f",
+            source_code="def f(): pass",
+            oracle="crash",
+            model="stub",
+            total_rounds=1,
+        )
+        assert session.final_pass_rate is None
+
+    def test_zero_denominator_returns_none(self):
+        # Latest round had only errors, no pass/fail outcomes.
+        session = _make_session(passed=0, failed=0, errors=3)
+        assert session.final_pass_rate is None
+
+    def test_uses_latest_round_only(self):
+        # Two rounds: first one bad, second one perfect. Should reflect the
+        # current variant, which is the latest round.
+        from qallm.verification.models import (
+            ExecutionResult,
+            GeneratedTest,
+            RewardBreakdown,
+            RoundResult,
+            TestGenerationSession,
+        )
+
+        def _make_round(round_num, passed, failed):
+            return RoundResult(
+                round_number=round_num,
+                generated_test=GeneratedTest(
+                    function_name="f",
+                    oracle="crash",
+                    test_code="x",
+                    is_valid=True,
+                    generation_error=None,
+                    model="stub",
+                    provider="stub",
+                    input_tokens=0,
+                    output_tokens=0,
+                ),
+                execution=ExecutionResult(
+                    passed=passed, failed=failed, total=passed + failed
+                ),
+                reward=RewardBreakdown(total=0.0),
+                cumulative_coverage=100.0,
+                cumulative_bugs=0,
+            )
+
+        session = TestGenerationSession(
+            function_name="f",
+            source_code="def f(): pass",
+            oracle="crash",
+            model="stub",
+            total_rounds=2,
+        )
+        session.rounds.append(_make_round(1, passed=2, failed=8))  # 0.2
+        session.rounds.append(_make_round(2, passed=10, failed=0))  # 1.0
+
+        assert session.final_pass_rate == 1.0  # latest, not historical
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
…s (NEW-03)

Replaces the deferred stubs for qallm.verification.pass_rate and qallm.verification.bugs with real implementations that read a list of TestGenerationSession instances from context['verification_sessions'].

pass_rate computes the mean of each session's final_pass_rate (passed / (passed + failed) in the latest round, errors excluded from the denominator). Returns None if no sessions are supplied or every session's rate is undefined.

bugs computes the sum of each session's final_bugs across the supplied sessions. Returns None only if the sessions key is absent; an empty list yields 0.0 because 'we ran verification on nothing' is a meaningful zero.

Adds TestGenerationSession.final_pass_rate property, parallel to the existing final_coverage and final_bugs.

Also fixes the long-standing pytest collection warning on TestGenerationSession by setting __test__ = False on the dataclass.

12 new tests, 1 renamed test, 0 broken; 139 tests pass total.

Closes NEW-03.