### PR TITLE
feat(fairness): four FAIRness indicators for EVERSE coverage (NEW-04)

### DIFF
--- a/docs/workflow-design.md
+++ b/docs/workflow-design.md
@@ -245,18 +245,44 @@ All three options are provided as configurable strategies:
 
 Comparing the three strategies empirically is itself a thesis contribution. Future work can add more.
 
-### 9.4 EVERSE coverage scope: `DECIDED`
+### 9.4 EVERSE coverage scope: `DELIVERED` (NEW-04)
 
-v1 covers five dimensions, not four: Maintainability, Security, Reliability, Reproducibility, and **FAIRness**. Nafis and Zhao explicitly requested FAIRness coverage. The FAIRness indicator(s) need to be selected; see section 11 for the implementation entry.
+v1 covers five dimensions: Maintainability, Security, Reliability, Reproducibility, and **FAIRness**. Nafis and Zhao explicitly requested FAIRness coverage. NEW-04 shipped the four FAIRness indicators below.
 
-Initial FAIRness indicators under consideration:
+```mermaid
+flowchart TD
+    P["IMPLEMENTATION_DEFAULT<br/>profile (5 dimensions)"] --> EE["evaluate_profile()"]
+    CTX["Evaluation context:<br/>project_root, source,<br/>include_private?"] --> EE
+    EE --> FN{Resolve evaluator id}
+    FN -->|qallm.fairness.licence| L["_fairness_licence<br/>(scans project_root)"]
+    FN -->|qallm.fairness.citation| C["_fairness_citation<br/>(scans project_root)"]
+    FN -->|qallm.fairness.readme| R["_fairness_readme<br/>(reads README body)"]
+    FN -->|qallm.fairness.docstring_coverage| D["_fairness_docstring_coverage<br/>(walks source AST)"]
+    L --> O["IndicatorResult (pass / fail / skipped)"]
+    C --> O
+    R --> O
+    D --> O
+    O --> V["DimensionResult: FAIRness"]
+```
 
-* Presence of a license file in the project root.
-* Presence of a citation file (CITATION.cff, CITATION.bib).
-* Presence of a README with required sections (description, install, usage).
-* Documented function signatures (docstring coverage above a threshold).
+The four indicators in the FAIRness dimension:
 
-These are all detectable with simple file or AST checks; they do not require LLM calls. Final indicator set to be confirmed before implementation.
+| Indicator              | Data source        | Threshold | Comparator | Notes                                                                                          |
+|------------------------|--------------------|-----------|------------|------------------------------------------------------------------------------------------------|
+| `has_licence`          | `project_root`     | 1.0       | GE         | Accepts LICENSE, LICENCE, COPYING, LICENSE.md, etc. (case-insensitive)                         |
+| `has_citation`         | `project_root`     | 1.0       | GE         | Accepts CITATION.cff or CITATION.bib (case-insensitive)                                        |
+| `has_readme`           | `project_root`     | 1.0       | GE         | Three checks: presence, body >= 200 chars, all required sections (description, install, usage) |
+| `docstring_coverage`   | `source` + AST     | 0.5       | GE         | Public symbols by default; `context['include_private'] = True` widens the count                |
+
+#### Required README sections
+
+The README indicator encodes a methodological opinion: a FAIR research-software README must explain *what* the software does, *how* to install it, and *how* to use it. Each required section accepts a set of synonyms so different but reasonable README structures are not penalised:
+
+* Description: `description`, `about`, `overview`, `introduction`
+* Installation: `install`, `installation`, `setup`, `getting started`
+* Usage: `usage`, `use`, `example`, `examples`, `how to use`
+
+The threshold (200 characters of body, all three section keywords present) is documented as a working definition; it is conservative enough to pass typical research-software READMEs and strict enough to fail empty stubs. Future work may refine this with corpus-grounded thresholds.
 
 ### 9.5 Validation experiment: `DECIDED`
 
@@ -318,7 +344,7 @@ For implementation, the workflow maps onto the modules already in place, plus th
 | Verification (RL loop)     | `qallm.verification`                                                  | Working.                          |
 | Test suite persistence     | `qallm.verification.test_persistence`                                 | Built (PR feature/test-stability). 250 lines plus 22 tests. Section 4.5. |
 | Profile evaluation         | `qallm.profiles` + `qallm.evaluation`                                 | Working; reliability indicators wired in NEW-03. Framework-agnostic by design. |
