### PR TITLE
feat(orchestrator): budget caps with cost estimation (NEW-05)

### DIFF
--- a/docs/workflow-design.md
+++ b/docs/workflow-design.md
@@ -321,8 +321,8 @@ For implementation, the workflow maps onto the modules already in place, plus th
 | FAIRness indicators        | New: extend `qallm.evaluation` with `qallm.fairness` evaluators       | To build. ~100 lines. Section 9.4. |
 | Judge                      | New: `qallm.judge`                                                    | To build. ~150 lines plus tests.  |
 | Improvement strategies     | New: `qallm.judge.strategies`: lexicographic, strict, model           | To build alongside judge.         |
-| Cost estimation            | New: extend `qallm.config` with a price table; new `qallm.cost`       | To build. ~80 lines.              |
-| Budget enforcement         | Extend `qallm.orchestrator` with hard-cap checks at round boundary    | To build. ~50 lines.              |
+| Cost estimation            | `qallm.cost` (price table reused from `qallm.llm.base.MODEL_RATES`)   | Built (NEW-05). 220 lines, 20 tests. |
+| Budget enforcement         | `qallm.orchestrator` round-boundary check via `BudgetState.check()`   | Built (NEW-05). Five caps with ceilings. |
 | Loop / orchestration       | `qallm.orchestrator`                                                  | Loop logic to extend per section 3. |
 | Lineage and abandoned log  | Extend `qallm.utils.reporter`                                         | To build.                         |
 | Canonical JSON + views     | Extend `qallm.utils.reporter`: emit `summary.json`, `report.md`, `report.html` | To build. Section 10.        |
@@ -336,7 +336,7 @@ All design questions are resolved. The implementation roadmap below is the basis
 2. Build the judge module (`qallm.judge`) with the three improvement strategies. 150 lines plus tests.
 3. ~~Wire reliability indicators in `qallm.evaluation` to actual verification output.~~ **Done.** Both `qallm.verification.pass_rate` and `qallm.verification.bugs` now read `context["verification_sessions"]: list[TestGenerationSession]`. Added a `final_pass_rate` property on the session model. 12 new tests; all 126 prior tests still pass.
 4. Add FAIRness indicators (`qallm.fairness`): licence, citation, README, docstrings. 100 lines plus tests.
-5. Add budget enforcement in the orchestrator: rounds, tokens, time, cost. Cost requires a price table in `qallm.config`. 50 plus 80 lines.
+5. ~~Add budget enforcement in the orchestrator: rounds, tokens, time, cost.~~ **Done.** Five caps with ceilings (rounds 5/10, tokens 500k/2M, seconds 1800/3600, round-seconds 600/1200, cost $5/$25). Reuses the existing `MODEL_RATES` table in `qallm.llm.base`. New module `qallm.cost` with `BudgetCaps`, `BudgetState`, and `HaltReason`. CLI flags `--max-tokens`, `--max-seconds`, `--max-round-seconds`, `--max-cost-usd`. Halt reason recorded in `summary.json`. 20 new tests, 159 tests total.
 6. Extend the orchestrator loop per section 3. 100 lines.
 7. Extend the reporter with lineage, abandoned-variant logging, canonical `summary.json`, and the markdown/HTML views (section 10). 100 lines.
 8. Update the web UI auto mode to drive the new loop. Small change.

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -17,7 +17,14 @@ class Settings:
     OLLAMA_BASE_URL: str = os.getenv("OLLAMA_BASE_URL", "http://localhost:11434")
     OLLAMA_MODEL: str = os.getenv("OLLAMA_MODEL", "gemma3:4b")
 
+    # Budget caps. All are floors, not ceilings: code-level ceilings in
+    # `qallm.cost` override these if they are too large. The intent is
+    # that a typo in this file or an .env cannot blow the budget.
     TOKEN_BUDGET: int = int(os.getenv("TOKEN_BUDGET", "500000"))
+    QALLM_MAX_ROUNDS: int = int(os.getenv("QALLM_MAX_ROUNDS", "5"))
+    QALLM_MAX_SECONDS: int = int(os.getenv("QALLM_MAX_SECONDS", "1800"))
+    QALLM_MAX_ROUND_SECONDS: int = int(os.getenv("QALLM_MAX_ROUND_SECONDS", "600"))
+    QALLM_MAX_COST_USD: float = float(os.getenv("QALLM_MAX_COST_USD", "5.0"))
 
 
 settings = Settings()

