### PR TITLE
feat(judge): three improvement strategies with structured deltas (NEW…

### DIFF
--- a/docs/workflow-design.md
+++ b/docs/workflow-design.md
@@ -319,8 +319,8 @@ For implementation, the workflow maps onto the modules already in place, plus th
 | Test suite persistence     | `qallm.verification.test_persistence`                                 | Built (PR feature/test-stability). 250 lines plus 22 tests. Section 4.5. |
 | Profile evaluation         | `qallm.profiles` + `qallm.evaluation`                                 | Working; reliability indicators wired in NEW-03. Framework-agnostic by design. |
 | FAIRness indicators        | New: extend `qallm.evaluation` with `qallm.fairness` evaluators       | To build. ~100 lines. Section 9.4. |
-| Judge                      | New: `qallm.judge`                                                    | To build. ~150 lines plus tests.  |
-| Improvement strategies     | New: `qallm.judge.strategies`: lexicographic, strict, model           | To build alongside judge.         |
+| Judge                      | `qallm.judge` package: models, comparator, prompts, strategies        | Built (NEW-02). 31 tests.         |
+| Improvement strategies     | `qallm.judge.strategies`: StrictJudge, LexicographicJudge, ModelJudge | Built (NEW-02). Model has Strict fallback on LLM error. |
 | Cost estimation            | `qallm.cost` (price table reused from `qallm.llm.base.MODEL_RATES`)   | Built (NEW-05). 220 lines, 20 tests. |
 | Budget enforcement         | `qallm.orchestrator` round-boundary check via `BudgetState.check()`   | Built (NEW-05). Five caps with ceilings. |
 | Loop / orchestration       | `qallm.orchestrator`                                                  | Loop logic to extend per section 3. |
@@ -333,7 +333,7 @@ For implementation, the workflow maps onto the modules already in place, plus th
 All design questions are resolved. The implementation roadmap below is the basis for the project backlog; each item is one focused, reviewable PR.
 
 1. ~~Extend verification for test-suite persistence per section 4.5.~~ **Done.** Two-axis configurable strategy (`test_stability` x `generation_policy`) with three meaningful modes. New `qallm.verification.test_persistence` module, 250 lines plus 22 tests. CLI flags `--test-stability` and `--generation-policy`. `summary.json` records the mode. Section 4.5.
-2. Build the judge module (`qallm.judge`) with the three improvement strategies. 150 lines plus tests.
+2. ~~Build the judge module (`qallm.judge`) with the three improvement strategies.~~ **Done.** New `qallm.judge` package: `models.py`, `comparator.py`, `prompts.py`, `strategies.py`. Three strategies (Strict, Lexicographic, Model). ModelJudge falls back to Strict on LLM error, parse failure, or `error` field on response. Every JudgeVerdict stores both the structured numerical comparison and (for Model) the LLM's free-text reasoning. 31 tests. FAIRness is omitted from the default Lexicographic priority until NEW-04 ships.
 3. ~~Wire reliability indicators in `qallm.evaluation` to actual verification output.~~ **Done.** Both `qallm.verification.pass_rate` and `qallm.verification.bugs` now read `context["verification_sessions"]: list[TestGenerationSession]`. Added a `final_pass_rate` property on the session model. 12 new tests; all 126 prior tests still pass.
 4. Add FAIRness indicators (`qallm.fairness`): licence, citation, README, docstrings. 100 lines plus tests.
 5. ~~Add budget enforcement in the orchestrator: rounds, tokens, time, cost.~~ **Done.** Five caps with ceilings (rounds 5/10, tokens 500k/2M, seconds 1800/3600, round-seconds 600/1200, cost $5/$25). Reuses the existing `MODEL_RATES` table in `qallm.llm.base`. New module `qallm.cost` with `BudgetCaps`, `BudgetState`, and `HaltReason`. CLI flags `--max-tokens`, `--max-seconds`, `--max-round-seconds`, `--max-cost-usd`. Halt reason recorded in `summary.json`. 20 new tests, 159 tests total.

--- a/src/qallm/judge/__init__.py
+++ b/src/qallm/judge/__init__.py
@@ -1,0 +1,61 @@
+"""The QALLM judge: decides whether a repaired variant improves on its parent.
+
+See workflow design v3 sections 5 and 9.1-9.3 for the full design discussion.
+
+Public API
+----------
+
+Construct a strategy:
+
+    from qallm.judge import StrictJudge, LexicographicJudge, ModelJudge
+
+Each strategy implements::
+
+    def decide(parent: ProfileVerdict,
+               variant: ProfileVerdict,
+               *,
+               raw_evidence: dict | None = None) -> JudgeVerdict
+
+The returned :class:`JudgeVerdict` has:
+
+  * ``outcome``: IMPROVEMENT, REGRESSION, or NO_CHANGE.
+  * ``deltas``: structured per-indicator and per-dimension comparison.
+  * ``explanation``: human-readable reason, either rule-derived (Strict,
+    Lexicographic) or LLM-generated (Model).
+  * ``strategy``: which strategy produced this verdict.
+  * ``fallback_used``: True if a Model strategy fell back to Strict due to
+    an LLM failure.
+
+The deltas object is always populated, regardless of strategy. This is
+deliberate: the thesis-quality validation argument (workflow design v3
+section 5.2) requires that every model verdict can be compared against the
+raw numerical comparison side-by-side.
+"""
+
+from qallm.judge.models import (
+    DimensionDelta,
+    IndicatorDelta,
+    JudgeOutcome,
+    JudgeVerdict,
+    VerdictComparison,
+)
+from qallm.judge.strategies import (
+    JudgeStrategy,
+    LexicographicJudge,
+    ModelJudge,
+    StrictJudge,
+    build_judge,
+)
+
+__all__ = [
+    "DimensionDelta",
+    "IndicatorDelta",
+    "JudgeOutcome",
+    "JudgeStrategy",
+    "JudgeVerdict",
+    "LexicographicJudge",
+    "ModelJudge",
+    "StrictJudge",
+    "VerdictComparison",
+    "build_judge",
+]

--- a/src/qallm/judge/comparator.py
+++ b/src/qallm/judge/comparator.py
@@ -1,0 +1,205 @@
+"""Numerical comparison of two ProfileVerdicts.
+
+Given a parent verdict and a variant verdict over the same profile, produce
+a :class:`VerdictComparison`: a structured side-by-side diff of every
+indicator and dimension. All three judge strategies build on this.
+
+The comparison is deterministic and never calls an LLM. It encodes only the
+rules of arithmetic and status ordering, not any opinion about whether the
+overall change is good.
+"""
+
+from __future__ import annotations
+
+from qallm.evaluation import (
+    DimensionResult,
+    IndicatorResult,
+    IndicatorStatus,
+    ProfileVerdict,
+)
+from qallm.judge.models import (
+    DimensionDelta,
+    IndicatorChange,
+    IndicatorDelta,
+    VerdictComparison,
+)
+
+
+def _direction_for_comparator(comparator: str) -> int:
+    """Return +1 if higher measured is better, -1 if lower is better.
+
+    Mirrors the Comparator enum in qallm.profiles. Unknown comparators
+    default to "higher is better".
+
+    Note on semantics: the indicator's comparator encodes what the
+    *profile author* meant. For example, ``bugs_caught`` uses GE because
+    higher is treated as better (more thorough test suite). This may be
+    counter-intuitive: a variant with fewer bugs caught is not necessarily
+    a *better* variant; it may just have a weaker test suite. The judge
+    here only enforces the profile's stated direction; methodological
+    interpretation of any single indicator is for the thesis to discuss.
+    """
+    comp = comparator.lower()
+    if comp in ("le", "lt", "lte"):
+        return -1
+    # ge, gt, eq, ne, and anything unrecognised: higher is better by default.
+    return +1
+
+
+def _classify_indicator(
+    parent: IndicatorResult, variant: IndicatorResult
+) -> tuple[IndicatorChange, float | None]:
+    """Compare one indicator and return (change, numeric_delta).
+
+    Rules:
+      * If either status is ERROR or SKIPPED, status-based comparison only.
+      * If both measured values exist, the comparator determines whether
+        an increase is improvement or regression.
+      * If only one measured value exists, classification is INCOMPARABLE.
+    """
+    # Status-driven cases first: ERROR or SKIPPED on either side.
+    p_status = parent.status
+    v_status = variant.status
+
+    if p_status is IndicatorStatus.ERROR or v_status is IndicatorStatus.ERROR:
+        # An ERROR on either side is uncomparable: we cannot say one is
+        # better than the other based on a broken measurement.
+        return IndicatorChange.INCOMPARABLE, None
+
+    if (
+        p_status is IndicatorStatus.SKIPPED
+        and v_status is IndicatorStatus.SKIPPED
+    ):
+        return IndicatorChange.UNCHANGED, None
+
+    # Status transitions when SKIPPED appears on only one side: we can't
+    # meaningfully compare because the parent or variant has no signal.
+    if (
+        p_status is IndicatorStatus.SKIPPED
+        or v_status is IndicatorStatus.SKIPPED
+    ):
+        return IndicatorChange.INCOMPARABLE, None
+
+    # At this point both statuses are PASS or FAIL.
+    p_meas = parent.measured
+    v_meas = variant.measured
+
+    if p_meas is None or v_meas is None:
+        # No measured value on one side: fall back to status only.
+        if p_status == v_status:
+            return IndicatorChange.UNCHANGED, None
+        # PASS -> FAIL is regression; FAIL -> PASS is improvement.
+        if p_status is IndicatorStatus.PASS and v_status is IndicatorStatus.FAIL:
+            return IndicatorChange.REGRESSED, None
+        return IndicatorChange.IMPROVED, None
+
+    direction = _direction_for_comparator(parent.comparator)
+    delta = v_meas - p_meas
+    # Direction-adjusted delta: positive means improvement.
+    adjusted = delta * direction
+
+    # Use a small epsilon to avoid floating-point noise being labelled as
+    # change.
+    eps = 1e-9
+    if abs(adjusted) < eps:
+        return IndicatorChange.UNCHANGED, delta
+    if adjusted > 0:
+        return IndicatorChange.IMPROVED, delta
+    return IndicatorChange.REGRESSED, delta
+
+
+def _compare_dimension(
+    parent_dim: DimensionResult, variant_dim: DimensionResult
+) -> DimensionDelta:
+    """Compare two DimensionResults by walking their indicators."""
+    # Match indicators by name. Profiles are stable across rounds, so the
+    # name set should match exactly; if it doesn't, we record what we can.
+    parent_by_name = {ind.name: ind for ind in parent_dim.indicators}
+    variant_by_name = {ind.name: ind for ind in variant_dim.indicators}
+
+    deltas: list[IndicatorDelta] = []
+    all_names = sorted(set(parent_by_name) | set(variant_by_name))
+    for name in all_names:
+        p = parent_by_name.get(name)
+        v = variant_by_name.get(name)
+        if p is None or v is None:
+            # Asymmetric: a new or missing indicator. Classify as
+            # INCOMPARABLE rather than guessing.
+            placeholder = p or v
+            assert placeholder is not None  # one is guaranteed non-None
+            deltas.append(
+                IndicatorDelta(
+                    name=name,
+                    evaluator=placeholder.evaluator,
+                    parent_status=p.status if p else IndicatorStatus.SKIPPED,
+                    variant_status=v.status if v else IndicatorStatus.SKIPPED,
+                    parent_measured=p.measured if p else None,
+                    variant_measured=v.measured if v else None,
+                    comparator=placeholder.comparator,
+                    change=IndicatorChange.INCOMPARABLE,
+                    delta=None,
+                )
+            )
+            continue
+
+        change, delta = _classify_indicator(p, v)
+        deltas.append(
+            IndicatorDelta(
+                name=name,
+                evaluator=p.evaluator,
+                parent_status=p.status,
+                variant_status=v.status,
+                parent_measured=p.measured,
+                variant_measured=v.measured,
+                comparator=p.comparator,
+                change=change,
+                delta=delta,
+            )
+        )
+
+    return DimensionDelta(
+        dimension=parent_dim.dimension,
+        parent_status=parent_dim.status,
+        variant_status=variant_dim.status,
+        indicator_deltas=deltas,
+    )
+
+
+def compare_verdicts(
+    parent: ProfileVerdict, variant: ProfileVerdict
+) -> VerdictComparison:
+    """Compare two ProfileVerdicts indicator-by-indicator, dimension-by-dimension.
+
+    Both verdicts should come from the same profile. If they don't (one has
+    dimensions the other lacks), missing dimensions are treated as SKIPPED
+    and any present indicators are marked INCOMPARABLE.
+    """
+    parent_by_dim = {d.dimension: d for d in parent.dimensions}
+    variant_by_dim = {d.dimension: d for d in variant.dimensions}
+
+    all_dims = sorted(
+        set(parent_by_dim) | set(variant_by_dim),
+        key=lambda d: d.value,
+    )
+
+    deltas: list[DimensionDelta] = []
+    for dim in all_dims:
+        p_dim = parent_by_dim.get(dim)
+        v_dim = variant_by_dim.get(dim)
+        if p_dim is None or v_dim is None:
+            # An entire dimension missing on one side. Build a placeholder
+            # delta with empty indicator list; consumers see status SKIPPED.
+            present = p_dim or v_dim
+            assert present is not None
+            deltas.append(
+                DimensionDelta(
+                    dimension=dim,
+                    parent_status=p_dim.status if p_dim else IndicatorStatus.SKIPPED,
+                    variant_status=v_dim.status if v_dim else IndicatorStatus.SKIPPED,
+                    indicator_deltas=[],
+                )
+            )
+            continue
+        deltas.append(_compare_dimension(p_dim, v_dim))
+
+    return VerdictComparison(dimension_deltas=deltas)

--- a/src/qallm/judge/models.py
+++ b/src/qallm/judge/models.py
@@ -1,0 +1,183 @@
+"""Data classes for the judge module.
+
+These describe what the judge reads (a comparison of two profile verdicts)
+and what it writes (a JudgeVerdict with structured deltas and an explanation).
+
+The deltas are the empirical anchor for the thesis's validation story: every
+LLM-judge verdict is stored alongside the numerical deltas that produced it.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any
+
+from qallm.evaluation import IndicatorStatus
+from qallm.profiles import QualityDimension
+
+
+class JudgeOutcome(str, Enum):
+    """The three verdict outcomes the judge can produce."""
+
+    IMPROVEMENT = "improvement"
+    REGRESSION = "regression"
+    NO_CHANGE = "no_change"
+
+
+class IndicatorChange(str, Enum):
+    """How one indicator changed between parent and variant."""
+
+    IMPROVED = "improved"
+    REGRESSED = "regressed"
+    UNCHANGED = "unchanged"
+    INCOMPARABLE = "incomparable"  # one or both sides have no measured value
+
+
+@dataclass
+class IndicatorDelta:
+    """The change in one indicator between parent and variant.
+
+    Both status and measured-value changes are recorded. They can disagree:
+    an indicator may improve in measured value while remaining the same
+    status (e.g. both pass, but MI rose from 65 to 75). The structured form
+    of this disagreement is what the thesis needs to validate model
+    judgements against the raw numbers.
+    """
+
+    name: str
+    evaluator: str
+    parent_status: IndicatorStatus
+    variant_status: IndicatorStatus
+    parent_measured: float | None
+    variant_measured: float | None
+    comparator: str  # "ge", "le", etc., from the indicator spec
+    change: IndicatorChange
+    # Numeric delta: variant_measured - parent_measured if both are present.
+    delta: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "name": self.name,
+            "evaluator": self.evaluator,
+            "parent_status": self.parent_status.value,
+            "variant_status": self.variant_status.value,
+            "parent_measured": self.parent_measured,
+            "variant_measured": self.variant_measured,
+            "comparator": self.comparator,
+            "change": self.change.value,
+            "delta": self.delta,
+        }
+
+
+@dataclass
+class DimensionDelta:
+    """The change in one dimension (a roll-up of its indicators)."""
+
+    dimension: QualityDimension
+    parent_status: IndicatorStatus
+    variant_status: IndicatorStatus
+    indicator_deltas: list[IndicatorDelta] = field(default_factory=list)
+
+    @property
+    def any_regression(self) -> bool:
+        return any(d.change is IndicatorChange.REGRESSED for d in self.indicator_deltas)
+
+    @property
+    def any_improvement(self) -> bool:
+        return any(d.change is IndicatorChange.IMPROVED for d in self.indicator_deltas)
+
+    @property
+    def status_regressed(self) -> bool:
+        """Whether the rolled-up dimension status got worse.
+
+        Worse means moving from PASS to anything else, or from SKIPPED to
+        FAIL/ERROR. SKIPPED → PASS is not a regression.
+        """
+        order = {
+            IndicatorStatus.PASS: 0,
+            IndicatorStatus.SKIPPED: 1,
+            IndicatorStatus.FAIL: 2,
+            IndicatorStatus.ERROR: 3,
+        }
+        return order[self.variant_status] > order[self.parent_status]
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "dimension": self.dimension.value,
+            "parent_status": self.parent_status.value,
+            "variant_status": self.variant_status.value,
+            "any_regression": self.any_regression,
+            "any_improvement": self.any_improvement,
+            "status_regressed": self.status_regressed,
+            "indicator_deltas": [d.to_dict() for d in self.indicator_deltas],
+        }
+
+
+@dataclass
+class VerdictComparison:
+    """A complete numerical comparison of two ProfileVerdicts.
+
+    This is the structured evidence that all three judge strategies consult.
+    The Strict and Lexicographic strategies derive their verdict directly
+    from it; the Model strategy uses it as part of the prompt and also stores
+    it for validation against the model's free-text reasoning.
+    """
+
+    dimension_deltas: list[DimensionDelta] = field(default_factory=list)
+
+    @property
+    def any_regression(self) -> bool:
+        return any(d.any_regression for d in self.dimension_deltas)
+
+    @property
+    def any_improvement(self) -> bool:
+        return any(d.any_improvement for d in self.dimension_deltas)
+
+    @property
+    def any_status_regression(self) -> bool:
+        return any(d.status_regressed for d in self.dimension_deltas)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "any_regression": self.any_regression,
+            "any_improvement": self.any_improvement,
+            "any_status_regression": self.any_status_regression,
+            "dimension_deltas": [d.to_dict() for d in self.dimension_deltas],
+        }
+
+
+@dataclass
+class JudgeVerdict:
+    """What a judge strategy returns.
+
+    Fields are deliberately verbose: a thesis-quality artefact should be
+    fully self-describing without needing to recover lost context.
+    """
+
+    outcome: JudgeOutcome
+    strategy: str  # "strict", "lexicographic", "model"
+    explanation: str
+    comparison: VerdictComparison
+    # Model strategy only: raw LLM response text (whatever the model
+    # produced), preserved for thesis validation. None for rule-based.
+    model_raw_response: str | None = None
+    # Model strategy: which model produced this verdict.
+    judge_model: str | None = None
+    # True iff a Model strategy fell back to Strict after an LLM failure.
+    fallback_used: bool = False
+    # Optional confidence score the model self-reported (0..1). None for
+    # rule-based strategies.
+    confidence: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "outcome": self.outcome.value,
+            "strategy": self.strategy,
+            "explanation": self.explanation,
+            "comparison": self.comparison.to_dict(),
+            "model_raw_response": self.model_raw_response,
+            "judge_model": self.judge_model,
+            "fallback_used": self.fallback_used,
+            "confidence": self.confidence,
+        }

--- a/src/qallm/judge/prompts.py
+++ b/src/qallm/judge/prompts.py
@@ -1,0 +1,84 @@
+"""Prompts for the ModelJudge.
+
+Kept in a separate module so the wording can be reviewed independently
+of the dispatch logic, and so it can be cited in the thesis methodology
+chapter without pulling the implementation file.
+
+Design notes
+------------
+
+The prompt asks for JSON. Asking for free text and trying to parse keywords
+out of it produces unreliable verdicts. JSON gives us a machine-checkable
+output and a structured place for the model to put its reasoning.
+
+We do NOT include the source code of the parent or variant in the prompt.
+v3 section 5.4: the judge reasons over evidence (the profile output and
+raw verification numbers), not over the look of the code. This keeps the
+judge from falling back to surface aesthetics.
+
+The system prompt is short and frames the role. The user prompt carries
+the data.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from qallm.judge.models import VerdictComparison
+
+
+SYSTEM_PROMPT = """\
+You are a software quality judge for a research-software verification tool.
+You will be shown a structured comparison of two variants of the same code
+unit: a parent (the previous variant) and a candidate (the proposed new
+variant). Each variant has been evaluated against a quality profile that
+produces measured values for indicators across several quality dimensions.
+
+Your job is to decide whether the candidate is an improvement, a regression,
+or no meaningful change, given the evidence shown.
+
+You must respond ONLY with a JSON object of this exact shape:
+
+{
+  "outcome": "improvement" | "regression" | "no_change",
+  "explanation": "one paragraph, plain prose, no markdown",
+  "confidence": <number between 0 and 1>
+}
+
+Rules:
+- Base your verdict on the structured evidence shown. Do not assume facts
+  that are not in the evidence.
+- If indicator values improved in some dimensions but regressed in others,
+  weigh them by importance. Security and Reliability regressions are more
+  serious than Maintainability regressions.
+- If the evidence is ambiguous, prefer "no_change" over inventing a verdict.
+- If a dimension is SKIPPED on one or both sides, it does not contribute
+  to your verdict.
+"""
+
+
+def build_user_prompt(
+    comparison: VerdictComparison,
+    raw_evidence: dict[str, Any] | None = None,
+) -> str:
+    """Build the user prompt for the model judge from a structured comparison.
+
+    The prompt is one JSON-shaped object with two sections: ``comparison``
+    (the structured diff) and ``raw_evidence`` (optional extras from
+    verification: pass rates, bug counts, coverage numbers).
+    """
+    payload: dict[str, Any] = {
+        "comparison": comparison.to_dict(),
+    }
+    if raw_evidence:
+        payload["raw_evidence"] = raw_evidence
+
+    body = json.dumps(payload, indent=2, default=str)
+    return (
+        "Below is the structured evidence comparing the parent variant to "
+        "the candidate variant. Decide whether the candidate is an "
+        "improvement, regression, or no_change, and respond with the JSON "
+        "shape described in the system prompt.\n\n"
+        f"```json\n{body}\n```"
+    )

--- a/src/qallm/judge/strategies.py
+++ b/src/qallm/judge/strategies.py
@@ -1,0 +1,430 @@
+"""Three judge strategies: Strict, Lexicographic, Model.
+
+Each strategy implements the same shape::
+
+    def decide(parent: ProfileVerdict,
+               variant: ProfileVerdict,
+               *,
+               raw_evidence: dict | None = None) -> JudgeVerdict
+
+The strategies share the comparison logic from :mod:`qallm.judge.comparator`;
+they differ in how they map a comparison to an outcome.
+
+Workflow design v3 section 9.3 defines the three strategies and the
+priority ordering for Lexicographic.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Optional, Protocol
+
+from qallm.evaluation import ProfileVerdict
+from qallm.judge.comparator import compare_verdicts
+from qallm.judge.models import (
+    DimensionDelta,
+    IndicatorChange,
+    JudgeOutcome,
+    JudgeVerdict,
+    VerdictComparison,
+)
+from qallm.judge.prompts import SYSTEM_PROMPT, build_user_prompt
+from qallm.llm.base import LLMModel, TokenTracker
+from qallm.profiles import QualityDimension
+
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- shared lexicographic ordering ----------
+
+# Higher priority first. Workflow design v3 section 9.3.
+#
+# v1 priority covers the four EVERSE dimensions currently implemented.
+# FAIRness will be added by NEW-04; it slots in at the end (lowest priority)
+# without changing the order of the others.
+DEFAULT_DIMENSION_PRIORITY: tuple[QualityDimension, ...] = (
+    QualityDimension.SECURITY,
+    QualityDimension.RELIABILITY,
+    QualityDimension.MAINTAINABILITY,
+    QualityDimension.REPRODUCIBILITY,
+)
+
+
+class JudgeStrategy(str, Enum):
+    """The three configurable strategies. Used at orchestrator startup."""
+
+    STRICT = "strict"
+    LEXICOGRAPHIC = "lexicographic"
+    MODEL = "model"
+
+
+# ---------- protocol that all strategies satisfy ----------
+
+
+class Judge(Protocol):
+    """Common shape for every strategy."""
+
+    def decide(
+        self,
+        parent: ProfileVerdict,
+        variant: ProfileVerdict,
+        *,
+        raw_evidence: dict[str, Any] | None = None,
+    ) -> JudgeVerdict: ...
+
+
+# ---------- StrictJudge ----------
+
+
+@dataclass
+class StrictJudge:
+    """Any indicator regression anywhere blocks acceptance.
+
+    Deterministic; no LLM call. Useful as a baseline and as the fallback
+    for ModelJudge when an LLM call fails.
+    """
+
+    strategy_name: str = "strict"
+
+    def decide(
+        self,
+        parent: ProfileVerdict,
+        variant: ProfileVerdict,
+        *,
+        raw_evidence: dict[str, Any] | None = None,
+    ) -> JudgeVerdict:
+        comparison = compare_verdicts(parent, variant)
+
+        if comparison.any_regression:
+            outcome = JudgeOutcome.REGRESSION
+            explanation = _summarise_regressions(comparison, prefix="Strict: ")
+        elif comparison.any_improvement:
+            outcome = JudgeOutcome.IMPROVEMENT
+            explanation = _summarise_improvements(comparison, prefix="Strict: ")
+        else:
+            outcome = JudgeOutcome.NO_CHANGE
+            explanation = (
+                "Strict: no indicator improved or regressed; "
+                "the comparison is neutral."
+            )
+
+        return JudgeVerdict(
+            outcome=outcome,
+            strategy=self.strategy_name,
+            explanation=explanation,
+            comparison=comparison,
+        )
+
+
+# ---------- LexicographicJudge ----------
+
+
+@dataclass
+class LexicographicJudge:
+    """Dimensions ranked by priority; high-priority regressions block.
+
+    A high-priority dimension regression makes the verdict REGRESSION
+    regardless of any low-priority improvements. A low-priority regression
+    is tolerated if a higher-priority dimension improved.
+
+    Default priority: SECURITY > RELIABILITY > MAINTAINABILITY >
+    REPRODUCIBILITY > FAIRNESS. Configurable via the ``priority`` field.
+    """
+
+    priority: tuple[QualityDimension, ...] = DEFAULT_DIMENSION_PRIORITY
+    strategy_name: str = "lexicographic"
+
+    def decide(
+        self,
+        parent: ProfileVerdict,
+        variant: ProfileVerdict,
+        *,
+        raw_evidence: dict[str, Any] | None = None,
+    ) -> JudgeVerdict:
+        comparison = compare_verdicts(parent, variant)
+        outcome, explanation = self._evaluate(comparison)
+        return JudgeVerdict(
+            outcome=outcome,
+            strategy=self.strategy_name,
+            explanation=explanation,
+            comparison=comparison,
+        )
+
+    def _evaluate(self, comparison: VerdictComparison) -> tuple[JudgeOutcome, str]:
+        by_dim = {d.dimension: d for d in comparison.dimension_deltas}
+
+        # Walk priorities in order. The first dimension that has either an
+        # improvement or a regression determines the verdict; lower-priority
+        # dimensions are tie-breakers.
+        for dim in self.priority:
+            delta = by_dim.get(dim)
+            if delta is None:
+                continue
+            if delta.any_regression:
+                return (
+                    JudgeOutcome.REGRESSION,
+                    (
+                        f"Lexicographic: regression in {dim.value}, "
+                        f"the highest-priority dimension showing change. "
+                        + _summarise_regressions(comparison)
+                    ),
+                )
+            if delta.any_improvement:
+                return (
+                    JudgeOutcome.IMPROVEMENT,
+                    (
+                        f"Lexicographic: improvement in {dim.value}, "
+                        f"the highest-priority dimension showing change. "
+                        + _summarise_improvements(comparison)
+                    ),
+                )
+
+        # No priority dimension changed. Check whether any non-priority
+        # dimension shows movement.
+        priority_set = set(self.priority)
+        for delta in comparison.dimension_deltas:
+            if delta.dimension in priority_set:
+                continue
+            if delta.any_regression:
+                return (
+                    JudgeOutcome.REGRESSION,
+                    f"Lexicographic: regression in {delta.dimension.value} "
+                    "(not in priority list).",
+                )
+            if delta.any_improvement:
+                return (
+                    JudgeOutcome.IMPROVEMENT,
+                    f"Lexicographic: improvement in {delta.dimension.value} "
+                    "(not in priority list).",
+                )
+
+        return (
+            JudgeOutcome.NO_CHANGE,
+            "Lexicographic: no dimension shows improvement or regression.",
+        )
+
+
+# ---------- ModelJudge ----------
+
+
+@dataclass
+class ModelJudge:
+    """LLM-driven judge with structured output and a Strict fallback.
+
+    The model receives a JSON payload describing the comparison plus any
+    raw evidence; it must respond with a JSON object having
+    {outcome, explanation, confidence}. On parse failure or LLM error the
+    judge falls back to :class:`StrictJudge` and sets ``fallback_used`` so
+    the failure is visible in the artefact.
+
+    The ``tracker`` argument is optional; if supplied, the judge's LLM
+    calls are recorded there for cost accounting.
+    """
+
+    llm: LLMModel
+    tracker: TokenTracker | None = None
+    strategy_name: str = "model"
+
+    def decide(
+        self,
+        parent: ProfileVerdict,
+        variant: ProfileVerdict,
+        *,
+        raw_evidence: dict[str, Any] | None = None,
+    ) -> JudgeVerdict:
+        comparison = compare_verdicts(parent, variant)
+        user_prompt = build_user_prompt(comparison, raw_evidence)
+
+        try:
+            response = self.llm.chat(
+                system=SYSTEM_PROMPT,
+                user=user_prompt,
+                tracker=self.tracker,
+            )
+        except Exception as exc:  # noqa: BLE001 - any LLM failure
+            logger.warning(
+                "ModelJudge: LLM call failed (%s: %s); falling back to Strict.",
+                type(exc).__name__,
+                exc,
+            )
+            return self._fallback(comparison, reason=f"llm_error: {exc}")
+
+        if response.error:
+            logger.warning(
+                "ModelJudge: LLM responded with error '%s'; falling back to Strict.",
+                response.error,
+            )
+            return self._fallback(comparison, reason=f"llm_error: {response.error}")
+
+        parsed = _parse_model_response(response.content or "")
+        if parsed is None:
+            logger.warning(
+                "ModelJudge: failed to parse JSON from response; falling back to Strict. "
+                "Response was: %r",
+                (response.content or "")[:300],
+            )
+            return self._fallback(
+                comparison,
+                reason="parse_failed",
+                raw_response=response.content,
+            )
+
+        outcome, explanation, confidence = parsed
+        return JudgeVerdict(
+            outcome=outcome,
+            strategy=self.strategy_name,
+            explanation=explanation,
+            comparison=comparison,
+            model_raw_response=response.content,
+            judge_model=response.model or self.llm.name(),
+            confidence=confidence,
+        )
+
+    def _fallback(
+        self,
+        comparison: VerdictComparison,
+        *,
+        reason: str,
+        raw_response: str | None = None,
+    ) -> JudgeVerdict:
+        # Re-derive a verdict from the comparison via strict rules so we
+        # still emit a deterministic outcome.
+        if comparison.any_regression:
+            outcome = JudgeOutcome.REGRESSION
+            why = _summarise_regressions(comparison)
+        elif comparison.any_improvement:
+            outcome = JudgeOutcome.IMPROVEMENT
+            why = _summarise_improvements(comparison)
+        else:
+            outcome = JudgeOutcome.NO_CHANGE
+            why = "no indicator improved or regressed."
+
+        return JudgeVerdict(
+            outcome=outcome,
+            strategy=self.strategy_name,
+            explanation=(
+                f"ModelJudge fell back to Strict ({reason}). Strict verdict: {why}"
+            ),
+            comparison=comparison,
+            model_raw_response=raw_response,
+            judge_model=self.llm.name(),
+            fallback_used=True,
+        )
+
+
+# ---------- factory ----------
+
+
+def build_judge(
+    strategy: JudgeStrategy | str,
+    *,
+    llm: LLMModel | None = None,
+    tracker: TokenTracker | None = None,
+    priority: tuple[QualityDimension, ...] = DEFAULT_DIMENSION_PRIORITY,
+) -> Judge:
+    """Construct a judge from a strategy string or enum.
+
+    Raises:
+        ValueError: if ``strategy`` is "model" but ``llm`` is None.
+    """
+    s = JudgeStrategy(strategy) if isinstance(strategy, str) else strategy
+    if s is JudgeStrategy.STRICT:
+        return StrictJudge()
+    if s is JudgeStrategy.LEXICOGRAPHIC:
+        return LexicographicJudge(priority=priority)
+    if s is JudgeStrategy.MODEL:
+        if llm is None:
+            raise ValueError("ModelJudge requires an `llm` argument.")
+        return ModelJudge(llm=llm, tracker=tracker)
+    raise ValueError(f"Unknown strategy: {strategy!r}")
+
+
+# ---------- helpers ----------
+
+
+def _summarise_regressions(
+    comparison: VerdictComparison, prefix: str = ""
+) -> str:
+    names = []
+    for d in comparison.dimension_deltas:
+        for ind in d.indicator_deltas:
+            if ind.change is IndicatorChange.REGRESSED:
+                names.append(f"{d.dimension.value}.{ind.name}")
+    if not names:
+        return f"{prefix}no indicator regressed."
+    return f"{prefix}regressions: {', '.join(names)}."
+
+
+def _summarise_improvements(
+    comparison: VerdictComparison, prefix: str = ""
+) -> str:
+    names = []
+    for d in comparison.dimension_deltas:
+        for ind in d.indicator_deltas:
+            if ind.change is IndicatorChange.IMPROVED:
+                names.append(f"{d.dimension.value}.{ind.name}")
+    if not names:
+        return f"{prefix}no indicator improved."
+    return f"{prefix}improvements: {', '.join(names)}."
+
+
+# ---------- response parsing ----------
+
+
+def _parse_model_response(
+    content: str,
+) -> Optional[tuple[JudgeOutcome, str, float | None]]:
+    """Extract (outcome, explanation, confidence) from the model output.
+
+    Tries: full JSON parse, then JSON parse of the first ``{...}`` block
+    found in the text. Returns None if both fail or the outcome is invalid.
+    """
+    obj = _try_parse_json(content)
+    if obj is None:
+        return None
+    raw_outcome = obj.get("outcome")
+    if not isinstance(raw_outcome, str):
+        return None
+    try:
+        outcome = JudgeOutcome(raw_outcome.lower().strip())
+    except ValueError:
+        return None
+    explanation = obj.get("explanation")
+    if not isinstance(explanation, str):
+        explanation = ""
+    raw_conf = obj.get("confidence")
+    confidence: float | None = None
+    if isinstance(raw_conf, (int, float)):
+        confidence = max(0.0, min(1.0, float(raw_conf)))
+    return outcome, explanation, confidence
+
+
+_JSON_OBJECT_RE = re.compile(r"\{[\s\S]*\}", re.MULTILINE)
+
+
+def _try_parse_json(text: str) -> dict | None:
+    """Try a strict parse, then a regex-fallback to find a JSON-shaped block."""
+    text = text.strip()
+    if not text:
+        return None
+    try:
+        obj = json.loads(text)
+        if isinstance(obj, dict):
+            return obj
+    except json.JSONDecodeError:
+        pass
+    # Some models wrap JSON in markdown fences or prose. Find the first
+    # `{...}` blob and try parsing that.
+    match = _JSON_OBJECT_RE.search(text)
+    if not match:
+        return None
+    try:
+        obj = json.loads(match.group(0))
+        return obj if isinstance(obj, dict) else None
+    except json.JSONDecodeError:
+        return None

--- a/tests/test_judge.py
+++ b/tests/test_judge.py
@@ -1,0 +1,442 @@
+"""Tests for qallm.judge.
+
+Coverage:
+
+  * comparator: indicator classification (IMPROVED, REGRESSED, UNCHANGED,
+    INCOMPARABLE) across all relevant combinations of status and measured
+    value.
+  * comparator: dimension-level rollup, including asymmetric profiles.
+  * StrictJudge: regression wins over improvement; neutral comparisons
+    yield NO_CHANGE.
+  * LexicographicJudge: priority ordering; high-priority regression
+    blocks lower-priority improvement.
+  * ModelJudge: structured JSON path, fenced-JSON path, parse-failure
+    fallback, LLM-error fallback.
+  * build_judge: factory dispatch and the ModelJudge-needs-llm error.
+
+ModelJudge tests use a stub LLM; no real API calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from qallm.evaluation import (
+    DimensionResult,
+    IndicatorResult,
+    IndicatorStatus,
+    ProfileVerdict,
+)
+from qallm.judge import (
+    JudgeOutcome,
+    JudgeStrategy,
+    JudgeVerdict,
+    LexicographicJudge,
+    ModelJudge,
+    StrictJudge,
+    build_judge,
+)
+from qallm.judge.comparator import compare_verdicts
+from qallm.judge.models import IndicatorChange, VerdictComparison
+from qallm.llm.base import LLMResponse
+from qallm.profiles import QualityDimension
+
+
+# ---------- helpers ----------
+
+
+def _indicator(
+    name: str,
+    status: IndicatorStatus,
+    measured: float | None,
+    comparator: str = "ge",
+    threshold: float = 0.0,
+    evaluator: str = "stub.eval",
+) -> IndicatorResult:
+    return IndicatorResult(
+        name=name,
+        evaluator=evaluator,
+        threshold=threshold,
+        comparator=comparator,
+        measured=measured,
+        status=status,
+    )
+
+
+def _dim(
+    dimension: QualityDimension, *indicators: IndicatorResult
+) -> DimensionResult:
+    return DimensionResult(dimension=dimension, indicators=list(indicators))
+
+
+def _verdict(*dims: DimensionResult, profile_id: str = "stub") -> ProfileVerdict:
+    return ProfileVerdict(profile_id=profile_id, dimensions=list(dims))
+
+
+# ---------- comparator: indicator classification ----------
+
+
+class TestIndicatorClassification:
+    """The 16 combinations are too many; cover the meaningful ones."""
+
+    def test_both_pass_higher_measured_is_improvement_for_ge(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0, comparator="ge")))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0, comparator="ge")))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.IMPROVED
+        assert d.delta == 15.0
+
+    def test_both_pass_lower_measured_is_regression_for_ge(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0, comparator="ge")))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0, comparator="ge")))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.REGRESSED
+        assert d.delta == -15.0
+
+    def test_le_comparator_inverts_direction(self):
+        # Lower is better for LE comparators (bandit count, complexity).
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 5.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 2.0, comparator="le")))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        # Lower means improvement under LE; delta is variant - parent = -3.
+        assert d.change is IndicatorChange.IMPROVED
+        assert d.delta == -3.0
+
+    def test_same_measured_is_unchanged(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.UNCHANGED
+
+    def test_status_only_when_no_measured(self):
+        # No measured values, but statuses differ: should fall back to status.
+        parent = _verdict(_dim(QualityDimension.RELIABILITY,
+            _indicator("x", IndicatorStatus.FAIL, None)))
+        variant = _verdict(_dim(QualityDimension.RELIABILITY,
+            _indicator("x", IndicatorStatus.PASS, None)))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.IMPROVED
+
+    def test_error_makes_indicator_incomparable(self):
+        parent = _verdict(_dim(QualityDimension.RELIABILITY,
+            _indicator("x", IndicatorStatus.PASS, 1.0)))
+        variant = _verdict(_dim(QualityDimension.RELIABILITY,
+            _indicator("x", IndicatorStatus.ERROR, None)))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.INCOMPARABLE
+
+    def test_skipped_on_both_is_unchanged(self):
+        parent = _verdict(_dim(QualityDimension.REPRODUCIBILITY,
+            _indicator("env", IndicatorStatus.SKIPPED, None)))
+        variant = _verdict(_dim(QualityDimension.REPRODUCIBILITY,
+            _indicator("env", IndicatorStatus.SKIPPED, None)))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.UNCHANGED
+
+    def test_skipped_on_one_side_is_incomparable(self):
+        parent = _verdict(_dim(QualityDimension.REPRODUCIBILITY,
+            _indicator("env", IndicatorStatus.SKIPPED, None)))
+        variant = _verdict(_dim(QualityDimension.REPRODUCIBILITY,
+            _indicator("env", IndicatorStatus.PASS, 1.0)))
+        comp = compare_verdicts(parent, variant)
+        d = comp.dimension_deltas[0].indicator_deltas[0]
+        assert d.change is IndicatorChange.INCOMPARABLE
+
+
+class TestDimensionRollup:
+    def test_dimension_with_one_regression_and_one_improvement(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0),
+            _indicator("cc", IndicatorStatus.PASS, 5.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0),     # improved
+            _indicator("cc", IndicatorStatus.PASS, 8.0, comparator="le")))  # regressed
+        comp = compare_verdicts(parent, variant)
+        delta = comp.dimension_deltas[0]
+        assert delta.any_improvement is True
+        assert delta.any_regression is True
+
+    def test_asymmetric_dimensions_handled(self):
+        # Parent has Security, variant doesn't.
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        comp = compare_verdicts(parent, variant)
+        # Both dimensions present in the output as placeholder deltas.
+        dims = {d.dimension for d in comp.dimension_deltas}
+        assert QualityDimension.SECURITY in dims
+        assert QualityDimension.MAINTAINABILITY in dims
+
+
+# ---------- StrictJudge ----------
+
+
+class TestStrictJudge:
+    def test_any_regression_means_regression(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0)))
+        verdict = StrictJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.REGRESSION
+        assert verdict.strategy == "strict"
+
+    def test_only_improvements_means_improvement(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0)))
+        verdict = StrictJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.IMPROVEMENT
+
+    def test_no_movement_means_no_change(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        verdict = StrictJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.NO_CHANGE
+
+    def test_mixed_movement_is_regression(self):
+        # One improved, one regressed: strict says regression wins.
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0),
+            _indicator("cc", IndicatorStatus.PASS, 5.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0),     # improved
+            _indicator("cc", IndicatorStatus.PASS, 9.0, comparator="le")))  # regressed
+        verdict = StrictJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.REGRESSION
+
+    def test_explanation_lists_offending_indicators(self):
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 3.0, comparator="le")))
+        verdict = StrictJudge().decide(parent, variant)
+        assert "bandit" in verdict.explanation.lower()
+
+
+# ---------- LexicographicJudge ----------
+
+
+class TestLexicographicJudge:
+    def test_high_priority_regression_blocks_lower_improvement(self):
+        # Security regresses; Maintainability improves. Lex says regression.
+        parent = _verdict(
+            _dim(QualityDimension.SECURITY,
+                _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")),
+            _dim(QualityDimension.MAINTAINABILITY,
+                _indicator("mi", IndicatorStatus.PASS, 60.0)),
+        )
+        variant = _verdict(
+            _dim(QualityDimension.SECURITY,
+                _indicator("bandit", IndicatorStatus.PASS, 2.0, comparator="le")),  # worse
+            _dim(QualityDimension.MAINTAINABILITY,
+                _indicator("mi", IndicatorStatus.PASS, 75.0)),  # better
+        )
+        verdict = LexicographicJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.REGRESSION
+        assert "security" in verdict.explanation.lower()
+
+    def test_high_priority_improvement_outweighs_lower_regression(self):
+        # Security improves; Maintainability regresses. Lex says improvement.
+        parent = _verdict(
+            _dim(QualityDimension.SECURITY,
+                _indicator("bandit", IndicatorStatus.PASS, 3.0, comparator="le")),
+            _dim(QualityDimension.MAINTAINABILITY,
+                _indicator("mi", IndicatorStatus.PASS, 75.0)),
+        )
+        variant = _verdict(
+            _dim(QualityDimension.SECURITY,
+                _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")),  # better
+            _dim(QualityDimension.MAINTAINABILITY,
+                _indicator("mi", IndicatorStatus.PASS, 60.0)),  # worse
+        )
+        verdict = LexicographicJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.IMPROVEMENT
+
+    def test_no_change_when_nothing_moves(self):
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        verdict = LexicographicJudge().decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.NO_CHANGE
+
+
+# ---------- ModelJudge ----------
+
+
+def _make_llm_stub(content: str = "", error: str | None = None) -> MagicMock:
+    """A stub LLM whose chat() returns a fixed LLMResponse."""
+    llm = MagicMock()
+    llm.name.return_value = "stub-judge-model"
+    llm.chat.return_value = LLMResponse(
+        content=content,
+        model="stub-judge-model",
+        provider="stub",
+        input_tokens=10,
+        output_tokens=20,
+        error=error,
+    )
+    return llm
+
+
+class TestModelJudge:
+    def test_clean_json_response_parsed(self):
+        llm = _make_llm_stub(content=(
+            '{"outcome": "improvement", '
+            '"explanation": "MI rose substantially.", '
+            '"confidence": 0.87}'
+        ))
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0)))
+
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.IMPROVEMENT
+        assert verdict.strategy == "model"
+        assert verdict.confidence == 0.87
+        assert verdict.fallback_used is False
+        assert "MI rose" in verdict.explanation
+
+    def test_json_inside_prose_is_recovered(self):
+        # Models sometimes wrap JSON in markdown fences or extra prose.
+        llm = _make_llm_stub(content=(
+            "Sure, here is my verdict:\n"
+            "```json\n"
+            '{"outcome": "regression", "explanation": "Security dropped.", '
+            '"confidence": 0.6}\n'
+            "```\n"
+            "Hope this helps."
+        ))
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 2.0, comparator="le")))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.outcome is JudgeOutcome.REGRESSION
+        assert verdict.fallback_used is False
+
+    def test_unparseable_response_falls_back_to_strict(self):
+        # No JSON at all. Strict fallback: should produce a regression
+        # because Security indicator regressed.
+        llm = _make_llm_stub(content="I cannot decide, sorry.")
+        parent = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 0.0, comparator="le")))
+        variant = _verdict(_dim(QualityDimension.SECURITY,
+            _indicator("bandit", IndicatorStatus.PASS, 2.0, comparator="le")))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.fallback_used is True
+        assert verdict.outcome is JudgeOutcome.REGRESSION
+        assert "fell back" in verdict.explanation.lower()
+
+    def test_llm_exception_falls_back_to_strict(self):
+        llm = MagicMock()
+        llm.name.return_value = "stub-failing-model"
+        llm.chat.side_effect = TimeoutError("network unreachable")
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0)))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.fallback_used is True
+        assert verdict.outcome is JudgeOutcome.IMPROVEMENT  # from strict rules
+        assert "llm_error" in verdict.explanation.lower()
+
+    def test_llm_error_field_triggers_fallback(self):
+        # LLM returned cleanly but with an error attached.
+        llm = _make_llm_stub(content="", error="rate_limited")
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.fallback_used is True
+        assert verdict.outcome is JudgeOutcome.NO_CHANGE
+
+    def test_invalid_outcome_in_json_falls_back(self):
+        llm = _make_llm_stub(content=(
+            '{"outcome": "maybe", "explanation": "I am uncertain"}'
+        ))
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.fallback_used is True
+
+    def test_confidence_clamped_to_unit_interval(self):
+        llm = _make_llm_stub(content=(
+            '{"outcome": "improvement", "explanation": "ok", "confidence": 3.5}'
+        ))
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 60.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 75.0)))
+        verdict = ModelJudge(llm=llm).decide(parent, variant)
+        assert verdict.confidence == 1.0
+
+
+# ---------- build_judge factory ----------
+
+
+class TestBuildJudge:
+    def test_strict(self):
+        j = build_judge("strict")
+        assert isinstance(j, StrictJudge)
+
+    def test_lexicographic(self):
+        j = build_judge(JudgeStrategy.LEXICOGRAPHIC)
+        assert isinstance(j, LexicographicJudge)
+
+    def test_model_requires_llm(self):
+        with pytest.raises(ValueError, match="llm"):
+            build_judge("model")
+
+    def test_model_with_llm(self):
+        llm = _make_llm_stub()
+        j = build_judge("model", llm=llm)
+        assert isinstance(j, ModelJudge)
+
+    def test_unknown_strategy_raises(self):
+        with pytest.raises(ValueError):
+            build_judge("definitely_not_a_strategy")
+
+
+# ---------- JudgeVerdict serialisation ----------
+
+
+class TestJudgeVerdictSerialisation:
+    def test_to_dict_round_trips_outcome(self):
+        parent = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        variant = _verdict(_dim(QualityDimension.MAINTAINABILITY,
+            _indicator("mi", IndicatorStatus.PASS, 70.0)))
+        verdict = StrictJudge().decide(parent, variant)
+        d = verdict.to_dict()
+        assert d["outcome"] == "no_change"
+        assert d["strategy"] == "strict"
+        assert d["fallback_used"] is False
+        assert "comparison" in d