-| FAIRness indicators        | New: extend `qallm.evaluation` with `qallm.fairness` evaluators       | To build. ~100 lines. Section 9.4. |
+| FAIRness indicators        | `qallm.fairness` module + four evaluators in `qallm.evaluation`       | Built (NEW-04). 40 tests, four indicators across project root and source AST. |
 | Judge                      | `qallm.judge` package: models, comparator, prompts, strategies        | Built (NEW-02). 31 tests.         |
 | Improvement strategies     | `qallm.judge.strategies`: StrictJudge, LexicographicJudge, ModelJudge | Built (NEW-02). Model has Strict fallback on LLM error. |
 | Cost estimation            | `qallm.cost` (price table reused from `qallm.llm.base.MODEL_RATES`)   | Built (NEW-05). 220 lines, 20 tests. |
@@ -335,7 +361,7 @@ All design questions are resolved. The implementation roadmap below is the basis
 1. ~~Extend verification for test-suite persistence per section 4.5.~~ **Done.** Two-axis configurable strategy (`test_stability` x `generation_policy`) with three meaningful modes. New `qallm.verification.test_persistence` module, 250 lines plus 22 tests. CLI flags `--test-stability` and `--generation-policy`. `summary.json` records the mode. Section 4.5.
 2. ~~Build the judge module (`qallm.judge`) with the three improvement strategies.~~ **Done.** New `qallm.judge` package: `models.py`, `comparator.py`, `prompts.py`, `strategies.py`. Three strategies (Strict, Lexicographic, Model). ModelJudge falls back to Strict on LLM error, parse failure, or `error` field on response. Every JudgeVerdict stores both the structured numerical comparison and (for Model) the LLM's free-text reasoning. 31 tests. FAIRness is omitted from the default Lexicographic priority until NEW-04 ships.
 3. ~~Wire reliability indicators in `qallm.evaluation` to actual verification output.~~ **Done.** Both `qallm.verification.pass_rate` and `qallm.verification.bugs` now read `context["verification_sessions"]: list[TestGenerationSession]`. Added a `final_pass_rate` property on the session model. 12 new tests; all 126 prior tests still pass.
-4. Add FAIRness indicators (`qallm.fairness`): licence, citation, README, docstrings. 100 lines plus tests.
+4. ~~Add FAIRness indicators (`qallm.fairness`): licence, citation, README, docstrings.~~ **Done.** New module `qallm.fairness` with four evaluators registered in `qallm.evaluation`. `QualityDimension.FAIRNESS` added to the enum. `IMPLEMENTATION_DEFAULT` profile extended to five dimensions. Default Lexicographic priority updated to include FAIRness at the end. The README indicator uses section validation with synonyms (description / installation / usage); the docstring-coverage indicator counts public symbols by default and is configurable via context. 40 new tests; 230 total.
 5. ~~Add budget enforcement in the orchestrator: rounds, tokens, time, cost.~~ **Done.** Five caps with ceilings (rounds 5/10, tokens 500k/2M, seconds 1800/3600, round-seconds 600/1200, cost $5/$25). Reuses the existing `MODEL_RATES` table in `qallm.llm.base`. New module `qallm.cost` with `BudgetCaps`, `BudgetState`, and `HaltReason`. CLI flags `--max-tokens`, `--max-seconds`, `--max-round-seconds`, `--max-cost-usd`. Halt reason recorded in `summary.json`. 20 new tests, 159 tests total.
 6. Extend the orchestrator loop per section 3. 100 lines.
 7. Extend the reporter with lineage, abandoned-variant logging, canonical `summary.json`, and the markdown/HTML views (section 10). 100 lines.

--- a/src/qallm/evaluation.py
+++ b/src/qallm/evaluation.py
@@ -374,6 +374,20 @@ def _register_builtins() -> None:
     register("qallm.repro.determinism", _repro_determinism)
     register("qallm.verification.pass_rate", _verification_pass_rate)
     register("qallm.verification.bugs", _verification_bugs)