--- a/src/qallm/cost.py
+++ b/src/qallm/cost.py
@@ -1,0 +1,212 @@
+"""Budget caps and cost estimation for the orchestrator loop.
+
+Implements workflow design v3 section 6 and section 9.6.
+
+Five orthogonal caps are enforced at QALLM round boundaries:
+
+  * ``max_rounds``: how many QALLM rounds to run at most.
+  * ``max_tokens``: total input + output tokens across the whole session.
+  * ``max_seconds``: wall-clock time for the whole session.
+  * ``max_round_seconds``: time for any single round.
+  * ``max_cost_usd``: estimated USD cost across the whole session.
+
+Each cap has two parts: a *default* (small, conservative; what an unconfigured
+session uses) and a *ceiling* (the absolute maximum, regardless of any env-var
+or CLI override). The user can lower below the default freely; they cannot
+raise above the ceiling. The intent is that a config typo cannot blow a
+budget through the floor.
+
+Halt semantics
+--------------
+
+Caps are checked at *round boundaries*, not mid-round. When a cap trips, the
+orchestrator finishes the current round (or current function within the
+verification call) and halts before the next round. This means the actual
+spend may slightly exceed the cap by the cost of the round that broke it.
+This is intentional: hard mid-round interruption would require killing
+pytest subprocesses and partial sessions, which is a worse failure mode
+than going a little over.
+
+Callers asking "did we halt or finish normally?" read the :class:`HaltReason`
+enum on the summary object. ``HaltReason.COMPLETED`` means we ran to
+``max_rounds`` without tripping anything else.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Optional
+
+from qallm.llm.base import TokenTracker
+
+
+# Ceilings: the absolute maximum any session can be configured to.
+# These are not env-configurable; they live in code so a typo in a .env
+# cannot raise them.
+CEILING_ROUNDS = 10
+CEILING_TOKENS = 2_000_000
+CEILING_SECONDS = 3600           # one hour
+CEILING_ROUND_SECONDS = 1200     # 20 minutes
+CEILING_COST_USD = 25.00
+
+# Defaults: the values an unconfigured session uses. Lower than the
+# ceilings on purpose; the user has to opt up.
+DEFAULT_ROUNDS = 5
+DEFAULT_TOKENS = 500_000
+DEFAULT_SECONDS = 1800           # 30 minutes
+DEFAULT_ROUND_SECONDS = 600      # 10 minutes
+DEFAULT_COST_USD = 5.00
+
+
+class HaltReason(str, Enum):
+    """Why a QALLM session stopped iterating."""
+
+    COMPLETED = "completed"           # ran to max_rounds without tripping a cap
+    MAX_ROUNDS = "max_rounds"
+    MAX_TOKENS = "max_tokens"
+    MAX_SECONDS = "max_seconds"
+    MAX_ROUND_SECONDS = "max_round_seconds"
+    MAX_COST_USD = "max_cost_usd"
+
+
+def _clamp(value: int, ceiling: int, name: str) -> int:
+    """Clamp ``value`` to ``ceiling`` with a noisy warning if clamped.
+
+    ``value`` of 0 or less is treated as 'unset' and replaced with the
+    ceiling, so users cannot accidentally configure an immediate halt.
+    """
+    if value <= 0:
+        return ceiling
+    if value > ceiling:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Requested %s=%d exceeds ceiling %d; clamping to ceiling.",
+            name, value, ceiling,
+        )
+        return ceiling
+    return value
+
+
+def _clamp_float(value: float, ceiling: float, name: str) -> float:
+    if value <= 0:
+        return ceiling
+    if value > ceiling:
+        import logging
+        logging.getLogger(__name__).warning(
+            "Requested %s=%.2f exceeds ceiling %.2f; clamping to ceiling.",
+            name, value, ceiling,
+        )
+        return ceiling
+    return value
+
+
+@dataclass(frozen=True)
+class BudgetCaps:
+    """The five caps that bound a session.
+
+    Construct via :meth:`from_kwargs` to get ceiling-clamping and 0-handling
+    for free. Direct construction is fine for tests but skips clamping.
+    """
+
+    max_rounds: int = DEFAULT_ROUNDS
+    max_tokens: int = DEFAULT_TOKENS
+    max_seconds: int = DEFAULT_SECONDS
+    max_round_seconds: int = DEFAULT_ROUND_SECONDS
+    max_cost_usd: float = DEFAULT_COST_USD
+
+    @classmethod
+    def from_kwargs(
+        cls,
+        *,
+        max_rounds: int = DEFAULT_ROUNDS,
+        max_tokens: int = DEFAULT_TOKENS,
+        max_seconds: int = DEFAULT_SECONDS,
+        max_round_seconds: int = DEFAULT_ROUND_SECONDS,
+        max_cost_usd: float = DEFAULT_COST_USD,
+    ) -> "BudgetCaps":
+        return cls(
+            max_rounds=_clamp(max_rounds, CEILING_ROUNDS, "max_rounds"),
+            max_tokens=_clamp(max_tokens, CEILING_TOKENS, "max_tokens"),
+            max_seconds=_clamp(max_seconds, CEILING_SECONDS, "max_seconds"),
+            max_round_seconds=_clamp(
+                max_round_seconds, CEILING_ROUND_SECONDS, "max_round_seconds"
+            ),
+            max_cost_usd=_clamp_float(
+                max_cost_usd, CEILING_COST_USD, "max_cost_usd"
+            ),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "max_rounds": self.max_rounds,
+            "max_tokens": self.max_tokens,
+            "max_seconds": self.max_seconds,
+            "max_round_seconds": self.max_round_seconds,
+            "max_cost_usd": self.max_cost_usd,
+        }
+
+
+@dataclass
+class BudgetState:
+    """Mutable session state inspected at each round boundary.
+
+    Owns the ``start_time``, the round count, and the last-round-start
+    timestamp. The token tracker lives elsewhere (the LLM clients) and is
+    passed in by reference.
+    """
+
+    caps: BudgetCaps
+    tracker: TokenTracker
+    start_time: float = field(default_factory=time.monotonic)
+    round_start_time: float = field(default_factory=time.monotonic)
+    rounds_completed: int = 0
+    last_round_seconds: float = 0.0
+
+    def mark_round_start(self) -> None:
+        self.round_start_time = time.monotonic()
+
+    def mark_round_end(self) -> None:
+        now = time.monotonic()
+        self.last_round_seconds = now - self.round_start_time
+        self.rounds_completed += 1
+
+    @property
+    def elapsed_seconds(self) -> float:
+        return time.monotonic() - self.start_time
+
+    def check(self) -> Optional[HaltReason]:
+        """Return a halt reason if any cap has tripped, else ``None``.
+
+        Caps are checked in the order: rounds, cost, tokens, wall-clock,
+        per-round. The first cap to trip wins, so the halt reason is
+        deterministic even when multiple caps are over at once.
+        """
+        if self.rounds_completed >= self.caps.max_rounds:
+            return HaltReason.MAX_ROUNDS
+
+        if self.tracker.total_cost_usd >= self.caps.max_cost_usd:
+            return HaltReason.MAX_COST_USD
+
+        if self.tracker.total_tokens >= self.caps.max_tokens:
+            return HaltReason.MAX_TOKENS
+
+        if self.elapsed_seconds >= self.caps.max_seconds:
+            return HaltReason.MAX_SECONDS
+
+        if self.last_round_seconds >= self.caps.max_round_seconds:
+            return HaltReason.MAX_ROUND_SECONDS
+
+        return None
+
+    def summary(self) -> dict:
+        """Snapshot suitable for inclusion in summary.json."""
+        return {
+            "caps": self.caps.to_dict(),
+            "rounds_completed": self.rounds_completed,
+            "elapsed_seconds": round(self.elapsed_seconds, 2),
+            "last_round_seconds": round(self.last_round_seconds, 2),
+            "tokens_used": self.tracker.total_tokens,
+            "cost_usd": round(self.tracker.total_cost_usd, 6),
+        }

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -36,6 +36,7 @@ LLM_PROVIDERS = {
 # 1. Add the import at the top of orchestrator.py
 from qallm.verification.verification_manager import VerificationManager
 from qallm.verification.test_persistence import TestStabilityConfig
+from qallm.cost import BudgetCaps, BudgetState, HaltReason
 
 
 class QALLMOrchestrator:
@@ -49,6 +50,7 @@ class QALLMOrchestrator:
             rounds: int = 5,
             test_stability: str = "frozen",
             generation_policy: str = "grow",
+            caps: BudgetCaps | None = None,
     ) -> None:
         self.ingestion_manager = IngestionManager()
         self.analysis_manager = AnalysisManager()
@@ -57,7 +59,16 @@ class QALLMOrchestrator:
         self.stage = stage
         self.strategy = strategy
         self.oracle = oracle
-        self.rounds = 1 if rounds < 1 else rounds
+
+        # Budget caps: if not supplied, construct from the legacy `rounds`
+        # argument plus default ceilings on the other axes. `rounds` is
+        # kept as a positional parameter for backward compatibility with
+        # earlier orchestrator clients (web UI, tests) that don't yet pass
+        # a full BudgetCaps.
+        self.caps = caps or BudgetCaps.from_kwargs(max_rounds=rounds)
+        # Legacy: keep `self.rounds` as an alias for caps.max_rounds so
+        # downstream code that reads it still works.
+        self.rounds = self.caps.max_rounds
         self.current_round: int = 1
 
         # Test-stability config: validated here so a bad combination fails
@@ -68,7 +79,13 @@ class QALLMOrchestrator:
 
         provider_cls = LLM_PROVIDERS.get(llm_type, OpenAIModel)
         self.llm: LLMModel = provider_cls(model_name) if model_name else provider_cls()
-        self.tracker = TokenTracker(budget=settings.TOKEN_BUDGET)
+        # The token tracker's own budget mirrors the cost-caps token budget,
+        # so the per-LLM-call "stop on out-of-tokens" logic still works.
+        self.tracker = TokenTracker(budget=self.caps.max_tokens)
+        # Budget state: tracks elapsed time and round count for cap checks.
+        self.budget_state = BudgetState(caps=self.caps, tracker=self.tracker)
+        # Set on halt; null until then.
+        self.halt_reason: HaltReason | None = None
 
         # 2. Initialize Repair Manager
         self.repair_manager = RepairManager(LLMRepairAgent(self.llm), analyzer=self.analysis_manager)
@@ -83,10 +100,11 @@ class QALLMOrchestrator:
         )
 
         logger.info(
-            "Initialization completed! Strategy %s, stability %s, policy %s",
+            "Initialization completed! Strategy %s, stability %s, policy %s, caps %s",
             self.strategy,
             self.stability_config.stability.value,
             self.stability_config.policy.value,
+            self.caps.to_dict(),
         )
 
     def run(self, source_path: str) -> dict:
@@ -111,15 +129,39 @@ class QALLMOrchestrator:
         logger.info("Baseline complete. Stored as round_00_baseline.")
 
         # QALLM rounds: Repair → Analyse → Verify → Report
+        # Loop terminates when either max_rounds is reached or any other
+        # budget cap trips at a round boundary.
         round_cus_to_process = units
-        while self.current_round <= self.rounds:
+        while True:
+            self.budget_state.mark_round_start()
             round_cus_tested = self.run_round(round_cus_to_process)
+            self.budget_state.mark_round_end()
+
             next_round_cus_to_process = [tcu.repaired_unit.repaired_code_unit for tcu in round_cus_tested]
             round_cus_to_process = next_round_cus_to_process
             self.current_round += 1
             # Under PER_ROUND, tests don't carry between rounds. Drop them
             # so the next round starts with an empty store. No-op for FROZEN.
             self.verification_manager.store.clear_for_round()
+
+            # Cap check at the round boundary. The first cap to trip wins;
+            # MAX_ROUNDS is the natural completion signal.
+            halt = self.budget_state.check()
+            if halt is not None:
+                self.halt_reason = halt
+                if halt is HaltReason.MAX_ROUNDS:
+                    logger.info("Completed all %d rounds.", self.caps.max_rounds)
+                else:
+                    logger.warning(
+                        "Budget cap tripped: %s. Halting after round %d. "
+                        "Spent: %d tokens, $%.4f, %.1fs total.",
+                        halt.value,
+                        self.budget_state.rounds_completed,
+                        self.tracker.total_tokens,
+                        self.tracker.total_cost_usd,
+                        self.budget_state.elapsed_seconds,
+                    )
+                break
 
         session_data = self.verification_manager.get_session_data()
         summary = self._build_summary(source_path, units, session_data)
@@ -166,6 +208,10 @@ class QALLMOrchestrator:
             "units_analyzed": len(units),
             "functions_verified": len(sessions_data),
             "cost": self.tracker.to_dict(),
+            "budget": self.budget_state.summary(),
+            "halt_reason": (
+                self.halt_reason.value if self.halt_reason is not None else None
+            ),
             "test_persistence": self.verification_manager.get_stability_summary(),
             "sessions": sessions_data,
         }

--- a/src/qallm/run_qallm.py
+++ b/src/qallm/run_qallm.py
@@ -43,6 +43,24 @@ def main():
             "grow: yes (existing tests are kept and new ones added)."
         ),
     )
+    # Budget caps. Default values are sensible for a beta session; the
+    # ceilings in qallm.cost override any larger value silently.
+    parser.add_argument(
+        "--max-tokens", type=int, default=None,
+        help="Max total tokens for the session (default: 500000, ceiling: 2M).",
+    )
+    parser.add_argument(
+        "--max-seconds", type=int, default=None,
+        help="Wall-clock cap for the whole session (default: 1800, ceiling: 3600).",
+    )
+    parser.add_argument(
+        "--max-round-seconds", type=int, default=None,
+        help="Time cap per single round (default: 600, ceiling: 1200).",
+    )
+    parser.add_argument(
+        "--max-cost-usd", type=float, default=None,
+        help="Estimated USD cost cap for the session (default: 5.00, ceiling: 25.00).",
+    )
     parser.add_argument("--verbose", "-v", action="store_true")
     args = parser.parse_args()
 
@@ -52,6 +70,17 @@ def main():
     )
 
     stage = LifecycleStage(args.stage)
+    # Build BudgetCaps from args, falling back to config defaults. Any
+    # value above the ceilings in qallm.cost is clamped by from_kwargs.
+    from qallm.cost import BudgetCaps
+    from qallm.config import settings
+    caps = BudgetCaps.from_kwargs(
+        max_rounds=args.rounds,
+        max_tokens=args.max_tokens if args.max_tokens is not None else settings.TOKEN_BUDGET,
+        max_seconds=args.max_seconds if args.max_seconds is not None else settings.QALLM_MAX_SECONDS,
+        max_round_seconds=args.max_round_seconds if args.max_round_seconds is not None else settings.QALLM_MAX_ROUND_SECONDS,
+        max_cost_usd=args.max_cost_usd if args.max_cost_usd is not None else settings.QALLM_MAX_COST_USD,
+    )
     orchestrator = QALLMOrchestrator(
         stage=stage,
         strategy=args.strategy,
@@ -61,6 +90,7 @@ def main():
         rounds=args.rounds,
         test_stability=args.test_stability,
         generation_policy=args.generation_policy,
+        caps=caps,
     )
 
     summary = orchestrator.run(args.source)
@@ -74,6 +104,9 @@ def main():
     print(f"Units:    {summary['units_analyzed']}")
     print(f"Verified: {summary['functions_verified']}")
     print(f"Cost:     ${summary['cost']['total_cost_usd']:.4f}")
+    halt = summary.get("halt_reason")
+    if halt and halt != "completed" and halt != "max_rounds":
+        print(f"Halted:   {halt} (budget cap)")
     print()
 
     for s in summary["sessions"]:

--- a/tests/test_cost.py
+++ b/tests/test_cost.py
@@ -1,0 +1,210 @@
+"""Tests for qallm.cost (budget caps and cost estimation).
+
+Coverage:
+
+  * BudgetCaps construction: defaults, clamping above ceiling, zero-handling.
+  * BudgetState.check: each cap trips, ordering of multi-trip cases.
+  * BudgetState integration with TokenTracker.
+  * Summary shape suitable for summary.json.
+
+These tests do not call any LLM; they manipulate the tracker directly to
+simulate cost accumulation.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from qallm.cost import (
+    CEILING_COST_USD,
+    CEILING_ROUNDS,
+    CEILING_ROUND_SECONDS,
+    CEILING_SECONDS,
+    CEILING_TOKENS,
+    DEFAULT_COST_USD,
+    DEFAULT_ROUNDS,
+    DEFAULT_TOKENS,
+    BudgetCaps,
+    BudgetState,
+    HaltReason,
+)
+from qallm.llm.base import TokenTracker
+
+
+# ---------- BudgetCaps construction ----------
+
+
+class TestBudgetCapsConstruction:
+    def test_defaults_match_module_constants(self):
+        caps = BudgetCaps()
+        assert caps.max_rounds == DEFAULT_ROUNDS
+        assert caps.max_tokens == DEFAULT_TOKENS
+        assert caps.max_cost_usd == DEFAULT_COST_USD
+
+    def test_from_kwargs_passes_through_valid_values(self):
+        caps = BudgetCaps.from_kwargs(
+            max_rounds=3,
+            max_tokens=100_000,
+            max_seconds=60,
+            max_round_seconds=30,
+            max_cost_usd=1.0,
+        )
+        assert caps.max_rounds == 3
+        assert caps.max_tokens == 100_000
+        assert caps.max_cost_usd == 1.0
+
+    def test_from_kwargs_clamps_above_ceiling(self):
+        caps = BudgetCaps.from_kwargs(max_rounds=10_000)
+        assert caps.max_rounds == CEILING_ROUNDS
+
+    def test_from_kwargs_clamps_cost_above_ceiling(self):
+        caps = BudgetCaps.from_kwargs(max_cost_usd=999.99)
+        assert caps.max_cost_usd == CEILING_COST_USD
+
+    def test_zero_and_negative_treated_as_ceiling(self):
+        caps_zero = BudgetCaps.from_kwargs(max_rounds=0)
+        caps_neg = BudgetCaps.from_kwargs(max_rounds=-5)
+        assert caps_zero.max_rounds == CEILING_ROUNDS
+        assert caps_neg.max_rounds == CEILING_ROUNDS
+
+    def test_to_dict_round_trips_all_fields(self):
+        caps = BudgetCaps.from_kwargs(
+            max_rounds=3, max_tokens=100_000, max_seconds=60,
+            max_round_seconds=30, max_cost_usd=1.5,
+        )
+        d = caps.to_dict()
+        assert d == {
+            "max_rounds": 3,
+            "max_tokens": 100_000,
+            "max_seconds": 60,
+            "max_round_seconds": 30,
+            "max_cost_usd": 1.5,
+        }
+
+
+# ---------- BudgetState ----------
+
+
+def _state(**caps_kwargs) -> BudgetState:
+    """Build a BudgetState with a fresh tracker for testing."""
+    tracker = TokenTracker(budget=99_999_999)
+    caps = BudgetCaps.from_kwargs(**caps_kwargs)
+    return BudgetState(caps=caps, tracker=tracker)
+
+
+class TestBudgetStateChecks:
+    def test_fresh_state_does_not_halt(self):
+        st = _state()
+        assert st.check() is None
+
+    def test_max_rounds_trips_after_completion(self):
+        st = _state(max_rounds=2)
+        st.mark_round_start()
+        st.mark_round_end()
+        st.mark_round_start()
+        st.mark_round_end()
+        assert st.check() is HaltReason.MAX_ROUNDS
+
+    def test_max_rounds_does_not_trip_before(self):
+        st = _state(max_rounds=2)
+        st.mark_round_start()
+        st.mark_round_end()
+        assert st.check() is None
+
+    def test_max_tokens_trips_on_tracker_state(self):
+        st = _state(max_tokens=1000)
+        st.tracker.total_input = 600
+        st.tracker.total_output = 401
+        assert st.check() is HaltReason.MAX_TOKENS
+
+    def test_max_cost_usd_trips_on_tracker_state(self):
+        st = _state(max_cost_usd=1.0)
+        st.tracker.total_cost_usd = 1.0001
+        assert st.check() is HaltReason.MAX_COST_USD
+
+    def test_max_seconds_trips_on_elapsed(self):
+        st = _state(max_seconds=1)
+        # Roll back start_time by 2 seconds to simulate elapsed time.
+        st.start_time = time.monotonic() - 2.0
+        assert st.check() is HaltReason.MAX_SECONDS
+
+    def test_max_round_seconds_trips_on_long_round(self):
+        st = _state(max_round_seconds=1)
+        # Simulate a round that lasted 5 seconds.
+        st.last_round_seconds = 5.0
+        assert st.check() is HaltReason.MAX_ROUND_SECONDS
+
+
+class TestCheckOrdering:
+    """When multiple caps would trip at the same check, the result is deterministic.
+
+    The order is: rounds, cost, tokens, wall-clock, per-round. Rationale: rounds
+    is the most natural completion signal; cost is what the user pays for and
+    should override anything else.
+    """
+
+    def test_rounds_beats_cost(self):
+        st = _state(max_rounds=1, max_cost_usd=0.01)
+        st.mark_round_start()
+        st.mark_round_end()
+        st.tracker.total_cost_usd = 5.0
+        assert st.check() is HaltReason.MAX_ROUNDS
+
+    def test_cost_beats_tokens(self):
+        st = _state(max_cost_usd=0.5, max_tokens=100)
+        st.tracker.total_cost_usd = 1.0
+        st.tracker.total_input = 500
+        assert st.check() is HaltReason.MAX_COST_USD
+
+    def test_tokens_beats_seconds(self):
+        st = _state(max_tokens=100, max_seconds=1)
+        st.tracker.total_input = 1000
+        st.start_time = time.monotonic() - 10
+        assert st.check() is HaltReason.MAX_TOKENS
+
+    def test_seconds_beats_round_seconds(self):
+        st = _state(max_seconds=1, max_round_seconds=1)
+        st.start_time = time.monotonic() - 10
+        st.last_round_seconds = 5.0
+        assert st.check() is HaltReason.MAX_SECONDS
+
+
+# ---------- BudgetState.summary() ----------
+
+
+class TestBudgetStateSummary:
+    def test_summary_shape(self):
+        st = _state(max_rounds=5, max_cost_usd=10.0)
+        st.mark_round_start()
+        st.mark_round_end()
+        st.tracker.total_input = 100
+        st.tracker.total_output = 200
+        st.tracker.total_cost_usd = 0.42
+
+        summary = st.summary()
+        assert summary["rounds_completed"] == 1
+        assert summary["tokens_used"] == 300
+        assert summary["cost_usd"] == 0.42
+        assert "elapsed_seconds" in summary
+        assert "last_round_seconds" in summary
+        assert summary["caps"]["max_rounds"] == 5
+        assert summary["caps"]["max_cost_usd"] == 10.0
+
+
+# ---------- HaltReason as a string enum ----------
+
+
+class TestHaltReason:
+    def test_completed_is_distinct_from_max_rounds(self):
+        # COMPLETED means the loop ran to its natural end without tripping
+        # any cap. MAX_ROUNDS means the rounds cap was the binding constraint.
+        # In practice the orchestrator sets MAX_ROUNDS on natural completion;
+        # COMPLETED is reserved for future use where a model verdict says stop.
+        assert HaltReason.COMPLETED.value != HaltReason.MAX_ROUNDS.value
+
+    def test_all_reasons_serialise_as_strings(self):
+        for r in HaltReason:
+            assert isinstance(r.value, str)
+            assert r.value  # not empty


