### PR TITLE
Architecture convergence: one loop, honest UI, deduplicated quality model

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,10 @@
-# QALLM: Execution-Based Quality Assessment for Research Software
+# QALLM: LLM-Driven Quality Improvement for Research Software
 
-QALLM is a research instrument that audits Python notebooks and scripts along the dimensions of the [EVERSE Research Software Quality framework](https://everse.software/RSQKit/quality_dimensions). Where static tools in the [EVERSE TechRadar](https://everse.software/TechRadar/) can confirm style, complexity, and known security smells, they cannot decide whether a function is actually correct at runtime. QALLM closes that gap. For each function under study, an LLM-driven reinforcement loop generates tests, runs them in a sandbox, and uses pass/fail feedback to refine the next round. The product is an evidence-backed quality report grounded in the EVERSE dimensions.
+QALLM is a research instrument that measures *and improves* the quality of Python notebooks and scripts against a preset quality standard. It runs a bounded, budget-capped loop: establish a baseline against a selected quality model (the default is an [EVERSE Research Software Quality framework](https://everse.software/RSQKit/quality_dimensions) profile), then repair the code with an LLM and re-verify, round after round, with a judge accepting or abandoning each variant. The product is a lineage of accepted improvements plus an evidence-backed quality report.
+
+Static tools in the [EVERSE TechRadar](https://everse.software/TechRadar/) can confirm style, complexity, and known security smells, but they cannot decide whether a function is actually correct at runtime, nor can they improve it. QALLM closes both gaps. Execution-based verification (the LLM generates tests, runs them in a sandbox, and uses pass/fail feedback) answers the correctness question and supplies the signal the repair loop optimises against.
+
+In one line: **baseline (round 0) → repair → re-verify → judge → accept or abandon, repeated under a budget, against a quality model you choose.** The LLM acts in two roles, test generator and code repairer; it is used through its API with quantitative feedback, not trained.
 
 QALLM is developed as a master thesis at the University of Amsterdam (MNS group, Dr. Zhiming Zhao; daily supervision by Dr. Nafis Tanveer Islam) in alignment with the EVERSE programme and the role and lifecycle aware quality framework introduced by Volentir et al. (QRS 2025).
 
@@ -21,18 +25,19 @@ flowchart LR
     Decision -->|With QALLM| Evidence[Answered with<br/>runtime evidence]
 ```
 
-Pilot results across 31 functions, 5 files, and three models (gpt-4o-mini, gpt-5-mini, gemma3:4b) showed a 91.3 percent false confidence rate when relying on static signals alone: code that passed every static check but contained a logic bug surfaced by the verification loop. The RL strategy found significantly more bugs than the one-shot and Hypothesis baselines (all pairwise Wilcoxon tests at p < 0.005).
+Pilot results across 31 functions, 5 files, and three models (gpt-4o-mini, gpt-5-mini, gemma3:4b) showed a 91.3 percent false confidence rate when relying on static signals alone: code that passed every static check but contained a logic bug surfaced only once it was executed. That finding motivates execution-based verification inside the loop. The verification-strategy ablation supports the design choice: the iterative-feedback verifier found significantly more bugs than the one-shot and Hypothesis baselines (all pairwise Wilcoxon tests at p < 0.005).
 
 ## EVERSE alignment
 
-QALLM treats the four EVERSE dimensions below as first-class. The remaining dimensions (FAIRness, Usability, Performance Efficiency, Compatibility) are discussed in the thesis but not implemented as automated indicators in v1.
+QALLM evaluates the five EVERSE dimensions below through the default `IMPLEMENTATION_DEFAULT` profile. The remaining dimensions (Usability, Performance Efficiency, Compatibility) are discussed in the thesis but not yet implemented as automated indicators.
 
 | EVERSE dimension       | QALLM indicator                                 | Source of evidence                       |
 | ---------------------- | ----------------------------------------------- | ---------------------------------------- |
 | Maintainability        | Maintainability Index, Cyclomatic Complexity    | Radon                                    |
-| Security               | Static security findings                        | Bandit                                   |
-| Reliability            | Test pass rate, bugs caught, coverage delta     | QALLM verification loop (LLM + sandbox)  |
+| Security               | High-severity static findings                   | Bandit                                   |
+| Reliability            | Test pass rate, bugs caught                      | QALLM verification loop (LLM + sandbox)  |
 | Reproducibility        | Environment manifest, deterministic execution   | QALLM sandbox + manifest probe           |
+| FAIRness               | Licence, citation, README, docstring coverage   | Project-shape probes (`qallm.fairness`)  |
 
 The mapping is materialised in [`src/qallm/profiles.py`](src/qallm/profiles.py) as a `QualityProfile` selecting indicators per dimension for a given lifecycle stage (initialization, implementation, publication, as defined by the EOSC software lifecycle).
 
@@ -57,10 +62,10 @@ flowchart TD
         Units --> Strategy{Strategy}
         Strategy -->|hypothesis| Hyp[Property-based<br/>baseline]
         Strategy -->|oneshot| One[LLM, 1 round]
-        Strategy -->|rl| RL[LLM, N rounds<br/>with feedback]
+        Strategy -->|feedback| FB[LLM, N rounds<br/>with execution feedback]
         Hyp --> Sessions[Verification sessions]
         One --> Sessions
-        RL --> Sessions
+        FB --> Sessions
     end
 
     subgraph S4["Stage 4: Quality Reporting"]
@@ -72,9 +77,9 @@ flowchart TD
 
 Stages map 1:1 to the package layout: [`qallm.ingestion`](src/qallm/ingestion), [`qallm.analysis`](src/qallm/analysis), [`qallm.verification`](src/qallm/verification), [`qallm.utils`](src/qallm/utils), with [`qallm.orchestrator`](src/qallm/orchestrator.py) as the conductor and [`qallm.profiles`](src/qallm/profiles.py) holding the EVERSE mapping.
 
-## The RL verification loop
+## Verification inside the loop
 
-The verification loop is the contribution that closes the gap. For each function, the loop generates tests, runs them in a sandbox, scores the round, and feeds the failure signal back into the next prompt until the budget is exhausted or coverage and bug-finding stabilise.
+The improvement loop is the contribution (see the pipeline below). Verification is the stage inside each round that decides whether a repair actually helped: for each function it generates tests, runs them in a sandbox, scores the round, and feeds the failure signal back into the next prompt until the budget is exhausted or bug-finding stabilises. That signal is what the repair step optimises against, so the quality of verification bounds the quality of the whole loop.
 
 ```mermaid
 sequenceDiagram
@@ -87,8 +92,8 @@ sequenceDiagram
 
     Orch->>Gen: function source + prompt for round n
     Gen-->>Orch: candidate test module
-    Orch->>Box: stage source + test module
-    Box->>Exec: pytest --cov, timeout-bounded
+    Orch->>Sandbox: stage source + test module
+    Sandbox->>Exec: pytest --cov, timeout-bounded
     Exec-->>Orch: pass or fail, coverage, traceback
     Orch->>Reward: round result + history
     Reward-->>Orch: score, feedback for round n+1
@@ -99,13 +104,15 @@ sequenceDiagram
     end
 ```
 
-Three strategies share this skeleton:
+### Verification strategy: an ablation, not a competing pipeline
 
-* **`hypothesis`**: property-based baseline, no LLM. Used as the reference floor in the empirical comparison.
-* **`oneshot`**: LLM, exactly one round, no feedback. Used as the ablation between zero-feedback and full RL.
-* **`rl`**: LLM, N rounds with feedback (default N = 5). The proposed method.
+A design question sits inside this stage: is the iterative-feedback test generator worth its cost, compared with cheaper alternatives? To answer it empirically, the verification stage can run in one of three strategies, all writing the same session schema so the comparison stays routine (Wilcoxon signed-rank, Cliff's delta):
 
-Strategy is a single CLI flag (`--strategy hypothesis|oneshot|rl`). All three write the same session schema, which keeps the statistical comparison (Wilcoxon signed-rank, Cliff's delta) routine.
+* **`hypothesis`**: property-based generation, no LLM. The reference floor.
+* **`oneshot`**: LLM, exactly one round, no feedback. Isolates the value of the feedback.
+* **`feedback`** (default): LLM, N rounds with execution feedback (default N = 5). The proposed verifier.
+
+This is an ablation *within* the verification stage, not three rival products. The thesis contribution is the improvement loop; the strategy flag exists to justify which verifier the loop should use. Selectable as a single flag (`--strategy hypothesis|oneshot|feedback`). The legacy value `rl` is accepted as an alias for `feedback` for back-compat.
 
 ## Quality profiles
 
@@ -191,7 +198,7 @@ docker compose up --build
 Open <http://localhost:8000> in a browser. The CLI is also available inside the container:
 
 ```bash
-docker compose exec api qallm --source /home/qallm/app/uploads/your_notebook.ipynb --strategy rl
+docker compose exec api qallm --source /home/qallm/app/uploads/your_notebook.ipynb --strategy feedback
 ```
 
 Outputs land in `./outputs` on the host (mounted into the container).
@@ -225,8 +232,8 @@ qallm --source notebooks/analysis.ipynb --strategy hypothesis
 # One-shot LLM verification
 qallm --source notebooks/analysis.ipynb --strategy oneshot --llm openai
 
-# Full RL verification, 5 rounds
-qallm --source notebooks/analysis.ipynb --strategy rl --rounds 5 --llm openai
+# Full iterative-feedback verification, 5 rounds
+qallm --source notebooks/analysis.ipynb --strategy feedback --rounds 5 --llm openai
 ```
 
 Inputs may be a single `.py` or `.ipynb` file, a directory, a `.zip` archive, or a GitHub URL.
@@ -258,7 +265,7 @@ For a shared deployment (e.g. a UvA-managed VM), the Compose stack above is the 
 src/qallm/
   ingestion/          Stage 1: notebook, script, ZIP, git
   analysis/           Stage 2: Radon, Bandit, lifecycle normaliser
-  verification/       Stage 3: RL loop, sandbox, executor, prompts
+  verification/       Stage 3: iterative-feedback loop, sandbox, executor, prompts
   utils/              Reporters, signatures
   llm/                OpenAI, Anthropic, Ollama adapters
   web/                FastAPI + React (in development)
@@ -290,7 +297,7 @@ In development:
 
 Out of scope for v1:
 
-* FAIRness and community indicators (discussed in thesis, not measured automatically).
+* Usability, Performance, and Compatibility indicators (discussed in thesis, not measured automatically).
 * Languages other than Python.
 * Cross-project lineage and identity attribution.
 

--- a/src/qallm/analysis/normalizer.py
+++ b/src/qallm/analysis/normalizer.py
@@ -1,22 +1,60 @@
-from enum import Enum
-from typing import Dict, Any
+"""Legacy lifecycle normaliser. Retained for reference and back-compat only.
 
+This module predates the EVERSE profile system. The authoritative way to
+evaluate code against a quality standard is now
+:func:`qallm.evaluation.evaluate_profile` driven by a
+:class:`qallm.profiles.QualityProfile`. See ``docs/workflow-design.md``.
 
-class LifecycleStage(Enum):
-    INITIALIZATION = "initialization"
-    IMPLEMENTATION = "implementation"
-    PUBLICATION = "publication"
+What remains here:
+
+* :class:`LifecycleStage` is re-exported from :mod:`qallm.profiles` so the
+  whole codebase shares one enum. The previous duplicate definition (kept
+  in sync by hand) has been removed. Importing it from here continues to
+  work for existing call sites.
+* :class:`LifecycleNormalizer` is the original hardcoded-threshold
+  evaluator. It is deprecated: it is not used anywhere in the pipeline and
+  is kept only so its thresholds remain documented and its unit test keeps
+  passing. New code must not use it; use a ``QualityProfile`` instead.
+"""
+
+from __future__ import annotations
+
+import warnings
+from typing import Any, Dict
+
+# Single source of truth for the lifecycle stages. Defined in profiles so
+# that module stays a dependency-light leaf; re-exported here so the many
+# existing ``from qallm.analysis.normalizer import LifecycleStage`` call
+# sites keep working unchanged.
+from qallm.profiles import LifecycleStage
+
+__all__ = ["LifecycleStage", "LifecycleNormalizer"]
 
 
 class LifecycleNormalizer:
-    """Normalizes raw metrics based on the EOSC lifecycle."""
+    """Deprecated. Hardcoded-threshold lifecycle evaluator.
 
-    # Example Thresholds for Maintainability Index (MI)
+    Superseded by :func:`qallm.evaluation.evaluate_profile`. The thresholds
+    below are mirrored, for the IMPLEMENTATION stage, by the
+    ``IMPLEMENTATION_DEFAULT`` profile in :mod:`qallm.profiles`. This class
+    is retained only for historical reference and to keep its unit test
+    meaningful; it is not wired into the orchestrator or the web API.
+    """
+
+    # Maintainability thresholds per lifecycle stage (MI floor, CC ceiling).
     THRESHOLDS = {
         LifecycleStage.INITIALIZATION: {"mi": 40.0, "cc": 15.0},
         LifecycleStage.IMPLEMENTATION: {"mi": 60.0, "cc": 10.0},
         LifecycleStage.PUBLICATION: {"mi": 80.0, "cc": 5.0},
     }
+
+    def __init__(self) -> None:
+        warnings.warn(
+            "LifecycleNormalizer is deprecated; evaluate quality with a "
+            "QualityProfile via qallm.evaluation.evaluate_profile instead.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
 
     def evaluate(self, metrics: Dict[str, Any], stage: LifecycleStage) -> str:
         mi = metrics.get("mi", 0)

--- a/src/qallm/api/main.py
+++ b/src/qallm/api/main.py
@@ -340,7 +340,7 @@ async def get_providers():
 
 @app.get("/api/verification/strategies")
 async def get_strategies():
-    return {"configured": ["rl", "oneshot", "hypothesis"]}
+    return {"configured": ["feedback", "oneshot", "hypothesis"]}
 
 
 @app.get("/api/verification/models")

--- a/src/qallm/experiment.py
+++ b/src/qallm/experiment.py
@@ -20,7 +20,7 @@ from datetime import datetime
 from pathlib import Path
 
 from qallm.analysis.analysis_manager import AnalysisManager
-from qallm.analysis.normalizer import LifecycleNormalizer, LifecycleStage
+from qallm.analysis.normalizer import LifecycleStage
 from qallm.config import settings
 from qallm.ingestion.ingestion_manager import IngestionManager
 from qallm.llm.base import TokenTracker

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -77,7 +77,11 @@ from qallm.repair.agents.llm_repair_agent import LLMRepairAgent
 
 logger = logging.getLogger(__name__)
 
-Strategy = Literal["rl", "oneshot", "hypothesis"]
+Strategy = Literal["feedback", "rl", "oneshot", "hypothesis"]
+# ``feedback`` is the canonical name for the iterative-feedback verifier
+# (the proposed method). ``rl`` is retained as a back-compat alias and is
+# normalised to ``feedback`` semantics at assignment; both select the same
+# multi-round, execution-feedback verification path.
 
 LLM_PROVIDERS = {
     "ollama": OllamaModel,
@@ -271,7 +275,10 @@ class QALLMOrchestrator:
             self.reporter = QualityReporter("outputs/quality_reporter", effective_run_id)
 
         self.stage = stage if isinstance(stage, LifecycleStage) else LifecycleStage(stage)
-        self.strategy = strategy
+        # Canonicalise the verifier name. ``rl`` is a legacy alias for the
+        # iterative-feedback verifier; store ``feedback`` so reports and the
+        # session schema use the current vocabulary. Behaviour is identical.
+        self.strategy = "feedback" if strategy == "rl" else strategy
         self.oracle = oracle
         self.profile = profile
 

--- a/src/qallm/run_qallm.py
+++ b/src/qallm/run_qallm.py
@@ -3,7 +3,7 @@
 Usage:
     qallm <source> --strategy hypothesis
     qallm <source> --strategy oneshot --llm openai --model gpt-4o-mini
-    qallm <source> --strategy rl --llm openai --model gpt-4o-mini --rounds 5
+    qallm <source> --strategy feedback --llm openai --model gpt-4o-mini --rounds 5
 """
 
 import argparse
@@ -16,11 +16,13 @@ from qallm.orchestrator import QALLMOrchestrator
 def main():
     parser = argparse.ArgumentParser(description="QALLM: Quality Assessment via LLMs")
     parser.add_argument("source", help="Path to .py, .ipynb, directory, .zip, or GitHub URL")
-    parser.add_argument("--strategy", default="rl", choices=["rl", "oneshot", "hypothesis"],
-                        help="Test generation strategy (default: rl)")
+    parser.add_argument("--strategy", default="feedback",
+                        choices=["feedback", "rl", "oneshot", "hypothesis"],
+                        help="Verification strategy ablation (default: feedback; "
+                             "'rl' is a back-compat alias for 'feedback')")
     parser.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama"])
     parser.add_argument("--model", default=None, help="Specific model name (e.g. gpt-4o-mini)")
-    parser.add_argument("--rounds", type=int, default=5, help="RL feedback rounds (default: 5)")
+    parser.add_argument("--rounds", type=int, default=5, help="Iterative feedback rounds (default: 5)")
     parser.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])
     parser.add_argument("--stage", default="implementation",
                         choices=["initialization", "implementation", "publication"])

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -11,7 +11,8 @@ import ReanalyseScreen from "./screens/ReanalyseScreen";
 import TestGenScreen from "./screens/TestGenScreen";
 import ResultsScreen from "./screens/ResultsScreen";
 
-const STEPS = 6;
+const STEPS_MANUAL = 6;
+const STEPS_AUTO = 4;
 
 export default function App() {
   const { state, patch, setStep } = useSession();
@@ -32,19 +33,42 @@ export default function App() {
     }
   }
 
+  // Screen routing is mode-aware. Auto mode runs the real pipeline in
+  // four phases (Upload, Baseline, Improvement rounds, Report) and maps
+  // step 3 to the live rounds view and step 4 to the report. Manual mode
+  // keeps the six-stage inspectable breakdown.
   const screen = (() => {
+    if (mode === "auto") {
+      switch (state.step) {
+        case 1: return <UploadScreen state={state} patch={patch} onSessionReady={onSessionReady} />;
+        case 2: return <AnalyseScreen state={state} patch={patch} autoMode />;
+        case 3: return <TestGenScreen state={state} patch={patch} autoMode />;
+        case 4: return <ResultsScreen state={state} />;
+        default: return null;
+      }
+    }
     switch (state.step) {
       case 1: return <UploadScreen state={state} patch={patch} onSessionReady={onSessionReady} />;
-      case 2: return <AnalyseScreen state={state} patch={patch} autoMode={mode === "auto"} />;
-      case 3: return <RepairScreen state={state} patch={patch} autoMode={mode === "auto"} />;
+      case 2: return <AnalyseScreen state={state} patch={patch} autoMode={false} />;
+      case 3: return <RepairScreen state={state} patch={patch} autoMode={false} />;
       case 4: return <ReanalyseScreen state={state} patch={patch} />;
-      case 5: return <TestGenScreen state={state} patch={patch} autoMode={mode === "auto"} />;
+      case 5: return <TestGenScreen state={state} patch={patch} autoMode={false} />;
       case 6: return <ResultsScreen state={state} />;
       default: return null;
     }
   })();
 
+  const maxStep = mode === "auto" ? STEPS_AUTO : STEPS_MANUAL;
+
   const canNext = (() => {
+    if (mode === "auto") {
+      switch (state.step) {
+        case 1: return !!state.sessionId;
+        case 2: return state.findings.length > 0 || state.summary !== null;
+        case 3: return state.testGenResult !== null;
+        default: return false;
+      }
+    }
     switch (state.step) {
       case 1: return !!state.sessionId;
       case 2: return state.findings.length > 0 || state.summary !== null;
@@ -70,7 +94,7 @@ export default function App() {
               )}
             </div>
             <h1 className="mt-2 text-3xl font-semibold tracking-tight">Quality Assessment of AI-Generated Code</h1>
-            <p className="mt-1 max-w-2xl text-sm text-slate-500">Static analysis, LLM repair, and RL-guided test generation in one pipeline.</p>
+            <p className="mt-1 max-w-2xl text-sm text-slate-500">Baseline, then LLM repair and execution-based verification across budget-capped rounds, judged against a quality model.</p>
           </div>
           {state.sessionId && (
             <div className="rounded-xl border border-slate-200 bg-white px-4 py-2 text-xs text-slate-500 shadow-sm">
@@ -86,24 +110,24 @@ export default function App() {
             that errors out leaves the user trapped on the failed step. */}
         <StepRail
           currentStep={state.step}
+          mode={mode}
           onStepClick={(mode === "auto" && state.loading) ? () => {} : setStep}
         />
-        {/* Preview-mode banner: steps 2-4 (Analyse, Repair, Re-analyse)
-            show a "preview" of what static analysis and one repair pass
-            look like. The actual QALLM pipeline that produces the
-            reported results runs in Step 5 (Generate Tests) and includes
-            its own baseline + N rounds of analyse → repair → verify →
-            judge. This banner explains the relationship so users don't
-            wonder why Step 5 re-runs everything. */}
-        {state.step >= 2 && state.step <= 4 && (
+        {/* Manual-mode preview banner. In manual mode, steps 2 to 4 let
+            the user inspect a static-analysis baseline and a single LLM
+            repair pass. These are a teaching preview: the full pipeline,
+            with all rounds and judge accept/abandon decisions, runs in the
+            "Run pipeline" step. Auto mode has no such preview, it runs the
+            real loop directly, so this banner is manual-only. */}
+        {mode === "manual" && state.step >= 2 && state.step <= 4 && (
           <div className="rounded-xl border border-blue-200 bg-blue-50 p-3 text-xs text-blue-800">
             <span className="font-semibold">Preview stages.</span>{" "}
-            Steps 2 to 4 show what static analysis and one LLM repair pass
-            produce. The full QALLM pipeline (with multiple RL-guided rounds,
-            test execution, and judge accept/abandon decisions) runs in
-            Step 5 and uses its own independent baseline. Use these
-            preview steps to inspect intermediate state and confirm your
-            uploaded code parses correctly.
+            Steps 2 to 4 let you inspect a static-analysis baseline and a
+            single LLM repair pass, so you can confirm your code parses and
+            see what one repair looks like. The full QALLM pipeline (all
+            rounds of repair, verification, and judge accept/abandon) runs
+            in the "Run pipeline" step against its own baseline. To run the
+            real pipeline directly, start a new session in Auto mode.
           </div>
         )}
         {state.error && (
@@ -121,9 +145,9 @@ export default function App() {
         {/* NextBar visible whenever navigation is allowed. */}
         {!(mode === "auto" && state.loading) && (
           <NextBar
-            step={state.step} maxStep={STEPS}
+            step={state.step} maxStep={maxStep}
             onPrev={() => setStep(Math.max(1, state.step - 1))}
-            onNext={() => canNext && setStep(Math.min(STEPS, state.step + 1))}
+            onNext={() => canNext && setStep(Math.min(maxStep, state.step + 1))}
             nextDisabled={!canNext}
           />
         )}

--- a/web/frontend/src/components/StepRail.tsx
+++ b/web/frontend/src/components/StepRail.tsx
@@ -1,18 +1,49 @@
-import { Upload, Search, Wrench, RotateCw, FlaskConical, TrendingUp, CheckCircle2 } from "lucide-react";
+import { Upload, GaugeCircle, Wrench, RotateCw, Repeat, FileCheck2, CheckCircle2 } from "lucide-react";
 
-const steps = [
+/**
+ * The step rail names the actual pipeline.
+ *
+ * Auto mode runs the real loop: Upload -> Baseline (round 0) -> Improvement
+ * rounds (orch.run: repair -> verify -> judge, repeated) -> Report. It has
+ * four phases.
+ *
+ * Manual mode exposes the same pipeline as inspectable stages, including a
+ * single-pass repair preview, for teaching and debugging. It keeps the
+ * finer-grained six-stage breakdown. Either way the labels describe what
+ * the stage does, not the obsolete "RL" framing.
+ */
+type Step = { id: number; title: string; icon: any; blurb: string };
+
+const AUTO_STEPS: Step[] = [
   { id: 1, title: "Upload", icon: Upload, blurb: "Bring in code" },
-  { id: 2, title: "Analyse", icon: Search, blurb: "Static analysis" },
-  { id: 3, title: "Repair", icon: Wrench, blurb: "LLM repair" },
-  { id: 4, title: "Re-analyse", icon: RotateCw, blurb: "Verify improvement" },
-  { id: 5, title: "Generate Tests", icon: FlaskConical, blurb: "RL test generation" },
-  { id: 6, title: "RL Results", icon: TrendingUp, blurb: "Learning curve" },
+  { id: 2, title: "Baseline", icon: GaugeCircle, blurb: "Round 0, no repair" },
+  { id: 3, title: "Improvement rounds", icon: Repeat, blurb: "Repair, verify, judge" },
+  { id: 4, title: "Report", icon: FileCheck2, blurb: "Lineage and verdict" },
 ];
 
-export default function StepRail({ currentStep, onStepClick }: { currentStep: number; onStepClick: (s: number) => void }) {
+const MANUAL_STEPS: Step[] = [
+  { id: 1, title: "Upload", icon: Upload, blurb: "Bring in code" },
+  { id: 2, title: "Baseline", icon: GaugeCircle, blurb: "Static analysis" },
+  { id: 3, title: "Repair preview", icon: Wrench, blurb: "One LLM pass" },
+  { id: 4, title: "Re-analyse", icon: RotateCw, blurb: "Inspect the delta" },
+  { id: 5, title: "Run pipeline", icon: Repeat, blurb: "Full loop, all rounds" },
+  { id: 6, title: "Report", icon: FileCheck2, blurb: "Lineage and verdict" },
+];
+
+export default function StepRail({
+  currentStep,
+  onStepClick,
+  mode = "manual",
+}: {
+  currentStep: number;
+  onStepClick: (s: number) => void;
+  mode?: "manual" | "auto";
+}) {
+  const steps = mode === "auto" ? AUTO_STEPS : MANUAL_STEPS;
+  const cols = steps.length === 4 ? "md:grid-cols-4" : "md:grid-cols-6";
   return (
     <div className="rounded-2xl border border-slate-200 bg-white/70 p-3 shadow-sm backdrop-blur">
-      <div className="grid grid-cols-3 gap-2 md:grid-cols-6">
+      <div className={`grid grid-cols-3 gap-2 ${cols}`}>
         {steps.map(s => {
           const Icon = s.icon;
           const done = currentStep > s.id;

--- a/web/frontend/src/hooks/useAutoRunner.ts
+++ b/web/frontend/src/hooks/useAutoRunner.ts
@@ -3,22 +3,37 @@ import type { SessionState } from "./useSession";
 import * as api from "../api";
 
 /**
- * Auto-runner: sequences analyse → repair → verify → results
- * with screen transitions between each step.
+ * Auto-runner: runs the real QALLM pipeline as a single call and renders
+ * its live progress.
  *
- * IMPORTANT: ``run`` accepts ``sessionId`` and ``files`` as explicit
- * arguments rather than reading them from the captured ``state`` closure.
+ * Design (post-convergence). Earlier builds sequenced a hand-rolled
+ * analyse -> repair -> re-analyse mini-loop on the client and *then* also
+ * called the verification step, which itself runs the full orchestrator
+ * loop (orch.run). The effect was that repair ran twice: once standalone,
+ * once inside the loop, against two different baselines. That contradicted
+ * the workflow design, where repair happens only inside a round, after the
+ * baseline.
  *
- * The reason is a React stale-closure trap. ``onSessionReady`` invokes
- * ``run()`` immediately after ``patch({ sessionId })``; because React
- * state updates are asynchronous, ``state.sessionId`` is still the
- * pre-upload value at the moment ``run()`` runs. Reading from the
- * closure would see ``undefined`` and the guard at the top would bail
- * silently, which is exactly what produced the "auto mode does nothing"
- * symptom in earlier builds.
+ * The corrected flow has exactly one source of truth for the loop, the
+ * orchestrator:
+ *
+ *   Step 2  Baseline   one static-analysis pass so the user sees the
+ *                      round-0 starting point and can confirm the code
+ *                      parsed. This is read-only; it does not repair.
+ *   Step 3  Rounds     api.runTestGen submits /api/verification/run, which
+ *                      calls orch.run(): baseline -> N rounds of
+ *                      (repair -> analyse -> verify -> judge), budget
+ *                      capped, with per-unit accept/abandon. Live progress
+ *                      is forwarded into session state for the rounds view.
+ *   Step 4  Report     the final lineage, verdicts, halt reason, budget.
+ *
+ * ``run`` takes ``sessionId`` and ``files`` explicitly rather than reading
+ * the captured ``state`` closure: ``onSessionReady`` calls ``run()``
+ * immediately after ``patch({ sessionId })`` and React state updates are
+ * asynchronous, so the closure would still hold the pre-upload value.
  */
 export function useAutoRunner(
-  state: SessionState,
+  _state: SessionState,
   patch: (p: Partial<SessionState>) => void,
   setStep: (step: number) => void,
 ) {
@@ -27,68 +42,44 @@ export function useAutoRunner(
   const run = useCallback(async (sessionId: string, files: string[]) => {
     if (!sessionId) return;
     aborted.current = false;
-
     const sid = sessionId;
 
     try {
-      // ─── Step 2: Analyse ───
+      // --- Step 2: Baseline (round 0 preview, read-only) ---
       setStep(2);
       patch({ loading: true, error: null });
-      await delay(600); // Let the UI render
+      await delay(400); // let the UI render
 
       const tools = await api.getAnalysisTools();
-      const analysis = await api.runAnalysis(sid, files, tools.tools);
+      const baseline = await api.runAnalysis(sid, files, tools.tools);
       const rounds = await api.getAnalysisHistory(sid).catch(() => []);
-      patch({ summary: analysis.summary, findings: analysis.findings, analysisRounds: rounds, loading: false });
+      patch({
+        summary: baseline.summary,
+        findings: baseline.findings,
+        analysisRounds: rounds,
+        loading: false,
+      });
       if (aborted.current) return;
-      await delay(1500); // Pause so user sees results
+      await delay(1200); // pause so the user sees the baseline
 
-      // ─── Step 3: Repair ───
+      // --- Step 3: Improvement rounds (the real loop) ---
       setStep(3);
-      patch({ loading: true });
-      await delay(600);
-
-      const repair = await api.runRepair(sid);
-      const versions = await api.getVersions(sid).catch(() => []);
-      patch({ repairResult: repair, repairRound: repair.repair_round, versions, loading: false });
-      if (aborted.current) return;
-      await delay(1500);
-
-      // ─── Step 4: Re-analyse ───
-      setStep(4);
-      patch({ loading: true });
-      await delay(600);
-
-      const reanalysis = await api.runAnalysis(sid, files, tools.tools);
-      const rounds2 = await api.getAnalysisHistory(sid).catch(() => []);
-      patch({ summary: reanalysis.summary, findings: reanalysis.findings, analysisRounds: rounds2, loading: false });
-      if (aborted.current) return;
-      await delay(1500);
-
-      // ─── Step 5: Generate Tests ───
-      setStep(5);
       patch({ loading: true, progress: null });
-      await delay(600);
+      await delay(400);
 
-      // The session config was locked in at upload. The backend now runs
-      // the full v3 loop (orch.run) regardless of the runTestGen args; we
-      // pass empty strings and 0 to make the back-compat shape explicit.
-      // The result includes tracks, judge verdicts, halt reason, budget,
-      // and the legacy `functions` list.
-      //
-      // Live progress is forwarded into the session state so TestGenScreen
-      // can render it. The orchestrator runs in a worker thread on the
-      // server; each poll captures a snapshot of its in-progress state.
+      // Session config was locked in at upload. The backend runs the full
+      // loop (orch.run) on submit; the args here are the back-compat shape.
+      // Live progress is forwarded so the rounds view can render phase,
+      // current round, stage, unit, and accepted/abandoned counts.
       const verification = await api.runTestGen(sid, "", "", 0, view => {
         if (view.progress) patch({ progress: view.progress });
       });
       patch({ testGenResult: verification, loading: false });
       if (aborted.current) return;
-      await delay(1000);
+      await delay(800);
 
-      // ─── Step 6: Results ───
-      setStep(6);
-
+      // --- Step 4: Report ---
+      setStep(4);
     } catch (e: any) {
       patch({ loading: false, error: e.message });
     }

--- a/web/frontend/src/screens/ResultsScreen.tsx
+++ b/web/frontend/src/screens/ResultsScreen.tsx
@@ -317,8 +317,8 @@ export default function ResultsScreen({ state }: { state: SessionState }) {
       {/* Learning curve + coverage */}
       <div className="grid gap-6 lg:grid-cols-2">
         <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">The RL loop improves across rounds</h2>
-          <p className="mt-1 text-sm text-slate-500">Cumulative reward per function. A rising line means the loop is learning.</p>
+          <h2 className="text-xl font-semibold">Verification improves across rounds</h2>
+          <p className="mt-1 text-sm text-slate-500">Cumulative reward per function. A rising line means the iterative feedback is finding more.</p>
           <div className="mt-4 h-[280px]">
             <ResponsiveContainer width="100%" height="100%">
               <LineChart data={curveData}>
@@ -371,7 +371,7 @@ export default function ResultsScreen({ state }: { state: SessionState }) {
             <p>LLM repair reduces them with actionable patches.</p>
             <p>Generated tests catch bugs static analysis misses.</p>
             <p>The judge accepts or abandons each round's variant per EVERSE dimensions.</p>
-            <p className="font-medium text-white">The RL loop with judged accept/abandon decisions is the v3 thesis contribution.</p>
+            <p className="font-medium text-white">The budget-capped improvement loop, with judged accept/abandon decisions against a quality model, is the core contribution.</p>
           </div>
         </div>
         <div className="flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">

--- a/web/frontend/src/screens/TestGenScreen.tsx
+++ b/web/frontend/src/screens/TestGenScreen.tsx
@@ -108,8 +108,8 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
     <div className="space-y-6">
       <div className="grid gap-6 lg:grid-cols-[1.1fr_0.9fr]">
         <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-          <h2 className="text-xl font-semibold">RL-Guided Test Generation</h2>
-          <p className="mt-1 text-sm text-slate-500">Generate tests, execute in sandbox, score with reward function, improve across rounds.</p>
+          <h2 className="text-xl font-semibold">Improvement Rounds</h2>
+          <p className="mt-1 text-sm text-slate-500">Baseline, then repair, verify, and judge across budget-capped rounds. Generate tests, execute in the sandbox, score with the reward, improve each round.</p>
 
           {/* Locked session config */}
           <div className="mt-4 grid grid-cols-3 gap-3">

--- a/web/frontend/src/screens/UploadScreen.tsx
+++ b/web/frontend/src/screens/UploadScreen.tsx
@@ -8,17 +8,17 @@ import * as api from "../api";
 interface ModelEntry { id: string; label: string; provider: string; available: boolean; }
 
 const STRATEGY_INFO: Record<string, { title: string; desc: string }> = {
-  rl: {
-    title: "RL-guided (iterative feedback)",
-    desc: "The LLM generates tests, executes them, scores the results with a reward function, then uses the feedback to generate better tests in subsequent rounds. This is the proposed method and the core thesis contribution.",
+  feedback: {
+    title: "Iterative feedback (proposed method)",
+    desc: "The LLM generates tests, executes them, scores the results with a quantitative reward, then uses that feedback to generate better tests over successive rounds. Iterative prompting with execution feedback through the model's API, not a trained model. This is the verification strategy used inside the improvement loop.",
   },
   oneshot: {
     title: "One-shot (single generation)",
-    desc: "The LLM generates tests once without feedback. This ablation isolates the LLM's contribution from the RL loop's contribution. Used as Strategy (b) in the three-strategy comparison.",
+    desc: "The LLM generates tests once, with no feedback. This ablation isolates the value of the feedback loop. Strategy (b) in the strategy comparison.",
   },
   hypothesis: {
     title: "Hypothesis (property-based, no LLM)",
-    desc: "Generates random typed inputs using the Hypothesis library with automatic shrinking. No LLM is involved. This is the non-trivial control group, Strategy (a) in the thesis.",
+    desc: "Generates random typed inputs with the Hypothesis library and automatic shrinking. No LLM involved. The non-trivial control, Strategy (a) in the strategy comparison.",
   },
 };
 
@@ -65,7 +65,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
   // Base config (always shown).
   const [config, setConfig] = useState({
     stage: "implementation",
-    strategy: "rl",
+    strategy: "feedback",
     oracle: "crash",
     rounds: 5,
     model_name: "",
@@ -136,7 +136,10 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
   }
 
   const selectedModel = models.find(m => m.id === config.model_name);
-  const selectedStrategy = STRATEGY_INFO[config.strategy];
+  // ``rl`` is a back-compat alias for ``feedback``; map it so an older
+  // backend that still advertises ``rl`` resolves to the same info card.
+  const strategyKey = config.strategy === "rl" ? "feedback" : config.strategy;
+  const selectedStrategy = STRATEGY_INFO[strategyKey];
   const selectedOracle = ORACLE_INFO[config.oracle];
 
   return (
@@ -168,7 +171,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
           <div className="space-y-1.5">
             <label className="flex items-center gap-1.5 text-xs font-bold text-slate-500 uppercase"><Layers className="h-3.5 w-3.5" /> Strategy</label>
             <select value={config.strategy} onChange={e => setConfig({ ...config, strategy: e.target.value })} className="w-full rounded-xl border p-2.5 text-sm">
-              {strategies.map(s => <option key={s} value={s}>{STRATEGY_INFO[s]?.title || s}</option>)}
+              {strategies.map(s => <option key={s} value={s}>{STRATEGY_INFO[s === "rl" ? "feedback" : s]?.title || s}</option>)}
             </select>
           </div>
           <div className="space-y-1.5">


### PR DESCRIPTION
Resolves the drift between README, RQ framing, code, and web UI surfaced in the architecture audit.

Unifies the duplicated LifecycleStage enum and deprecates the dead LifecycleNormalizer (EVERSE QualityProfile is the authoritative path). Fixes auto-mode repairing the code twice; auto mode now runs the single orchestrator loop (orch.run) with live progress. StepRail and screens are mode-aware and honestly labelled. Reframes the contribution as the budget-capped improvement loop; the three-strategy comparison is now an ablation within verification. feedback is the canonical verifier name, rl kept as a back-compat alias.

No behaviour change. 363 Python tests pass; frontend type-checks and builds.