+    # FAIRness indicators live in qallm.fairness; imported here to keep
+    # the indicator module thin and avoid a circular import.
+    from qallm.fairness import (
+        _fairness_citation,
+        _fairness_docstring_coverage,
+        _fairness_licence,
+        _fairness_readme,
+    )
+    register("qallm.fairness.licence", _fairness_licence)
+    # American spelling is the same evaluator; profiles in either dialect work.
+    register("qallm.fairness.license", _fairness_licence)
+    register("qallm.fairness.citation", _fairness_citation)
+    register("qallm.fairness.readme", _fairness_readme)
+    register("qallm.fairness.docstring_coverage", _fairness_docstring_coverage)
 
 
 _register_builtins()

--- a/src/qallm/fairness.py
+++ b/src/qallm/fairness.py
@@ -1,0 +1,247 @@
+"""FAIRness indicators for QALLM.
+
+Implements workflow design v3 section 9.4: four project-level indicators that
+together approximate the FAIR4RS principles' core "findable and reusable"
+criteria for research software. Three indicators check for required project
+artefacts (licence, citation file, README); one is code-shaped (docstring
+coverage).
+
+These indicators are intentionally small and falsifiable. They are NOT a
+comprehensive FAIR assessment: that requires manual evaluation by a human
+familiar with the project's domain. They ARE a useful, cheap, automatable
+signal that the project author has paid the basic price of admission for
+sharing research software.
+
+Pipeline
+--------
+
+.. code-block:: text
+
+    Profile evaluation
+           |
+           v
+    ┌──────────────────────────────────────────────────────┐
+    │  qallm.evaluation.evaluate_profile(profile, source,  │
+    │                                    context)          │
+    └──────────────────────────────────────────────────────┘
+           |
+           |  resolves four evaluator IDs to functions in this module
+           v
+    ┌──────────────────────────────────────────────────────┐
+    │  qallm.fairness.licence       (reads project_root)   │
+    │  qallm.fairness.citation      (reads project_root)   │
+    │  qallm.fairness.readme        (reads project_root)   │
+    │  qallm.fairness.docstring_coverage  (reads source)   │
+    └──────────────────────────────────────────────────────┘
+           |
+           v
+       Each returns float | None
+           |
+           v
+       IndicatorResult: pass / fail / skipped per threshold
+
+
+Indicator semantics
+-------------------
+
+``licence``
+    1.0 if a recognised licence file exists at the project root; 0.0
+    otherwise. SKIPPED if no ``project_root`` in context.
+
+``citation``
+    1.0 if a CITATION.cff or CITATION.bib (or lowercase variants) exists;
+    0.0 otherwise. SKIPPED if no ``project_root``.
+
+``readme``
+    1.0 if a README file exists, has at least 200 characters of body, AND
+    contains all required section keywords (description, installation,
+    usage). 0.0 if README exists but fails any check. SKIPPED if no
+    ``project_root``.
+
+``docstring_coverage``
+    Fraction of functions/methods/classes in ``source`` that have a
+    non-empty docstring. Defaults to counting only public symbols (no
+    leading underscore); set ``context['include_private'] = True`` to
+    count private ones too. Returns None (SKIPPED) if the source contains
+    no definitions to count.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+from pathlib import Path
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+# ---------- file-presence helpers ----------
+
+# All candidate filenames are matched case-insensitively against the directory
+# listing. Different projects use different conventions; we honour them all.
+
+LICENCE_NAMES = (
+    "LICENSE",
+    "LICENCE",
+    "LICENSE.txt",
+    "LICENCE.txt",
+    "LICENSE.md",
+    "LICENCE.md",
+    "COPYING",
+    "COPYING.txt",
+)
+
+CITATION_NAMES = (
+    "CITATION.cff",
+    "CITATION.bib",
+)
+
+README_NAMES = (
+    "README.md",
+    "README.rst",
+    "README.txt",
+    "README",
+)
+
+# Required sections in a "FAIR" README. Each tuple is a set of accepted
+# synonyms; matching any one counts as the section present.
+README_REQUIRED_SECTIONS: tuple[tuple[str, ...], ...] = (
+    ("description", "about", "overview", "introduction"),
+    ("install", "installation", "setup", "getting started"),
+    ("usage", "use", "example", "examples", "how to use"),
+)
+
+README_MIN_BODY_CHARS = 200
+
+
+def _find_case_insensitive(root: Path, candidates: tuple[str, ...]) -> Path | None:
+    """Return the first existing file under ``root`` whose name matches any
+    candidate (case-insensitive). Returns ``None`` if no match exists.
+    """
+    try:
+        entries = {p.name.lower(): p for p in root.iterdir() if p.is_file()}
+    except (OSError, PermissionError):
+        return None
+    for name in candidates:
+        match = entries.get(name.lower())
+        if match is not None:
+            return match
+    return None
+
+
+# ---------- evaluators ----------
+
+
+def _fairness_licence(source: str, context: dict[str, Any]) -> float | None:
+    """1.0 if any recognised licence file is present at the project root.
+
+    Names accepted (case-insensitive): LICENSE, LICENCE, LICENSE.txt,
+    LICENCE.txt, LICENSE.md, LICENCE.md, COPYING, COPYING.txt.
+
+    SKIPPED if no ``project_root`` in context, mirroring the
+    ``qallm.repro.manifest`` pattern.
+    """
+    root = context.get("project_root")
+    if root is None:
+        return None
+    root_path = Path(root)
+    if not root_path.exists() or not root_path.is_dir():
+        return None
+    return 1.0 if _find_case_insensitive(root_path, LICENCE_NAMES) else 0.0
+
+
+def _fairness_citation(source: str, context: dict[str, Any]) -> float | None:
+    """1.0 if CITATION.cff or CITATION.bib (case-insensitive) is present."""
+    root = context.get("project_root")
+    if root is None:
+        return None
+    root_path = Path(root)
+    if not root_path.exists() or not root_path.is_dir():
+        return None
+    return 1.0 if _find_case_insensitive(root_path, CITATION_NAMES) else 0.0
+
+
+def _fairness_readme(source: str, context: dict[str, Any]) -> float | None:
+    """1.0 if a README is present, non-trivial, and has required sections.
+
+    Three checks, all must pass:
+
+      1. A README.* file exists at the project root.
+      2. Its body is at least ``README_MIN_BODY_CHARS`` characters.
+      3. It mentions each of the three required sections (matching any of
+         the accepted synonyms in each group, case-insensitive).
+
+    The synonyms are deliberately permissive so this indicator does not
+    penalise different but reasonable README structures. The required
+    structure ("description / install / usage") is itself a methodological
+    opinion; it is documented in the thesis as a working definition of a
+    minimally FAIR research-software README.
+    """
+    root = context.get("project_root")
+    if root is None:
+        return None
+    root_path = Path(root)
+    if not root_path.exists() or not root_path.is_dir():
+        return None
+
+    readme_path = _find_case_insensitive(root_path, README_NAMES)
+    if readme_path is None:
+        return 0.0
+
+    try:
+        body = readme_path.read_text(encoding="utf-8", errors="replace")
+    except OSError:
+        return 0.0
+
+    if len(body.strip()) < README_MIN_BODY_CHARS:
+        return 0.0
+
+    lower = body.lower()
+    for section_synonyms in README_REQUIRED_SECTIONS:
+        if not any(syn in lower for syn in section_synonyms):
+            return 0.0
+
+    return 1.0
+
+
+def _fairness_docstring_coverage(
+    source: str, context: dict[str, Any]
+) -> float | None:
+    """Fraction of definitions (functions/classes/methods) that have a docstring.
+
+    Walks the source's AST and counts every ``FunctionDef``,
+    ``AsyncFunctionDef``, and ``ClassDef`` node. Returns
+    ``documented / total`` as a float in [0, 1].
+
+    By default counts only public symbols (those whose names do not start
+    with an underscore). Set ``context['include_private'] = True`` to count
+    private ones as well.
+
+    SKIPPED in two cases:
+      * The source cannot be parsed (syntax error). We do not want a bad
+        snippet to be counted as 0% documented; that is misleading.
+      * The source contains zero countable definitions. Coverage is then
+        undefined and we report SKIPPED rather than a placeholder.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return None
+
+    include_private = bool(context.get("include_private", False))
+
+    total = 0
+    documented = 0
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if not include_private and node.name.startswith("_"):
+            continue
+        total += 1
+        if ast.get_docstring(node):
+            documented += 1
+
+    if total == 0:
+        return None
+    return documented / total