### PR DESCRIPTION
Adds qallm.cost with BudgetCaps, BudgetState, and HaltReason. Five caps enforced at QALLM round boundaries:
  - max_rounds (default 5, ceiling 10)
  - max_tokens (default 500k, ceiling 2M)
  - max_seconds (default 1800, ceiling 3600)
  - max_round_seconds (default 600, ceiling 1200)
  - max_cost_usd (default 5.00, ceiling 25.00)

Code-level ceilings cannot be raised by env-var or CLI flag; the intent is that a config typo cannot blow a budget through the floor. Values <= 0 are treated as 'unset' and clamped to the ceiling.

The orchestrator owns a BudgetState and checks it at every round boundary. When a cap trips, the loop halts and records the halt reason in summary.json. CLI surfaces it on stdout for runs that halt early.

Reuses the existing MODEL_RATES price table in qallm.llm.base; no duplicate cost tracking.

CLI gains four flags: --max-tokens, --max-seconds, --max-round-seconds, --max-cost-usd. The existing --rounds remains as the source of max_rounds. Env vars QALLM_MAX_ROUNDS, QALLM_MAX_SECONDS, QALLM_MAX_ROUND_SECONDS, QALLM_MAX_COST_USD provide defaults.

20 new tests; all 139 prior tests still pass; 159 total.

Closes NEW-05.