### PR DESCRIPTION
…-02)

Adds qallm.judge package: models, comparator, prompts, strategies. Three strategies implement the same shape:
  - StrictJudge: any indicator regression blocks acceptance.
  - LexicographicJudge: dimensions ordered by priority; high-priority regression blocks lower-priority improvement.
  - ModelJudge: LLM-driven decision with structured JSON output and a Strict fallback on LLM error, parser failure, or response error.

Every JudgeVerdict carries the structured numerical comparison (VerdictComparison) regardless of strategy. This is the empirical anchor for the thesis-quality validation argument (workflow design v3 section 5.2): every model verdict is stored alongside the raw numerical comparison that produced it, so the analysis chapter can compare model judgements against the numbers.

Asymmetric profiles (one dimension present on only one side) are tolerated rather than crashed; missing sides become placeholder deltas with SKIPPED status. ERROR or SKIPPED indicators contribute INCOMPARABLE to deltas.

ModelJudge prompt asks for a JSON object {outcome, explanation, confidence}. Parser handles full JSON and fenced/wrapped JSON blocks.

Default Lexicographic priority is SECURITY > RELIABILITY > MAINTAINABILITY > REPRODUCIBILITY. FAIRness is omitted until NEW-04 adds the QualityDimension.FAIRNESS enum member.

The judge is not yet wired into the orchestrator loop; that is NEW-06's scope.

31 new tests across all three strategies; all 159 prior tests still pass; 190 total.

Closes NEW-02.