--- a/src/qallm/judge/strategies.py
+++ b/src/qallm/judge/strategies.py
@@ -44,14 +44,17 @@ logger = logging.getLogger(__name__)
 
 # Higher priority first. Workflow design v3 section 9.3.
 #
-# v1 priority covers the four EVERSE dimensions currently implemented.
-# FAIRness will be added by NEW-04; it slots in at the end (lowest priority)
-# without changing the order of the others.
+# Priority order rationale: Security issues block release entirely;
+# Reliability is the next-most-binding (a feature that doesn't work is
+# not really a feature); Maintainability and Reproducibility are
+# important for sustainability but not blocking; FAIRness is documentation
+# hygiene that should not override engineering quality concerns.
 DEFAULT_DIMENSION_PRIORITY: tuple[QualityDimension, ...] = (
     QualityDimension.SECURITY,
     QualityDimension.RELIABILITY,
     QualityDimension.MAINTAINABILITY,
     QualityDimension.REPRODUCIBILITY,
+    QualityDimension.FAIRNESS,
 )
 
 

--- a/src/qallm/profiles.py
+++ b/src/qallm/profiles.py
@@ -32,15 +32,17 @@ from typing import Any
 class QualityDimension(str, Enum):
     """The EVERSE quality dimensions QALLM measures automatically in v1.
 
-    The full EVERSE catalogue is broader (FAIRness, Usability, Performance,
-    Compatibility, etc.). These four are the ones QALLM has tooling for:
-    static metrics for the first two, execution evidence for the others.
+    The full EVERSE catalogue is broader (Usability, Performance,
+    Compatibility, etc.). These five are the ones QALLM has tooling for:
+    static metrics for Maintainability and Security, execution evidence
+    for Reliability, project-shape checks for Reproducibility and FAIRness.
     """
 
     MAINTAINABILITY = "Maintainability"
     SECURITY = "Security"
     RELIABILITY = "Reliability"
     REPRODUCIBILITY = "Reproducibility"
