### PR TITLE
refactor: Debt + features + orchestrator

### DIFF
--- a/src/qallm/evaluation.py
+++ b/src/qallm/evaluation.py
@@ -40,7 +40,6 @@ EVERSE Research Software Quality Dimensions:
 from __future__ import annotations
 
 import json
-import os
 import subprocess
 from dataclasses import dataclass, field
 from enum import Enum
@@ -48,7 +47,6 @@ from pathlib import Path
 from typing import Any, Callable
 
 from qallm.profiles import (
-    Comparator,
     DimensionSpec,
     QualityDimension,
     QualityIndicator,

--- a/src/qallm/experiment.py
+++ b/src/qallm/experiment.py
@@ -15,12 +15,9 @@ import argparse
 import csv
 import json
 import logging
-import time
 from datetime import datetime
 from pathlib import Path
 
-from qallm.analysis.analysis_manager import AnalysisManager
-from qallm.analysis.normalizer import LifecycleStage
 from qallm.config import settings
 from qallm.ingestion.ingestion_manager import IngestionManager
 from qallm.llm.base import TokenTracker
@@ -28,7 +25,6 @@ from qallm.llm.openai_provider import OpenAIModel
 from qallm.llm.anthropic_provider import AnthropicModel
 from qallm.llm.ollama_provider import OllamaModel
 from qallm.verification.extractor import extract_functions_from_source
-from qallm.verification.executor import run_tests
 from qallm.verification.loop import TestGenerationLoop
 from qallm.verification.models import OracleType
 

--- a/src/qallm/experiments/humaneval_dataset.py
+++ b/src/qallm/experiments/humaneval_dataset.py
@@ -21,7 +21,7 @@ reviewer can re-run the sampling.
 from __future__ import annotations
 
 import random
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Optional
 
 

--- a/src/qallm/experiments/humaneval_metrics.py
+++ b/src/qallm/experiments/humaneval_metrics.py
@@ -28,7 +28,7 @@ import subprocess
 import sys
 import tempfile
 import textwrap
-from dataclasses import dataclass, field, asdict
+from dataclasses import dataclass, asdict
 from pathlib import Path
 from typing import Optional
 

--- a/src/qallm/experiments/humaneval_report.py
+++ b/src/qallm/experiments/humaneval_report.py
@@ -8,7 +8,6 @@ be readable as a standalone document.
 from __future__ import annotations
 
 from datetime import datetime, timezone
-from typing import Any
 
 from qallm.experiments.humaneval_metrics import (
     AggregateResult,

--- a/src/qallm/experiments/humaneval_runner.py
+++ b/src/qallm/experiments/humaneval_runner.py
@@ -32,13 +32,12 @@ import json
 import logging
 import time
 import traceback
-from dataclasses import dataclass, asdict
+from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Callable, Optional
 
 from qallm.experiments.humaneval_dataset import HumanEvalProblem, load_humanevalfix
 from qallm.experiments.humaneval_metrics import (
-    AggregateResult,
     ProblemResult,
     aggregate,
     bug_was_detected,

--- a/src/qallm/judge/strategies.py
+++ b/src/qallm/judge/strategies.py
@@ -26,7 +26,6 @@ from typing import Any, Optional, Protocol
 from qallm.evaluation import ProfileVerdict
 from qallm.judge.comparator import compare_verdicts
 from qallm.judge.models import (
-    DimensionDelta,
     IndicatorChange,
     JudgeOutcome,
     JudgeVerdict,

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -315,26 +315,23 @@ class QALLMOrchestrator:
         for unit in units:
             self.tracks[_unit_id(unit)] = UnitTrack(unit_id=_unit_id(unit))
 
-        # ────── Round 0: baseline analyse + verify ──────
-        # The baseline is the ground truth. Round 1 is judged against
-        # the ProfileVerdict produced here. No repair is performed.
-        logger.info("Round 0 (baseline): analyse + verify the original code")
-        for unit in units:
-            self._run_baseline_for_unit(unit)
+        # One unified loop. Round 0 is the baseline (analyse + verify the
+        # original, no repair, always accepted, no budget round consumed).
+        # Rounds 1..max are repair rounds (analyse-repair-verify-judge).
+        # _run_round -> _process_unit handles the round-0-vs-N differences;
+        # there is no separate baseline method.
+        next_inputs: dict[str, CodeUnit] = {_unit_id(u): u for u in units}
+
+        # Round 0: baseline. Does not consume a budget round; max_rounds
+        # bounds the number of repair rounds only.
+        self.current_phase = "baseline"
+        self.current_round = 0
+        next_inputs = self._run_round(next_inputs)
         logger.info("Baseline complete. Round 0 stored on each unit's lineage.")
-        # Baseline does NOT consume a budget round; max_rounds bounds
-        # the number of *repair* rounds, not the baseline.
+
+        # Rounds 1..max: repair loop.
         self.current_phase = "rounds"
         self.current_round = 1
-
-        # QALLM rounds: Analyse → Repair → Verify → Judge → Accept/Abandon.
-        # Each unit independently advances its lineage or stalls on its
-        # last accepted variant. Inputs for round 1 are the originals (the
-        # round-0 baselines), then each subsequent round consumes the last
-        # accepted variant.
-        next_inputs: dict[str, CodeUnit] = {
-            _unit_id(u): u for u in units
-        }
         while True:
             self.budget_state.mark_round_start()
             next_inputs = self._run_round(next_inputs)
@@ -406,36 +403,16 @@ class QALLMOrchestrator:
             halt_reason=self.halt_reason.value if self.halt_reason else None,
         )
 
-    def _run_baseline_for_unit(self, unit: CodeUnit) -> None:
-        """Run round 0 (baseline) for a single code unit.
+    def _identity_repair(self, analysed) -> RepairedCodeUnit:
+        """A no-op 'repair' whose output equals the input.
 
-        Round 0 analyses + verifies the original code; it does NOT call
-        repair. A synthetic ``RepairedCodeUnit`` is constructed where the
-        repaired source equals the original source so that ``verify`` can
-        run unchanged. The resulting ProfileVerdict becomes the first
-        entry in the unit's lineage, and is the parent against which
-        round 1 will be judged.
-
-        This is the change introduced for the "baseline verification"
-        methodology decision: see docs/methodology-decisions.md.
+        Round 0 (baseline) verifies the *original* code, so there is no
+        repair to perform. ``verify`` still expects a RepairedCodeUnit (it
+        uses ``original_code_unit`` to filter functions the repair added
+        out of the test surface), so we wrap the analysed code with itself:
+        repaired_source == original, compiles == True, empty diff.
         """
-        unit_id = _unit_id(unit)
-        track = self.tracks[unit_id]
-        self.current_unit_id = unit_id
-
-        # Step 1: static analysis on the original code. This is the same
-        # call the analysis_manager makes during a normal round.
-        self.current_stage = "analyse"
-        analysed = self.analysis_manager.analyse_code_unit(unit)
-
-        # Step 2: build a synthetic RepairedCodeUnit. The verify method
-        # signature expects a RepairedCodeUnit (it uses
-        # ``original_code_unit`` to filter "functions added by repair"
-        # out of the test surface). For the baseline there is no repair,
-        # so we wrap the analysed code with itself: repaired_source ==
-        # original source, compiles == True, no diff. The construction
-        # mirrors what repair_manager would have produced for an
-        # identity transformation.
+        unit = analysed.code_unit
         identity_result = RepairResult(
             file_path=str(unit.original_path) if unit.original_path else "",
             repaired_source=unit.source_code,
@@ -443,151 +420,102 @@ class QALLMOrchestrator:
             compiles=True,
             unified_diff="",
         )
-        baseline_repaired = RepairedCodeUnit(analysed, identity_result)
+        return RepairedCodeUnit(analysed, identity_result)
 
-        # Step 3: verify the original. round_number=0 lets the test
-        # stability store recognise this as the baseline round; under
-        # FROZEN+REPLAY_ONLY (the default) this is exactly the round
-        # in which tests are generated. Round 1+ then replays.
+    def _process_unit(
+        self, unit_id: str, unit: CodeUnit, track: UnitTrack
+    ) -> CodeUnit:
+        """Process one code unit for the current round, return its next input.
+
+        This is the single path for *every* round, including the baseline.
+        The only differences between round 0 and rounds >= 1 are three
+        small branches, all keyed on ``self.current_round == 0``:
+
+          * Repair: round 0 uses an identity (no LLM call); rounds >= 1
+            call the repair manager.
+          * Judge: round 0 has no parent so there is no judge verdict and
+            the result is unconditionally accepted; rounds >= 1 judge the
+            variant against the parent and accept or abandon.
+          * Improvement report: round 0 has nothing to compare against, so
+            it is skipped; rounds >= 1 record parent-vs-variant deltas.
+
+        Collapsing the former ``_run_baseline_for_unit`` into this method
+        removes the analyse/verify/evaluate/persist duplication: baseline
+        is simply "a round where repair is a no-op and the result is always
+        accepted".
+        """
+        is_baseline = self.current_round == 0
+        self.current_unit_id = unit_id
+        set_context(round_number=self.current_round, unit_id=unit_id,
+                    function=None, oracle=None)
+
+        # Step 1: static analysis.
+        self.current_stage = "analyse"
+        set_context(stage="analyse", role=None)
+        analysed = self.analysis_manager.analyse_code_unit(unit)
+
+        # Step 2: repair (identity for the baseline, real otherwise).
+        self.current_stage = "repair"
+        if is_baseline:
+            repaired = self._identity_repair(analysed)
+        else:
+            set_context(stage="repair", role="repair")
+            repaired = self.repair_manager.repair_code_unit(analysed)
+
+        # Step 3: verify. round_number=0 tells the stability store this is
+        # the baseline round (where tests are generated under the default
+        # FROZEN+REPLAY_ONLY policy; later rounds replay).
         self.current_stage = "verify"
+        set_context(stage="verify", role="testgen", oracle=self.oracle)
 
         def _on_function_start(name: str, idx: int, total: int) -> None:
+            # On slow local LLMs an 8-function unit can spend 10+ minutes
+            # in verify; this keeps the snapshot's current_function live so
+            # the UI inactivity timer does not trip.
             self.current_function = name
             self.function_index = idx
             self.function_total = total
+            set_context(function=name)
 
         tested_unit = self.verification_manager.verify(
-            baseline_repaired,
-            persist_dir=None,
+            repaired,
+            persist_dir=None,  # reporter owns disk layout (NEW-07)
             on_function_start=_on_function_start,
-            round_number=0,
+            round_number=self.current_round,
         )
-        # Clear function-level fields so the next stage doesn't show
-        # stale "verifying foo" while we're in judge.
         self.current_function = None
         self.function_index = 0
         self.function_total = 0
 
-        # Step 4: build the ProfileVerdict from baseline evidence.
+        # Step 4: build the variant's ProfileVerdict.
         self.current_stage = "judge"
-        baseline_verdict = self._evaluate_profile_for(unit, tested_unit)
+        set_context(stage="judge", role="judge", function=None, oracle=None)
+        variant_unit = tested_unit.repaired_unit.repaired_code_unit
+        variant_verdict = self._evaluate_profile_for(variant_unit, tested_unit)
 
-        # Step 5: record the baseline as the first lineage entry. There
-        # is no judge verdict because there is no parent; that is the
-        # only round in the entire run where judge_verdict is None.
-        track.lineage.append(LineageEntry(
-            round_number=0,
-            code_unit=unit,
-            verdict=baseline_verdict,
-            judge_verdict=None,
-        ))
+        # Step 5: judge + accept/abandon (baseline is always accepted).
+        parent = track.current_parent
+        judge_verdict = None
+        improvement = None
 
-        # Step 6: persist the baseline artefacts on disk. We route
-        # through save_round_artefacts (the same call used for repair
-        # rounds) so that disk layout is uniform: every round including
-        # the baseline lives under lineage/round_NN/{unit_id}/ with the
-        # same six files. The legacy save_baseline path is no longer
-        # used by run(); kept on the reporter for backward compatibility
-        # with callers that constructed reports outside the orchestrator.
-        self.reporter.save_round_artefacts(
-            round_number=0,
-            unit_id=unit_id,
-            code_unit=unit,
-            analysed=analysed,
-            tested=tested_unit,
-            profile_verdict=baseline_verdict,
-            judge_verdict_dict=None,
-            accepted=True,
-        )
-
-        logger.info("  %s: baseline (round 0) recorded.", unit_id)
-
-    def _run_round(
-        self, inputs: dict[str, CodeUnit]
-    ) -> dict[str, CodeUnit]:
-        """Run one QALLM round across all units.
-
-        Args:
-            inputs: Mapping unit_id -> CodeUnit to process this round.
-              Typically each unit's last accepted variant (or its original
-              source on round 1).
-
-        Returns:
-            Mapping unit_id -> CodeUnit for the next round. Accepted units
-            return their new variant; rejected units return their unchanged
-            parent.
-        """
-        logger.info(
-            "Round (%d of %d) started, %d unit(s)...",
-            self.current_round, self.rounds, len(inputs),
-        )
-        next_inputs: dict[str, CodeUnit] = {}
-
-        for unit_id, unit in inputs.items():
-            track = self.tracks[unit_id]
-            self.current_unit_id = unit_id
-            set_context(round_number=self.current_round, unit_id=unit_id,
-                        function=None, oracle=None)
-
-            # Step 1: Analyse current variant.
-            self.current_stage = "analyse"
-            set_context(stage="analyse", role=None)
-            analysed = self.analysis_manager.analyse_code_unit(unit)
-
-            # Step 2: Repair.
-            self.current_stage = "repair"
-            set_context(stage="repair", role="repair")
-            repaired = self.repair_manager.repair_code_unit(analysed)
-
-            # Step 3: Verify.
-            self.current_stage = "verify"
-            set_context(stage="verify", role="testgen", oracle=self.oracle)
-
-            def _on_function_start(name: str, idx: int, total: int) -> None:
-                """Update orchestrator progress when verify enters each function.
-
-                On slow local LLMs (gemma3:4b ~30-90s per call), an 8-function
-                unit can spend 10+ minutes in verify. Without this callback
-                the snapshot would show stale "current_function" for that
-                entire window and the UI's inactivity timer could trip.
-                """
-                self.current_function = name
-                self.function_index = idx
-                self.function_total = total
-                set_context(function=name)
-
-            tested_unit = self.verification_manager.verify(
-                repaired,
-                persist_dir=None,  # reporter owns disk layout under NEW-07
-                on_function_start=_on_function_start,
-                round_number=self.current_round,
+        if is_baseline:
+            assert parent is None, (
+                f"Unit {unit_id}: baseline ran but lineage was not empty."
             )
-
-            # Verify finished: clear function-level fields so the next stage
-            # doesn't show stale "verifying foo" while we're in judge.
-            self.current_function = None
-            self.function_index = 0
-            self.function_total = 0
-
-            # Step 4: Build a ProfileVerdict for the variant.
-            self.current_stage = "judge"
-            set_context(stage="judge", role="judge", function=None, oracle=None)
-            variant_unit = tested_unit.repaired_unit.repaired_code_unit
-            variant_verdict = self._evaluate_profile_for(
-                variant_unit, tested_unit
-            )
-
-            # Step 5 + 6: Judge and accept/abandon.
-            # Post baseline-verification: every repair round (>= 1) has
-            # a parent on the lineage because round 0 was recorded by
-            # _run_baseline_for_unit. There is no longer an
-            # "unconditionally accepted first round" case.
-            parent = track.current_parent
+            accepted = True
+            track.lineage.append(LineageEntry(
+                round_number=0,
+                code_unit=unit,
+                verdict=variant_verdict,
+                judge_verdict=None,
+            ))
+            next_input = variant_unit
+            logger.info("  %s: baseline (round 0) recorded.", unit_id)
+        else:
             assert parent is not None, (
-                f"Unit {unit_id}: no parent on lineage at round "
-                f"{self.current_round}. Did baseline (round 0) run?"
+                f"Unit {unit_id}: no parent at round {self.current_round}. "
+                f"Did baseline (round 0) run?"
             )
-
             judge_verdict = self.judge.decide(
                 parent.verdict, variant_verdict,
                 raw_evidence=self._raw_evidence_for(tested_unit),
@@ -600,7 +528,7 @@ class QALLMOrchestrator:
                     verdict=variant_verdict,
                     judge_verdict=judge_verdict,
                 ))
-                next_inputs[unit_id] = parent.code_unit
+                next_input = parent.code_unit
                 logger.info(
                     "  %s: round %d REJECTED (%s); reverting to parent.",
                     unit_id, self.current_round, judge_verdict.outcome.value,
@@ -613,14 +541,12 @@ class QALLMOrchestrator:
                     verdict=variant_verdict,
                     judge_verdict=judge_verdict,
                 ))
-                next_inputs[unit_id] = variant_unit
+                next_input = variant_unit
                 logger.info(
                     "  %s: round %d ACCEPTED (%s).",
                     unit_id, self.current_round, judge_verdict.outcome.value,
                 )
 
-            # Step 7: persist the variant's full provenance bundle. The
-            # accepted flag routes into lineage/ or abandoned/.
             improvement = build_improvement_report(
                 round_number=self.current_round,
                 unit_id=unit_id,
@@ -631,26 +557,52 @@ class QALLMOrchestrator:
                 judge_verdict=judge_verdict.to_dict(),
             )
             logger.info("  %s: %s", unit_id, improvement.headline())
-            self.reporter.save_round_artefacts(
-                round_number=self.current_round,
-                unit_id=unit_id,
-                code_unit=variant_unit,
-                analysed=analysed,
-                tested=tested_unit,
-                profile_verdict=variant_verdict,
-                judge_verdict_dict=judge_verdict.to_dict(),
-                accepted=accepted,
-                improvement_dict=improvement.to_dict(),
-                transcript_records=[
-                    r.to_dict() for r in self.transcript.for_round(self.current_round)
-                    if r.context.get("unit_id") == unit_id
-                ],
-            )
 
-        logger.info(
-            "Round (%d of %d) completed.",
-            self.current_round, self.rounds,
+        # Step 6: persist the round bundle. Same disk layout for every
+        # round including the baseline: lineage|abandoned/round_NN/{unit}/.
+        self.reporter.save_round_artefacts(
+            round_number=self.current_round,
+            unit_id=unit_id,
+            code_unit=variant_unit if not is_baseline else unit,
+            analysed=analysed,
+            tested=tested_unit,
+            profile_verdict=variant_verdict,
+            judge_verdict_dict=judge_verdict.to_dict() if judge_verdict else None,
+            accepted=accepted,
+            improvement_dict=improvement.to_dict() if improvement else None,
+            transcript_records=[
+                r.to_dict() for r in self.transcript.for_round(self.current_round)
+                if r.context.get("unit_id") == unit_id
+            ],
         )
+        return next_input
+
+    def _run_round(
+        self, inputs: dict[str, CodeUnit]
+    ) -> dict[str, CodeUnit]:
+        """Run one round (baseline or repair) across all units.
+
+        Round 0 is the baseline; rounds >= 1 are repair rounds. Per-unit
+        work is identical in shape and lives in ``_process_unit``; this
+        method just iterates and collects the next round's inputs.
+
+        Args:
+            inputs: unit_id -> CodeUnit to process this round. The last
+              accepted variant per unit (the originals on round 0/1).
+
+        Returns:
+            unit_id -> CodeUnit for the next round.
+        """
+        label = "baseline" if self.current_round == 0 else "repair"
+        logger.info(
+            "Round %d (%s) started, %d unit(s)...",
+            self.current_round, label, len(inputs),
+        )
+        next_inputs: dict[str, CodeUnit] = {}
+        for unit_id, unit in inputs.items():
+            track = self.tracks[unit_id]
+            next_inputs[unit_id] = self._process_unit(unit_id, unit, track)
+        logger.info("Round %d (%s) completed.", self.current_round, label)
         return next_inputs
 
     def _evaluate_profile_for(

--- a/src/qallm/profiles.py
+++ b/src/qallm/profiles.py
@@ -19,7 +19,7 @@ References:
 
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 

--- a/src/qallm/repair/agents/llm_repair_agent.py
+++ b/src/qallm/repair/agents/llm_repair_agent.py
@@ -8,7 +8,6 @@ Flow per file:
   5. Return RepairResult with compile status
 """
 
-import ast
 import re
 
 from qallm.llm.base import LLMModel, TokenTracker

--- a/src/qallm/repair/repair_manager.py
+++ b/src/qallm/repair/repair_manager.py
@@ -62,7 +62,7 @@ class RepairManager:
 
         repaired_code_unit = RepairedCodeUnit(analysed_code_unit, repair_result)
 
-        logger.info(f"Repair completed:")
+        logger.info("Repair completed:")
 
         # Log whether the repair compiles or not.
         if not repaired_code_unit.repaired_result.compiles:

--- a/src/qallm/stats.py
+++ b/src/qallm/stats.py
@@ -13,7 +13,6 @@ import argparse
 import csv
 import logging
 from collections import defaultdict
-from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -234,7 +233,7 @@ def analyze_rq2(csv_path: str) -> None:
         print(f"\n  Testable functions:    {len(testable)}")
         print(f"  Functions with bugs:   {len(with_bugs)}")
         print(f"  False confidence rate: {fcr:.1%}")
-        print(f"  (Proportion of testable code where execution found defects)")
+        print("  (Proportion of testable code where execution found defects)")
     else:
         print("  No testable functions found.")
 

--- a/src/qallm/utils/views.py
+++ b/src/qallm/utils/views.py
@@ -24,7 +24,6 @@ Design choices
 from __future__ import annotations
 
 import html
-import json
 from pathlib import Path
 from typing import Any
 
@@ -34,7 +33,7 @@ def render_markdown(summary: dict[str, Any]) -> str:
     lines: list[str] = []
 
     # Header
-    lines.append(f"# QALLM session report")
+    lines.append("# QALLM session report")
     lines.append("")
     lines.append(f"**Source**: `{summary.get('source', 'unknown')}`")
     lines.append(f"**Strategy**: {summary.get('strategy', '?')}  ")
@@ -145,7 +144,7 @@ def render_html(summary: dict[str, Any]) -> str:
 
     parts: list[str] = []
     parts.append(_HTML_HEAD.format(title=title))
-    parts.append(f"<h1>QALLM session report</h1>")
+    parts.append("<h1>QALLM session report</h1>")
     parts.append(f"<p class='meta'><b>Source:</b> <code>{title}</code></p>")
     parts.append(
         f"<p class='meta'>"

--- a/src/qallm/verification/hypothesis_baseline.py
+++ b/src/qallm/verification/hypothesis_baseline.py
@@ -7,13 +7,12 @@ the non-trivial control group for the three-strategy comparison.
 
 from __future__ import annotations
 
-import ast
 import logging
 from pathlib import Path
 
 from qallm.verification.executor import run_tests
 from qallm.verification.extractor import extract_functions_from_source
-from qallm.verification.models import FunctionInfo, ExecutionResult
+from qallm.verification.models import FunctionInfo
 
 logger = logging.getLogger(__name__)
 

--- a/src/qallm/verification/test_persistence.py
+++ b/src/qallm/verification/test_persistence.py
@@ -34,7 +34,6 @@ for the session.
 
 from __future__ import annotations
 
-import dataclasses
 import json
 import logging
 from dataclasses import asdict, dataclass, field

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -214,15 +214,19 @@ def _wire_collaborators(
         return _stub_judge_verdict(outcome)
     orch.judge.decide.side_effect = _next_judge
 
-    # Wrap _run_round to reset unit_idx and advance repair_round_idx
-    # between rounds. Baseline (round 0) is run by _run_baseline_for_unit
-    # one unit at a time, not by _run_round; baseline_idx tracks that.
+    # Wrap _run_round to reset unit_idx between rounds and advance
+    # repair_round_idx between *repair* rounds. The baseline (round 0) now
+    # flows through _run_round too (the unified _process_unit path), so we
+    # must not treat it as a repair round: reset unit_idx for every round,
+    # but only advance repair_round_idx once we are past the baseline.
     real_run_round = orch._run_round
 
     def _wrapped_run_round(inputs):
         state["unit_idx"] = 0
+        is_baseline = orch.current_round == 0
         out = real_run_round(inputs)
-        state["repair_round_idx"] += 1
+        if not is_baseline:
+            state["repair_round_idx"] += 1
         return out
     orch._run_round = _wrapped_run_round
 


### PR DESCRIPTION
**1. refactor(api):** split the api/main.py god-file
1040 -> 116 lines. api/core.py (app, session store, model catalog, helpers, logging) + six stage-based api/routers/ modules; main.py is a thin assembler. All 32 routes register identically. Fixed two latent bugs the split exposed (a sessions name collision, a sample-data path).
2. refactor(orchestrator) — extract state/progress dataclasses
851 -> 733 lines. Moved the state types into orchestrator_models.py. Removed 133 unused imports across the new router modules.
**3. feat(profiles):** a real FAIR4RS profile
A second runnable quality model (not a stub), validating the selector's generality. Two available profiles (EVERSE + FAIR4RS) plus ISO/IEC 25010 as roadmap; frontend renders both with no code change.
**4. feat(cli):** observability output
CLI parity with the web audit view: per-round improvement audit always printed, --show-transcript lists every LLM call. Full prompt text stays in transcript.json.
**5. refactor(orchestrator):** unify baseline and repair rounds  ← NEW
The baseline (round 0) was a separate method (_run_baseline_for_unit) duplicating the analyse/verify/evaluate/persist sequence of a repair round. Now there is one path: _process_unit handles every round, with round 0 differing only in three explicit branches (no repair via a named _identity_repair helper; no judge/unconditional accept; no improvement report). run() dropped its special-case baseline loop; _run_round is a thin iterator. 733 -> 685 lines. The only test change was the loop harness, which had assumed baseline bypassed _run_round.
Note verified during this work: the baseline does write a full bundle (static.json, verification.json, profile.json, transcript.json) under round_00. If a report ever showed an empty baseline, that is a UI display gap or an older run, not missing backend data, worth a separate look at the UI's baseline rendering.