+    FAIRNESS = "FAIRness"
 
 
 class LifecycleStage(str, Enum):
@@ -264,6 +266,54 @@ IMPLEMENTATION_DEFAULT: QualityProfile = QualityProfile(
                     description=(
                         "1 if repeated runs in the sandbox produce identical "
                         "test telemetry, 0 otherwise."
+                    ),
+                ),
+            ),
+        ),
+        DimensionSpec(
+            dimension=QualityDimension.FAIRNESS,
+            repair_prompt_id="fairness_repair_v1",
+            indicators=(
+                QualityIndicator(
+                    name="has_licence",
+                    evaluator="qallm.fairness.licence",
+                    threshold=1.0,
+                    comparator=Comparator.GE,
+                    description=(
+                        "1 if a recognised licence file (LICENSE, LICENCE, "
+                        "COPYING, etc.) is present at the project root, "
+                        "0 otherwise."
+                    ),
+                ),
+                QualityIndicator(
+                    name="has_citation",
+                    evaluator="qallm.fairness.citation",
+                    threshold=1.0,
+                    comparator=Comparator.GE,
+                    description=(
+                        "1 if CITATION.cff or CITATION.bib is present at "
+                        "the project root, 0 otherwise."
+                    ),
+                ),
+                QualityIndicator(
+                    name="has_readme",
+                    evaluator="qallm.fairness.readme",
+                    threshold=1.0,
+                    comparator=Comparator.GE,
+                    description=(
+                        "1 if a non-trivial README (>= 200 chars) exists "
+                        "and contains description, installation, and usage "
+                        "sections; 0 otherwise."
+                    ),
+                ),
+                QualityIndicator(
+                    name="docstring_coverage",
+                    evaluator="qallm.fairness.docstring_coverage",
+                    threshold=0.5,
+                    comparator=Comparator.GE,
+                    description=(
+                        "Fraction of public functions, methods, and classes "
+                        "with a non-empty docstring. Threshold 0.5."
                     ),
                 ),
             ),

--- a/tests/test_evaluation.py
+++ b/tests/test_evaluation.py
@@ -620,13 +620,14 @@ def test_evaluate_default_profile_on_real_source_does_not_crash(
         simple_clean_source,
         context={"project_root": str(temp_project_with_manifest)},
     )
-    # All four EVERSE dimensions appear in the verdict.
+    # All five EVERSE dimensions appear in the verdict.
     dims = {d.dimension for d in verdict.dimensions}
     assert dims == {
         QualityDimension.MAINTAINABILITY,
         QualityDimension.SECURITY,
         QualityDimension.RELIABILITY,
         QualityDimension.REPRODUCIBILITY,
+        QualityDimension.FAIRNESS,
     }
     # Reliability is fully deferred in v1, so its dimension status is SKIPPED.
     rel = verdict.get_dimension(QualityDimension.RELIABILITY)

--- a/tests/test_fairness.py
+++ b/tests/test_fairness.py
@@ -1,0 +1,269 @@
+"""Tests for qallm.fairness.
+
+Coverage:
+
+  * `_fairness_licence`: presence detection, case-insensitivity, every
+    accepted filename variant.
+  * `_fairness_citation`: presence detection for .cff and .bib.
+  * `_fairness_readme`: presence, minimum length, required sections,
+    synonym matching, failure modes.
+  * `_fairness_docstring_coverage`: AST parsing, public vs private,
+    edge cases (empty source, syntax error, zero definitions).
+  * Integration via the evaluator registry: indicators resolvable by id.
+
+These tests are pure-Python; no LLM, no subprocess. Uses pytest's tmp_path
+fixture to materialise fake project trees.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from qallm.evaluation import resolve
+from qallm.fairness import (
+    LICENCE_NAMES,
+    README_MIN_BODY_CHARS,
+    _fairness_citation,
+    _fairness_docstring_coverage,
+    _fairness_licence,
+    _fairness_readme,
+)
+
+
+# ---------- helpers ----------
+
+
+def _readme_body(*sections: str) -> str:
+    """Build a README body containing the listed section headings.
+
+    Always includes enough filler text to exceed the minimum length.
+    """
+    body = "# Project\n\n" + ("Some descriptive prose. " * 20) + "\n\n"
+    for s in sections:
+        body += f"## {s}\n\nContent for {s}.\n\n"
+    return body
+
+
+# ---------- licence ----------
+
+
+class TestLicenceIndicator:
+    def test_skipped_when_no_project_root(self):
+        assert _fairness_licence("", {}) is None
+
+    def test_skipped_when_project_root_does_not_exist(self):
+        assert _fairness_licence("", {"project_root": "/no/such/path"}) is None
+
+    def test_zero_when_root_has_no_licence(self, tmp_path: Path):
+        # Empty directory; no licence files of any kind.
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_one_when_root_has_LICENSE(self, tmp_path: Path):
+        (tmp_path / "LICENSE").write_text("MIT")
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_root_has_lowercase_license(self, tmp_path: Path):
+        (tmp_path / "license").write_text("Apache-2.0")
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_root_has_LICENCE_british_spelling(self, tmp_path: Path):
+        (tmp_path / "LICENCE").write_text("MIT")
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_root_has_COPYING(self, tmp_path: Path):
+        (tmp_path / "COPYING").write_text("GPL-3.0")
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_root_has_LICENSE_md_with_extension(self, tmp_path: Path):
+        (tmp_path / "LICENSE.md").write_text("Permission is hereby granted...")
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_directory_named_LICENSE_does_not_count(self, tmp_path: Path):
+        # A directory with that name doesn't satisfy the indicator.
+        (tmp_path / "LICENSE").mkdir()
+        assert _fairness_licence("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_all_accepted_names_each_pass(self, tmp_path: Path):
+        # Exercise every name in the accepted list.
+        for i, name in enumerate(LICENCE_NAMES):
+            sub = tmp_path / f"proj_{i}"
+            sub.mkdir()
+            (sub / name).write_text("text")
+            assert _fairness_licence("", {"project_root": str(sub)}) == 1.0
+
+
+# ---------- citation ----------
+
+
+class TestCitationIndicator:
+    def test_skipped_when_no_project_root(self):
+        assert _fairness_citation("", {}) is None
+
+    def test_zero_when_no_citation_file(self, tmp_path: Path):
+        assert _fairness_citation("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_one_when_CITATION_cff_present(self, tmp_path: Path):
+        (tmp_path / "CITATION.cff").write_text(
+            "cff-version: 1.2.0\ntitle: Example\n"
+        )
+        assert _fairness_citation("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_CITATION_bib_present(self, tmp_path: Path):
+        (tmp_path / "CITATION.bib").write_text("@misc{ex, title={Example}}")
+        assert _fairness_citation("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_one_when_lowercase_citation_cff(self, tmp_path: Path):
+        (tmp_path / "citation.cff").write_text("cff-version: 1.2.0")
+        assert _fairness_citation("", {"project_root": str(tmp_path)}) == 1.0
+
+
+# ---------- readme ----------
+
+
+class TestReadmeIndicator:
+    def test_skipped_when_no_project_root(self):
+        assert _fairness_readme("", {}) is None
+
+    def test_zero_when_no_readme(self, tmp_path: Path):
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_zero_when_readme_too_short(self, tmp_path: Path):
+        (tmp_path / "README.md").write_text("Tiny.")
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_zero_when_missing_required_section(self, tmp_path: Path):
+        # Has description and usage but not install. Long enough.
+        body = _readme_body("Description", "Usage")  # no install
+        (tmp_path / "README.md").write_text(body)
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 0.0
+
+    def test_one_when_all_required_sections_present(self, tmp_path: Path):
+        body = _readme_body("Description", "Installation", "Usage")
+        (tmp_path / "README.md").write_text(body)
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_synonyms_accepted(self, tmp_path: Path):
+        # "About" stands in for description; "Setup" for installation;
+        # "Example" for usage.
+        body = _readme_body("About", "Setup", "Example")
+        (tmp_path / "README.md").write_text(body)
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_case_insensitive_section_matching(self, tmp_path: Path):
+        body = (
+            "# Project\n\n" + ("Long enough body text. " * 20) + "\n\n"
+            "## DESCRIPTION\n\ntext\n\n"
+            "## installation\n\ntext\n\n"
+            "## Usage\n\ntext\n\n"
+        )
+        (tmp_path / "README.md").write_text(body)
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_readme_without_extension_accepted(self, tmp_path: Path):
+        body = _readme_body("Description", "Installation", "Usage")
+        (tmp_path / "README").write_text(body)
+        assert _fairness_readme("", {"project_root": str(tmp_path)}) == 1.0
+
+    def test_min_body_chars_threshold_is_a_constant(self):
+        # Surface this as an explicit assertion so the methodology
+        # chapter has a stable reference: 200 chars minimum.
+        assert README_MIN_BODY_CHARS == 200
+
+
+# ---------- docstring coverage ----------
+
+
+class TestDocstringCoverage:
+    def test_skipped_on_empty_source(self):
+        assert _fairness_docstring_coverage("", {}) is None
+
+    def test_skipped_on_source_without_definitions(self):
+        src = "x = 1\ny = 2\nprint(x + y)\n"
+        assert _fairness_docstring_coverage(src, {}) is None
+
+    def test_skipped_on_syntax_error(self):
+        # An evaluator must not penalise broken syntax as 0% documented.
+        src = "def f(:\n    pass\n"
+        assert _fairness_docstring_coverage(src, {}) is None
+
+    def test_all_documented_returns_one(self):
+        src = (
+            'def a():\n    """A."""\n    pass\n\n'
+            'def b():\n    """B."""\n    pass\n'
+        )
+        assert _fairness_docstring_coverage(src, {}) == 1.0
+
+    def test_none_documented_returns_zero(self):
+        src = "def a():\n    pass\n\ndef b():\n    pass\n"
+        assert _fairness_docstring_coverage(src, {}) == 0.0
+
+    def test_half_documented_returns_half(self):
+        src = (
+            'def a():\n    """A."""\n    pass\n\n'
+            "def b():\n    pass\n"
+        )
+        assert _fairness_docstring_coverage(src, {}) == 0.5
+
+    def test_default_excludes_private_functions(self):
+        # _private has no docstring; public has one. Default mode counts
+        # only public => 1/1 = 1.0.
+        src = (
+            'def public():\n    """Yes."""\n    pass\n\n'
+            "def _private():\n    pass\n"
+        )
+        assert _fairness_docstring_coverage(src, {}) == 1.0
+
+    def test_include_private_changes_count(self):
+        src = (
+            'def public():\n    """Yes."""\n    pass\n\n'
+            "def _private():\n    pass\n"
+        )
+        # Now 1/2 = 0.5.
+        assert (
+            _fairness_docstring_coverage(src, {"include_private": True})
+            == 0.5
+        )
+
+    def test_classes_and_methods_are_counted(self):
+        src = (
+            'class Foo:\n    """A class."""\n'
+            '    def bar(self):\n        """A method."""\n        return 1\n\n'
+            "    def baz(self):\n        return 2\n"
+        )
+        # 2/3 documented (Foo and bar yes, baz no).
+        assert _fairness_docstring_coverage(src, {}) == pytest.approx(2 / 3)
+
+    def test_async_functions_are_counted(self):
+        src = (
+            'async def fetch():\n    """Fetches."""\n    pass\n\n'
+            "async def parse():\n    pass\n"
+        )
+        assert _fairness_docstring_coverage(src, {}) == 0.5
+
+
+# ---------- registry integration ----------
+
+
+class TestEvaluatorRegistration:
+    """Confirm the four indicators are reachable through the registry."""
+
+    @pytest.mark.parametrize(
+        "evaluator_id",
+        [
+            "qallm.fairness.licence",
+            "qallm.fairness.license",  # American spelling alias
+            "qallm.fairness.citation",
+            "qallm.fairness.readme",
+            "qallm.fairness.docstring_coverage",
+        ],
+    )
+    def test_evaluator_resolvable(self, evaluator_id: str):
+        fn = resolve(evaluator_id)
+        assert callable(fn)
+
+    def test_licence_aliases_point_at_same_function(self):
+        british = resolve("qallm.fairness.licence")
+        american = resolve("qallm.fairness.license")
+        assert british is american

--- a/tests/test_profiles.py
+++ b/tests/test_profiles.py
@@ -35,12 +35,13 @@ from qallm.profiles import (
 # ---------------------------------------------------------------------------
 
 
-def test_default_profile_covers_the_four_v1_dimensions():
+def test_default_profile_covers_the_v1_dimensions():
     expected = {
         QualityDimension.MAINTAINABILITY,
         QualityDimension.SECURITY,
         QualityDimension.RELIABILITY,
         QualityDimension.REPRODUCIBILITY,
+        QualityDimension.FAIRNESS,
     }
     actual = {spec.dimension for spec in IMPLEMENTATION_DEFAULT.dimensions}
     assert actual == expected
@@ -161,6 +162,7 @@ def test_profile_roundtrips_through_json():
         "Security",
         "Reliability",
         "Reproducibility",
+        "FAIRness",
     }
 
 


### PR DESCRIPTION
Adds qallm.fairness with four project- and code-level evaluators:
  - has_licence: scans project_root for LICENSE / LICENCE / COPYING etc.
  - has_citation: scans for CITATION.cff or CITATION.bib
  - has_readme: presence + body >= 200 chars + required sections (description / installation / usage, with synonym matching)
  - docstring_coverage: AST-walk of source, public symbols by default, configurable via context['include_private'] = True

QualityDimension.FAIRNESS added; IMPLEMENTATION_DEFAULT profile extended to five dimensions; default Lexicographic priority extended with FAIRness at the lowest position.

The README indicator's required-sections rubric (description/installation/ usage with synonym sets) is the methodological opinion of v1; documented in docs/workflow-design.md section 9.4 with a Mermaid diagram of the evaluation pipeline. The 200-character body threshold is a working definition; future work may refine with corpus-grounded values.

Licence evaluator is registered under both British (qallm.fairness.licence) and American (qallm.fairness.license) spellings; same function.

40 new tests; 3 existing tests updated for the five-dimension default; 0 broken; 230 total.

Closes NEW-04.