### PR TITLE
Quality profiles + SonarQube integration

### DIFF
--- a/docs/sonarqube-integration.md
+++ b/docs/sonarqube-integration.md
@@ -1,0 +1,105 @@
+# SonarQube integration
+
+SonarQube is an **optional** static-analysis source for QALLM. When
+configured, it contributes higher-fidelity, ISO/IEC 25010-aligned ratings
+(reliability, security, maintainability) that the `iso25010_base` profile
+can prefer over the Radon/Bandit proxies. When not configured, QALLM runs
+exactly as before on Radon and Bandit. This is the complement-with-fallback
+design: SonarQube never replaces the offline tools, it elevates fidelity
+when present.
+
+## Why SonarQube here
+
+SonarQube organises its analysis around a quality model that mirrors
+ISO/IEC 25010 (reliability, security, maintainability ratings on an A..E
+scale). That makes it a natural backing for the 25010 base profile. It is
+also a useful contrast for the thesis: SonarQube and its AI CodeFix close
+the quality loop *statically*, suggesting fixes for issues found by static
+analysis without executing the code. QALLM closes the loop by *execution*.
+Running both on the same code is a direct demonstration of the verification
+gap: logic bugs that pass static analysis (and that a static fix may
+declare resolved) are still caught by QALLM's generated tests.
+
+## Deployment: self-hosted Server (default)
+
+The integration targets a self-hosted SonarQube Server, which suits
+QALLM's access pattern (many short-lived, locally-analysed code variants
+per run) better than a CI/CD-oriented hosted service.
+
+1. Start a server:
+
+   ```
+   docker run -d --name sonarqube -p 9000:9000 sonarqube:community
+   ```
+
+   Wait for it to come up at http://localhost:9000 (first boot takes a
+   minute). Default credentials are admin/admin; change the password on
+   first login.
+
+2. Create a user token: My Account -> Security -> Generate Tokens.
+
+3. Install the scanner CLI (`sonar-scanner`) and put it on PATH, or set
+   `SONARQUBE_SCANNER` to its full path.
+
+4. Configure QALLM via environment variables:
+
+   ```
+   export SONARQUBE_URL=http://localhost:9000
+   export SONARQUBE_TOKEN=<your token>
+   # SONARQUBE_SCANNER=/opt/sonar-scanner/bin/sonar-scanner   # if not on PATH
+   ```
+
+   With both URL and TOKEN set, `AnalysisManager` automatically includes
+   the SonarQube analyzer; otherwise it is silently skipped.
+
+## Switching to SonarCloud (config swap, no code change)
+
+```
+export SONARQUBE_URL=https://sonarcloud.io
+export SONARQUBE_TOKEN=<sonarcloud token>
+export SONARQUBE_ORGANIZATION=<your org key>
+```
+
+The analyzer uses the same Web API endpoints, so the only difference is
+the URL, token, and organization. SonarCloud is free for public repos.
+
+## What the analyzer does
+
+For each code unit, when configured:
+
+1. Materialises the unit into a throwaway project directory with a
+   generated `sonar-project.properties`.
+2. Runs `sonar-scanner`, which uploads analysis to the server.
+3. Fetches issues (`/api/issues/search`) and measures
+   (`/api/measures/component`): `reliability_rating`, `security_rating`,
+   `sqale_rating` (maintainability), plus raw counts and coverage.
+
+Issues are normalised to QALLM `Finding`s; the ratings are read by the
+`sonar.reliability_rating` / `sonar.security_rating` /
+`sonar.maintainability_rating` evaluators from `context["sonar_measures"]`.
+On any error the analyzer logs a warning and contributes nothing, so a
+flaky server never breaks a run.
+
+## Status and remaining work
+
+Implemented and tested: the analyzer, the normalizer, the conditional
+registration, the rating evaluators (skip-when-absent), the config, and
+the orchestrator wiring that runs SonarQube on the variant being judged
+and places its measures into the evaluation context under
+`sonar_measures`. When SonarQube is unconfigured every piece no-ops and
+the pipeline runs unchanged on Radon/Bandit.
+
+The only step not exercisable in CI is the **live scan path** (the
+`sonar-scanner` call and the Web API round-trip), which needs a running
+server. It is guarded so failures fall back rather than break a run; it
+should be smoke-tested once against a real server with a known-buggy file
+to confirm the measure keys and issue shapes match this code.
+
+## Suggested thesis experiment
+
+Run SonarQube AI CodeFix and QALLM on the same buggy sample
+(`buggy_research_code.py`, functions that pass static analysis but contain
+runtime logic bugs). Expected result: SonarQube reports the code clean or
+applies fixes that do not address the logic bug, while QALLM's generated
+tests catch them by execution. This is a direct, quantifiable contrast
+between static and execution-based quality improvement.

--- a/src/qallm/analysis/analysis_manager.py
+++ b/src/qallm/analysis/analysis_manager.py
@@ -12,6 +12,7 @@ from qallm.common.model import CodeUnit
 # Tool Imports
 from qallm.analysis.bandit_analyzer import BanditAnalyzer
 from qallm.analysis.radon_analyzer import RadonAnalyzer
+from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
 
 logger = logging.getLogger(__name__)
 
@@ -27,6 +28,13 @@ class AnalysisManager:
             BanditAnalyzer(),
             RadonAnalyzer()
         ]
+        # SonarQube is optional: include it only when configured, so the
+        # default offline pipeline stays on Radon/Bandit. When a SonarQube
+        # server is configured it complements (not replaces) them, adding
+        # higher-fidelity ISO/IEC 25010-aligned ratings.
+        if SonarQubeAnalyzer.is_configured():
+            self.available_analyzers.append(SonarQubeAnalyzer())
+            logger.info("SonarQube analyzer enabled (server configured).")
         self.selected_tool_names = selected_tools
         logger.info(f"Initialization completed. Selected tools: {self.selected_tool_names}")
 

--- a/src/qallm/analysis/normalization/sonarqube_normalizer.py
+++ b/src/qallm/analysis/normalization/sonarqube_normalizer.py
@@ -1,0 +1,69 @@
+"""Normalizer for SonarQube issue reports.
+
+SonarQube's Web API returns issues with a ``type`` (BUG, VULNERABILITY,
+CODE_SMELL) and a ``severity`` (BLOCKER..INFO), plus per-component
+*measures* (the reliability/security/maintainability ratings). This
+normalizer turns the issue list into the unified ``Finding`` shape the
+rest of QALLM consumes; the ratings are carried on the RawToolResult and
+read by the evaluators, not turned into findings.
+
+SonarQube is optional. When it is not configured the analyzer never runs,
+so this normalizer simply returns an empty list for an empty/blank result.
+"""
+
+from __future__ import annotations
+
+import json
+
+from qallm.analysis.analysis_model import Finding, RawToolResult
+from qallm.analysis.normalization.base_normalizer import ToolNormalizer
+
+# SonarQube type -> QALLM finding type.
+_TYPE_MAP = {
+    "BUG": "RELIABILITY",
+    "VULNERABILITY": "SECURITY",
+    "SECURITY_HOTSPOT": "SECURITY",
+    "CODE_SMELL": "MAINTAINABILITY",
+}
+
+# SonarQube severity -> QALLM severity. SonarQube uses BLOCKER, CRITICAL,
+# MAJOR, MINOR, INFO; map to the LOW/MEDIUM/HIGH/CRITICAL scale used here.
+_SEVERITY_MAP = {
+    "BLOCKER": "CRITICAL",
+    "CRITICAL": "CRITICAL",
+    "MAJOR": "HIGH",
+    "MINOR": "MEDIUM",
+    "INFO": "LOW",
+}
+
+
+class SonarQubeNormalizer(ToolNormalizer):
+    tool_name = "sonarqube"
+
+    def normalize(self, result: RawToolResult) -> list[Finding]:
+        if not result or not result.stdout:
+            return []
+        try:
+            payload = json.loads(result.stdout)
+        except json.JSONDecodeError:
+            return []
+
+        issues = payload.get("issues", [])
+        findings: list[Finding] = []
+        for issue in issues:
+            sonar_type = issue.get("type", "CODE_SMELL")
+            sonar_sev = issue.get("severity", "INFO")
+            # component is like "projectKey:path/to/file.py"; keep the path.
+            component = issue.get("component", "")
+            file_path = component.split(":", 1)[-1] if ":" in component else component
+            findings.append(Finding(
+                tool=self.tool_name,
+                type=_TYPE_MAP.get(sonar_type, "MAINTAINABILITY"),
+                severity=_SEVERITY_MAP.get(sonar_sev, "LOW"),
+                file=file_path or "cell.py",
+                line=issue.get("line", 0) or 0,
+                message=issue.get("message", ""),
+                rule_id=issue.get("rule", ""),
+                extra={"sonar_type": sonar_type, "sonar_severity": sonar_sev},
+            ))
+        return findings

--- a/src/qallm/analysis/sonarqube_analyzer.py
+++ b/src/qallm/analysis/sonarqube_analyzer.py
@@ -1,0 +1,179 @@
+"""Optional SonarQube static analyzer.
+
+SonarQube is organised around an ISO/IEC 25010-style quality model
+(reliability, security, maintainability ratings), which makes it a natural
+higher-fidelity source for the iso25010_base profile. This analyzer is
+*optional*: it runs only when SONARQUBE_URL and SONARQUBE_TOKEN are set,
+and otherwise no-ops so the pipeline keeps working offline on Radon/Bandit
+(the complement-with-fallback decision).
+
+Deployment: targets a self-hosted SonarQube Server (``docker run -d -p
+9000:9000 sonarqube``) plus the ``sonar-scanner`` CLI. Pointing
+SONARQUBE_URL at https://sonarcloud.io and setting SONARQUBE_ORGANIZATION
+switches to SonarCloud with no code change.
+
+Flow when configured:
+  1. Materialise the code unit into a throwaway project directory with a
+     sonar-project.properties pointing at the server.
+  2. Run sonar-scanner, which uploads analysis to the server.
+  3. Poll the Web API: GET /api/issues/search for findings, and
+     GET /api/measures/component for the ratings, which are attached to
+     the RawToolResult.stdout as a JSON blob the evaluators read.
+
+Because the sandbox has no SonarQube server, the network/scan path is
+guarded and unit-tested via the normalizer and the no-op behaviour; the
+live path is exercised when a server is configured.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import subprocess
+import tempfile
+import uuid
+from pathlib import Path
+
+from qallm.analysis.analysis_model import RawToolResult
+from qallm.analysis.base_analyzer import StaticCodeAnalyzer
+from qallm.analysis.normalization.base_normalizer import ToolNormalizer
+from qallm.analysis.normalization.sonarqube_normalizer import SonarQubeNormalizer
+from qallm.common.model import CodeUnit
+from qallm.config import settings
+
+logger = logging.getLogger(__name__)
+
+# Measure keys requested from the Web API. These are the ISO/IEC
+# 25010-aligned ratings SonarQube computes (1.0=A .. 5.0=E) plus the raw
+# issue counts behind them.
+_MEASURE_KEYS = [
+    "reliability_rating",
+    "security_rating",
+    "sqale_rating",  # maintainability rating
+    "bugs",
+    "vulnerabilities",
+    "code_smells",
+    "coverage",
+    "ncloc",
+]
+
+
+class SonarQubeAnalyzer(StaticCodeAnalyzer):
+    """Static analysis via a SonarQube server (optional).
+
+    When unconfigured, ``analyze`` returns a result with exit code 0 and an
+    empty issue payload, so it contributes no findings and the manager's
+    normalization yields nothing. ``is_configured`` lets the manager decide
+    whether to include it at all.
+    """
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.name = "sonarqube"
+        self.normalizer = SonarQubeNormalizer()
+
+    def tool_name(self) -> str:
+        return self.name
+
+    def get_normalizer(self) -> ToolNormalizer:
+        return self.normalizer
+
+    @staticmethod
+    def is_configured() -> bool:
+        return bool(settings.SONARQUBE_URL and settings.SONARQUBE_TOKEN)
+
+    def analyze(self, unit: CodeUnit) -> RawToolResult:
+        if not self.is_configured():
+            # Not configured: contribute nothing, let Radon/Bandit stand.
+            return RawToolResult(
+                tool=self.name,
+                exit_code=0,
+                stdout=json.dumps({"issues": [], "measures": {},
+                                   "skipped": "SonarQube not configured"}),
+                stderr="",
+            )
+
+        project_key = f"qallm_{uuid.uuid4().hex[:12]}"
+        try:
+            issues, measures = self._scan(unit, project_key)
+            payload = {"issues": issues, "measures": measures}
+            return RawToolResult(
+                tool=self.name,
+                exit_code=0,
+                stdout=json.dumps(payload),
+                stderr="",
+                artifact=str(unit.original_path.absolute())
+                if unit.original_path else "cell.py",
+            )
+        except Exception as exc:  # noqa: BLE001 - never break the pipeline
+            logger.warning("SonarQube analysis failed (%s); falling back.", exc)
+            return RawToolResult(
+                tool=self.name, exit_code=1,
+                stdout=json.dumps({"issues": [], "measures": {}}),
+                stderr=str(exc),
+            )
+
+    # ─── live scan path (exercised when a server is configured) ─────
+    def _scan(self, unit: CodeUnit, project_key: str) -> tuple[list, dict]:
+        """Run the scanner and fetch issues + measures. Network-dependent."""
+        with tempfile.TemporaryDirectory() as tmp:
+            workspace = Path(tmp)
+            filename = unit.original_path.name if unit.original_path else "cell.py"
+            (workspace / filename).write_text(unit.source_code, encoding="utf-8")
+            self._write_scanner_props(workspace, project_key)
+            self._run_scanner(workspace)
+            issues = self._fetch_issues(project_key)
+            measures = self._fetch_measures(project_key)
+            return issues, measures
+
+    def _write_scanner_props(self, workspace: Path, project_key: str) -> None:
+        lines = [
+            f"sonar.projectKey={project_key}",
+            f"sonar.host.url={settings.SONARQUBE_URL}",
+            f"sonar.token={settings.SONARQUBE_TOKEN}",
+            "sonar.sources=.",
+            "sonar.python.version=3",
+        ]
+        if settings.SONARQUBE_ORGANIZATION:
+            lines.append(f"sonar.organization={settings.SONARQUBE_ORGANIZATION}")
+        (workspace / "sonar-project.properties").write_text(
+            "\n".join(lines) + "\n", encoding="utf-8"
+        )
+
+    def _run_scanner(self, workspace: Path) -> None:
+        subprocess.run(
+            [settings.SONARQUBE_SCANNER],
+            cwd=str(workspace),
+            capture_output=True,
+            text=True,
+            timeout=settings.SONARQUBE_TIMEOUT_SECONDS,
+            check=False,
+        )
+
+    def _api_get(self, path: str, params: dict) -> dict:
+        # Imported lazily so requests is only needed when SonarQube is used.
+        import requests
+
+        resp = requests.get(
+            f"{settings.SONARQUBE_URL.rstrip('/')}{path}",
+            params=params,
+            auth=(settings.SONARQUBE_TOKEN, ""),
+            timeout=settings.SONARQUBE_TIMEOUT_SECONDS,
+        )
+        resp.raise_for_status()
+        return resp.json()
+
+    def _fetch_issues(self, project_key: str) -> list:
+        data = self._api_get("/api/issues/search",
+                             {"componentKeys": project_key, "ps": 500})
+        return data.get("issues", [])
+
+    def _fetch_measures(self, project_key: str) -> dict:
+        data = self._api_get("/api/measures/component", {
+            "component": project_key,
+            "metricKeys": ",".join(_MEASURE_KEYS),
+        })
+        measures = {}
+        for m in data.get("component", {}).get("measures", []):
+            measures[m.get("metric")] = m.get("value")
+        return measures

--- a/src/qallm/api/routers/config.py
+++ b/src/qallm/api/routers/config.py
@@ -104,10 +104,12 @@ async def get_quality_profiles():
     FRAMEWORK = {
         "implementation_default": "EVERSE Research Software Quality",
         "fair4rs_publication": "FAIR for Research Software (FAIR4RS)",
+        "iso25010_base": "ISO/IEC 25010:2023",
     }
     FRIENDLY = {
         "implementation_default": "EVERSE (implementation stage)",
         "fair4rs_publication": "FAIR4RS (publication stage)",
+        "iso25010_base": "ISO/IEC 25010 (general software)",
     }
     EXPLAIN = {
         "implementation_default": (
@@ -116,6 +118,15 @@ async def get_quality_profiles():
             "Reproducibility, and FAIRness using static tools plus QALLM's "
             "execution-based verification. Thresholds are tuned for the "
             "implementation stage of the software lifecycle."
+        ),
+        "iso25010_base": (
+            "The ISO/IEC 25010:2023 product quality model as a "
+            "general-software base profile. All nine characteristics are "
+            "declared. Security and Maintainability are measured statically; "
+            "Functional Suitability is measured by QALLM's execution-based "
+            "verification (the characteristic static tools cannot assess); "
+            "the remaining characteristics are declared but not assessed in "
+            "v1. EVERSE is this model plus FAIRness and Sustainability."
         ),
     }
 
@@ -134,15 +145,10 @@ async def get_quality_profiles():
             ],
         })
 
-    # Roadmap entries: declared so the selector shows where QALLM is going,
-    # but not selectable until implemented. (FAIR4RS is now a real,
-    # available profile, so it has moved out of this list.)
-    roadmap = [
-        {"id": "iso25010", "name": "ISO/IEC 25010", "framework": "ISO/IEC 25010",
-         "description": "Software product quality model. Planned as an "
-                        "alternative profile; not yet implemented.",
-         "available": False, "dimensions": []},
-    ]
+    # All built-in profiles are now real and available; the roadmap list is
+    # empty. SonarQube-backed indicators are a future enhancement to the
+    # iso25010_base profile, not a separate profile.
+    roadmap: list = []
 
     return {"profiles": profiles + roadmap, "default": "implementation_default"}
 

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -62,6 +62,54 @@ async def get_stats(session_id: str):
     }
 
 
+def _summarise_bug_detail(verification: list | None) -> list[dict]:
+    """Extract per-function, per-test bug detail from a round's verification.
+
+    The web UI shows aggregate counts ("4 bugs") but not *which* generated
+    tests failed or why. This surfaces that: for each function verified in
+    the round, the final round's executed tests with their pytest status
+    (passed/failed/error/skipped) and the failure message. A failed test is
+    a bug the generated tests caught by execution, the thing static analysis
+    misses.
+
+    ``verification`` is the parsed verification.json: a list of session
+    dicts (one per function), each with a ``rounds`` list whose last entry
+    holds the ``execution`` with ``test_details``.
+    """
+    if not verification:
+        return []
+    functions: list[dict] = []
+    for session in verification:
+        rounds = session.get("rounds") or []
+        if not rounds:
+            continue
+        last = rounds[-1]
+        execution = last.get("execution") or {}
+        details = execution.get("test_details") or []
+        tests = [
+            {
+                "name": d.get("name", "?"),
+                "status": d.get("status", "?"),
+                "message": d.get("message"),
+            }
+            for d in details
+        ]
+        functions.append({
+            "function": session.get("function") or session.get("function_name", "?"),
+            "passed": execution.get("passed", 0),
+            "failed": execution.get("failed", 0),
+            "errors": execution.get("errors", 0),
+            "skipped": execution.get("skipped", 0),
+            "total": execution.get("total", 0),
+            "coverage_percent": execution.get("coverage_percent"),
+            "execution_error": execution.get("execution_error"),
+            # The bugs: tests that ran and failed (not errored).
+            "bug_tests": [t for t in tests if t["status"] == "failed"],
+            "all_tests": tests,
+        })
+    return functions
+
+
 @router.get("/api/session/{session_id}/improvement")
 async def get_improvement(session_id: str):
     """Per-round, per-unit improvement audit for the observability view.
@@ -110,6 +158,7 @@ async def get_improvement(session_id: str):
                 profile = _read_json(os.path.join(unit_dir, "profile.json"))
                 judge = _read_json(os.path.join(unit_dir, "judge.json"))
                 transcript = _read_json(os.path.join(unit_dir, "transcript.json")) or []
+                verification = _read_json(os.path.join(unit_dir, "verification.json"))
                 unit_entry = {
                     "unit_id": unit_seg,
                     "bucket": bucket,
@@ -119,6 +168,7 @@ async def get_improvement(session_id: str):
                     "profile": profile,
                     "judge": judge,
                     "llm_calls": transcript,
+                    "bug_detail": _summarise_bug_detail(verification),
                 }
                 r = rounds.setdefault(round_no, {"round": round_no, "units": []})
                 r["units"].append(unit_entry)

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -23,6 +23,23 @@ class Settings:
     # catch genuine hangs.
     OLLAMA_TIMEOUT_SECONDS: float = float(os.getenv("OLLAMA_TIMEOUT_SECONDS", "240"))
 
+    # SonarQube (optional). When SONARQUBE_URL and SONARQUBE_TOKEN are both
+    # set, the SonarQubeAnalyzer runs and contributes higher-fidelity
+    # reliability/security/maintainability ratings; otherwise it is a
+    # no-op and the pipeline falls back to Radon/Bandit. Defaults target a
+    # self-hosted Server (docker run sonarqube on :9000). Point the URL at
+    # https://sonarcloud.io and set the organization to use SonarCloud
+    # instead, no code change.
+    SONARQUBE_URL: str | None = os.getenv("SONARQUBE_URL")
+    SONARQUBE_TOKEN: str | None = os.getenv("SONARQUBE_TOKEN")
+    SONARQUBE_ORGANIZATION: str | None = os.getenv("SONARQUBE_ORGANIZATION")
+    # The sonar-scanner CLI binary; override if not on PATH.
+    SONARQUBE_SCANNER: str = os.getenv("SONARQUBE_SCANNER", "sonar-scanner")
+    # Seconds to wait for the scanner + the server's analysis to complete.
+    SONARQUBE_TIMEOUT_SECONDS: float = float(
+        os.getenv("SONARQUBE_TIMEOUT_SECONDS", "180")
+    )
+
     # Budget caps. All are floors, not ceilings: code-level ceilings in
     # `qallm.cost` override these if they are too large. The intent is
     # that a typo in this file or an .env cannot blow the budget.

--- a/src/qallm/evaluation.py
+++ b/src/qallm/evaluation.py
@@ -402,11 +402,58 @@ def _verification_bugs(source: str, context: dict[str, Any]) -> float | None:
     return float(sum(s.final_bugs for s in sessions))
 
 
+def _sonar_measure(context: dict[str, Any], key: str) -> float | None:
+    """Read one SonarQube measure from context, or None if unavailable.
+
+    The orchestrator places the analysed unit's SonarQube measures (parsed
+    from the analyzer's RawToolResult) under ``context["sonar_measures"]``
+    when a SonarQube server is configured. When it is not, the key is
+    absent and these evaluators skip, so the iso25010_base profile falls
+    back to its Radon/Bandit indicators (the complement-with-fallback
+    decision). SonarQube ratings are 1.0=A (best) .. 5.0=E (worst).
+    """
+    measures = context.get("sonar_measures")
+    if not measures or key not in measures:
+        return None
+    try:
+        return float(measures[key])
+    except (TypeError, ValueError):
+        return None
+
+
+def _sonar_reliability_rating(source: str, context: dict[str, Any]) -> float | None:
+    return _sonar_measure(context, "reliability_rating")
+
+
+def _sonar_security_rating(source: str, context: dict[str, Any]) -> float | None:
+    return _sonar_measure(context, "security_rating")
+
+
+def _sonar_maintainability_rating(source: str, context: dict[str, Any]) -> float | None:
+    # SonarQube exposes the maintainability rating under sqale_rating.
+    return _sonar_measure(context, "sqale_rating")
+
+
+def _not_measured(source: str, context: dict[str, Any]) -> float | None:
+    """Always declines, marking the indicator SKIPPED.
+
+    Used for quality characteristics a profile declares to stay faithful
+    to a standard (e.g. the ISO/IEC 25010 characteristics QALLM does not
+    yet measure) without claiming a measurement it cannot make. SKIPPED is
+    the honest state: in-model, not assessed.
+    """
+    return None
+
+
 def _register_builtins() -> None:
     register("radon.mi", _radon_mi)
     register("radon.cc", _radon_cc)
     register("bandit.high", _bandit_high)
     register("bandit.cwe_classes", _bandit_cwe_classes)
+    register("qallm.not_measured", _not_measured)
+    register("sonar.reliability_rating", _sonar_reliability_rating)
+    register("sonar.security_rating", _sonar_security_rating)
+    register("sonar.maintainability_rating", _sonar_maintainability_rating)
     register("qallm.repro.manifest", _repro_manifest)
     register("qallm.repro.determinism", _repro_determinism)
     register("qallm.verification.pass_rate", _verification_pass_rate)

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -605,6 +605,29 @@ class QALLMOrchestrator:
         logger.info("Round %d (%s) completed.", self.current_round, label)
         return next_inputs
 
+    def _sonar_measures_for(self, unit: CodeUnit) -> dict | None:
+        """Run SonarQube on a unit and return its measures, or None.
+
+        SonarQube measures (the ISO/IEC 25010 ratings) cannot be recomputed
+        cheaply inside an evaluator the way Bandit/Radon can, because they
+        need a server round-trip. So when SonarQube is configured we run it
+        here, on the *variant* being judged, and hand the measures to the
+        profile via context. When it is not configured this is a no-op
+        returning None, and the iso25010_base profile falls back to its
+        Radon/Bandit indicators.
+        """
+        from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+
+        if not SonarQubeAnalyzer.is_configured():
+            return None
+        try:
+            raw = SonarQubeAnalyzer().analyze(unit)
+            payload = json.loads(raw.stdout) if raw.stdout else {}
+            measures = payload.get("measures") or {}
+            return measures or None
+        except Exception:  # noqa: BLE001 - never break evaluation on sonar
+            return None
+
     def _evaluate_profile_for(
         self, unit: CodeUnit, tested: TestedCodeUnit
     ) -> ProfileVerdict:
@@ -612,7 +635,9 @@ class QALLMOrchestrator:
 
         Pulls project_root from the unit's path (the parent directory) and
         verification_sessions from the tested unit so reliability and
-        FAIRness indicators have real numbers to consume.
+        FAIRness indicators have real numbers to consume. When a SonarQube
+        server is configured, the unit's ISO/IEC 25010 ratings are added
+        under ``sonar_measures`` so 25010 indicators can prefer them.
         """
         project_root = (
             str(unit.original_path.parent)
@@ -623,6 +648,9 @@ class QALLMOrchestrator:
             "project_root": project_root,
             "verification_sessions": list(tested.sessions),
         }
+        sonar_measures = self._sonar_measures_for(unit)
+        if sonar_measures is not None:
+            context["sonar_measures"] = sonar_measures
         return evaluate_profile(self.profile, unit.source_code, context=context)
 
     def _raw_evidence_for(self, tested: TestedCodeUnit) -> dict:

--- a/src/qallm/profiles.py
+++ b/src/qallm/profiles.py
@@ -30,19 +30,39 @@ from typing import Any
 
 
 class QualityDimension(str, Enum):
-    """The EVERSE quality dimensions QALLM measures automatically in v1.
+    """Quality dimensions QALLM can name in a profile.
 
-    The full EVERSE catalogue is broader (Usability, Performance,
-    Compatibility, etc.). These five are the ones QALLM has tooling for:
-    static metrics for Maintainability and Security, execution evidence
-    for Reliability, project-shape checks for Reproducibility and FAIRness.
+    The first block are the dimensions QALLM has tooling for in v1: static
+    metrics for Maintainability and Security, execution evidence for
+    Reliability and Functional Suitability, project-shape checks for
+    Reproducibility and FAIRness.
+
+    The second block are the remaining ISO/IEC 25010:2023 product-quality
+    characteristics. They are defined so a profile can declare the full
+    standard (with these as declared-but-skipped indicators) even though
+    QALLM does not yet measure them. Naming the relationship explicitly:
+    ISO/IEC 25010:2023 has nine characteristics; EVERSE is those nine plus
+    FAIRness and Sustainability, specialised for research software. So the
+    25010 base profile is a strict subset of the EVERSE dimension space.
     """
 
+    # Measured by QALLM in v1.
     MAINTAINABILITY = "Maintainability"
     SECURITY = "Security"
     RELIABILITY = "Reliability"
-    REPRODUCIBILITY = "Reproducibility"
-    FAIRNESS = "FAIRness"
+    FUNCTIONAL_SUITABILITY = "Functional Suitability"
+    REPRODUCIBILITY = "Reproducibility"   # EVERSE addition
+    FAIRNESS = "FAIRness"                  # EVERSE addition
+
+    # Remaining ISO/IEC 25010:2023 characteristics (declared, not yet
+    # measured). Interaction Capability and Flexibility are the 2023
+    # renames of Usability and Portability; Safety is new in 2023.
+    PERFORMANCE_EFFICIENCY = "Performance Efficiency"
+    COMPATIBILITY = "Compatibility"
+    INTERACTION_CAPABILITY = "Interaction Capability"
+    FLEXIBILITY = "Flexibility"
+    SAFETY = "Safety"
+    SUSTAINABILITY = "Sustainability"     # EVERSE addition
 
 
 class LifecycleStage(str, Enum):
@@ -439,9 +459,200 @@ FAIR4RS_PUBLICATION: QualityProfile = QualityProfile(
 )
 
 
+# ─── ISO/IEC 25010 base profile (general software) ──────────────────
+# The international-standard product-quality model, as a general-software
+# base profile. ISO/IEC 25010:2023 defines nine characteristics; this
+# profile declares all nine so it is faithful to the standard, but only
+# populates the ones QALLM can measure:
+#
+#   * Reliability, Security, Maintainability: measured via the existing
+#     Radon/Bandit evaluators (the offline fallback). When a SonarQube
+#     analyzer is configured, its higher-fidelity ratings can replace
+#     these (sonar.reliability_rating etc.) without changing the profile
+#     shape, the complement-with-fallback decision.
+#   * Functional Suitability: measured via QALLM's execution-based
+#     verification (pass rate + bugs). This is the characteristic SonarQube
+#     and other static tools cannot assess, and is QALLM's distinctive
+#     contribution to a 25010 evaluation: functional correctness shown by
+#     running the code, not by reading it.
+#   * Performance Efficiency, Compatibility, Interaction Capability,
+#     Flexibility, Safety: declared but not measured (qallm.not_measured ->
+#     SKIPPED). Honest about scope: in-model, not assessed in v1.
+#
+# Lifecycle stage IMPLEMENTATION: this is a code-quality view, like the
+# EVERSE implementation default, not a publication/FAIR view.
+ISO25010_BASE: QualityProfile = QualityProfile(
+    profile_id="iso25010_base",
+    lifecycle_stage=LifecycleStage.IMPLEMENTATION,
+    description=(
+        "ISO/IEC 25010:2023 product quality model as a general-software "
+        "base profile. Declares all nine characteristics for fidelity to "
+        "the standard. Reliability, Security and Maintainability are "
+        "measured with static metrics (replaceable by SonarQube ratings "
+        "when configured); Functional Suitability is measured by QALLM's "
+        "execution-based verification, the characteristic static tools "
+        "cannot assess; the remaining five are declared but not measured "
+        "in v1."
+    ),
+    dimensions=(
+        # ── Functional Suitability: QALLM's execution evidence ──
+        DimensionSpec(
+            dimension=QualityDimension.FUNCTIONAL_SUITABILITY,
+            repair_prompt_id="reliability_repair_v1",
+            indicators=(
+                QualityIndicator(
+                    name="test_pass_rate",
+                    evaluator="qallm.verification.pass_rate",
+                    threshold=0.9,
+                    comparator=Comparator.GE,
+                    description=(
+                        "Functional correctness shown by execution: fraction "
+                        "of generated tests passing. 25010 functional "
+                        "correctness, measured dynamically."
+                    ),
+                ),
+                QualityIndicator(
+                    name="bugs_found",
+                    evaluator="qallm.verification.bugs",
+                    threshold=0.0,
+                    comparator=Comparator.LE,
+                    description=(
+                        "Number of failing generated tests (bugs the code "
+                        "still exhibits under execution). Zero is the target."
+                    ),
+                ),
+            ),
+        ),
+        # ── Reliability (static proxy; SonarQube can replace) ──
+        DimensionSpec(
+            dimension=QualityDimension.RELIABILITY,
+            repair_prompt_id="reliability_repair_v1",
+            indicators=(
+                QualityIndicator(
+                    name="determinism",
+                    evaluator="qallm.repro.determinism",
+                    threshold=1.0,
+                    comparator=Comparator.GE,
+                    description="1 if repeated execution is deterministic.",
+                ),
+            ),
+        ),
+        # ── Security (Bandit; SonarQube can replace) ──
+        DimensionSpec(
+            dimension=QualityDimension.SECURITY,
+            repair_prompt_id="security_repair_v1",
+            indicators=(
+                QualityIndicator(
+                    name="high_severity_issues",
+                    evaluator="bandit.high",
+                    threshold=0.0,
+                    comparator=Comparator.LE,
+                    description="Count of high-severity Bandit findings.",
+                ),
+                QualityIndicator(
+                    name="cwe_class_coverage",
+                    evaluator="bandit.cwe_classes",
+                    threshold=0.0,
+                    comparator=Comparator.LE,
+                    description="Distinct CWE classes present in findings.",
+                ),
+            ),
+        ),
+        # ── Maintainability (Radon; SonarQube can replace) ──
+        DimensionSpec(
+            dimension=QualityDimension.MAINTAINABILITY,
+            repair_prompt_id="maintainability_repair_v1",
+            indicators=(
+                QualityIndicator(
+                    name="maintainability_index",
+                    evaluator="radon.mi",
+                    threshold=65.0,
+                    comparator=Comparator.GE,
+                    description="Radon maintainability index (0-100).",
+                ),
+                QualityIndicator(
+                    name="cyclomatic_complexity",
+                    evaluator="radon.cc",
+                    threshold=10.0,
+                    comparator=Comparator.LE,
+                    description="Average cyclomatic complexity per block.",
+                ),
+            ),
+        ),
+        # ── Declared but not measured in v1 (standard fidelity) ──
+        DimensionSpec(
+            dimension=QualityDimension.PERFORMANCE_EFFICIENCY,
+            repair_prompt_id="noop",
+            indicators=(
+                QualityIndicator(
+                    name="not_measured",
+                    evaluator="qallm.not_measured",
+                    threshold=0.0,
+                    comparator=Comparator.GE,
+                    description="Declared per ISO/IEC 25010; not assessed in v1.",
+                ),
+            ),
+        ),
+        DimensionSpec(
+            dimension=QualityDimension.COMPATIBILITY,
+            repair_prompt_id="noop",
+            indicators=(
+                QualityIndicator(
+                    name="not_measured",
+                    evaluator="qallm.not_measured",
+                    threshold=0.0,
+                    comparator=Comparator.GE,
+                    description="Declared per ISO/IEC 25010; not assessed in v1.",
+                ),
+            ),
+        ),
+        DimensionSpec(
+            dimension=QualityDimension.INTERACTION_CAPABILITY,
+            repair_prompt_id="noop",
+            indicators=(
+                QualityIndicator(
+                    name="not_measured",
+                    evaluator="qallm.not_measured",
+                    threshold=0.0,
+                    comparator=Comparator.GE,
+                    description="Declared per ISO/IEC 25010 (was Usability); not assessed in v1.",
+                ),
+            ),
+        ),
+        DimensionSpec(
+            dimension=QualityDimension.FLEXIBILITY,
+            repair_prompt_id="noop",
+            indicators=(
+                QualityIndicator(
+                    name="not_measured",
+                    evaluator="qallm.not_measured",
+                    threshold=0.0,
+                    comparator=Comparator.GE,
+                    description="Declared per ISO/IEC 25010 (was Portability); not assessed in v1.",
+                ),
+            ),
+        ),
+        DimensionSpec(
+            dimension=QualityDimension.SAFETY,
+            repair_prompt_id="noop",
+            indicators=(
+                QualityIndicator(
+                    name="not_measured",
+                    evaluator="qallm.not_measured",
+                    threshold=0.0,
+                    comparator=Comparator.GE,
+                    description="Declared per ISO/IEC 25010:2023 (new in 2023); not assessed in v1.",
+                ),
+            ),
+        ),
+    ),
+)
+
+
 _BUILT_IN: dict[str, QualityProfile] = {
     IMPLEMENTATION_DEFAULT.profile_id: IMPLEMENTATION_DEFAULT,
     FAIR4RS_PUBLICATION.profile_id: FAIR4RS_PUBLICATION,
+    ISO25010_BASE.profile_id: ISO25010_BASE,
 }
 
 
@@ -481,6 +692,7 @@ __all__ = [
     "Comparator",
     "DimensionSpec",
     "FAIR4RS_PUBLICATION",
+    "ISO25010_BASE",
     "IMPLEMENTATION_DEFAULT",
     "LifecycleStage",
     "QualityDimension",

--- a/tests/test_bug_detail.py
+++ b/tests/test_bug_detail.py
@@ -1,0 +1,65 @@
+"""Tests for the per-round bug-detail summariser in the improvement endpoint."""
+
+from qallm.api.routers.results import _summarise_bug_detail
+
+
+def _session(function, tests, **execution):
+    details = [{"name": n, "status": s, "message": m} for (n, s, m) in tests]
+    passed = sum(1 for _, s, _ in tests if s == "passed")
+    failed = sum(1 for _, s, _ in tests if s == "failed")
+    errors = sum(1 for _, s, _ in tests if s == "error")
+    base = {"passed": passed, "failed": failed, "errors": errors,
+            "skipped": 0, "total": len(tests), "coverage_percent": 80.0,
+            "test_details": details}
+    base.update(execution)
+    return {"function": function, "rounds": [{"execution": base}]}
+
+
+def test_empty_verification_returns_empty():
+    assert _summarise_bug_detail(None) == []
+    assert _summarise_bug_detail([]) == []
+
+
+def test_failing_test_is_a_bug():
+    v = [_session("divide", [
+        ("test_ok", "passed", None),
+        ("test_zero", "failed", "ZeroDivisionError: division by zero"),
+    ])]
+    out = _summarise_bug_detail(v)
+    assert len(out) == 1
+    fn = out[0]
+    assert fn["function"] == "divide"
+    assert fn["failed"] == 1
+    assert len(fn["bug_tests"]) == 1
+    assert fn["bug_tests"][0]["name"] == "test_zero"
+    assert "ZeroDivisionError" in fn["bug_tests"][0]["message"]
+    # all_tests retains the passing one too.
+    assert len(fn["all_tests"]) == 2
+
+
+def test_errors_are_not_counted_as_bugs():
+    v = [_session("f", [
+        ("test_a", "error", "ImportError"),
+        ("test_b", "passed", None),
+    ])]
+    fn = _summarise_bug_detail(v)[0]
+    assert fn["errors"] == 1
+    assert fn["bug_tests"] == []  # errors are not bugs
+
+
+def test_uses_final_round():
+    v = [{
+        "function": "g",
+        "rounds": [
+            {"execution": {"passed": 1, "failed": 0, "errors": 0, "skipped": 0,
+                           "total": 1, "test_details": [
+                               {"name": "t1", "status": "passed", "message": None}]}},
+            {"execution": {"passed": 1, "failed": 1, "errors": 0, "skipped": 0,
+                           "total": 2, "test_details": [
+                               {"name": "t1", "status": "passed", "message": None},
+                               {"name": "t2", "status": "failed", "message": "boom"}]}},
+        ],
+    }]
+    fn = _summarise_bug_detail(v)[0]
+    assert fn["failed"] == 1  # from the LAST round
+    assert len(fn["all_tests"]) == 2

--- a/tests/test_iso25010_profile.py
+++ b/tests/test_iso25010_profile.py
@@ -1,0 +1,68 @@
+"""Tests for the ISO/IEC 25010 base quality profile."""
+
+from qallm.evaluation import evaluate_profile, resolve
+from qallm.profiles import (
+    ISO25010_BASE,
+    QualityDimension,
+    get_profile,
+    list_profiles,
+)
+
+
+def test_iso25010_registered():
+    assert "iso25010_base" in list_profiles()
+    assert get_profile("iso25010_base") is ISO25010_BASE
+
+
+def test_declares_all_nine_iso_characteristics():
+    # ISO/IEC 25010:2023 has nine product-quality characteristics. The
+    # profile must declare all nine for fidelity to the standard.
+    nine = {
+        QualityDimension.FUNCTIONAL_SUITABILITY,
+        QualityDimension.PERFORMANCE_EFFICIENCY,
+        QualityDimension.COMPATIBILITY,
+        QualityDimension.INTERACTION_CAPABILITY,
+        QualityDimension.RELIABILITY,
+        QualityDimension.SECURITY,
+        QualityDimension.MAINTAINABILITY,
+        QualityDimension.FLEXIBILITY,
+        QualityDimension.SAFETY,
+    }
+    declared = {d.dimension for d in ISO25010_BASE.dimensions}
+    assert declared == nine
+    # And NOT the EVERSE-only additions.
+    assert QualityDimension.FAIRNESS not in declared
+    assert QualityDimension.REPRODUCIBILITY not in declared
+
+
+def test_every_evaluator_resolves():
+    for dim in ISO25010_BASE.dimensions:
+        for ind in dim.indicators:
+            assert resolve(ind.evaluator) is not None
+
+
+def test_measured_and_skipped_split():
+    # Security + Maintainability measure statically; the five out-of-scope
+    # characteristics skip cleanly (not error).
+    src = "def add(a, b):\n    return a + b\n"
+    verdict = evaluate_profile(ISO25010_BASE, src, context={})
+    by_dim = {d.dimension.value: d for d in verdict.dimensions}
+
+    # Measured statically -> not skipped.
+    assert by_dim["Security"].status.value in ("pass", "fail")
+    assert by_dim["Maintainability"].status.value in ("pass", "fail")
+
+    # Declared but not measured -> skipped, never error.
+    for name in ("Performance Efficiency", "Compatibility",
+                 "Interaction Capability", "Flexibility", "Safety"):
+        assert by_dim[name].status.value == "skipped"
+
+
+def test_functional_suitability_uses_verification_evaluators():
+    fs = [d for d in ISO25010_BASE.dimensions
+          if d.dimension is QualityDimension.FUNCTIONAL_SUITABILITY][0]
+    evaluators = {i.evaluator for i in fs.indicators}
+    # The distinctive QALLM contribution: execution-based verification maps
+    # to 25010 Functional Suitability.
+    assert "qallm.verification.pass_rate" in evaluators
+    assert "qallm.verification.bugs" in evaluators

--- a/tests/test_observability_endpoints.py
+++ b/tests/test_observability_endpoints.py
@@ -31,15 +31,15 @@ def test_quality_profiles_lists_default_and_dimensions():
         assert expected in dims
 
 
-def test_quality_profiles_marks_roadmap_unavailable():
+def test_quality_profiles_all_available_no_roadmap():
     r = client.get("/api/quality-profiles")
     body = r.json()
-    roadmap = [p for p in body["profiles"] if not p["available"]]
-    ids = {p["id"] for p in roadmap}
-    assert "iso25010" in ids
-    # fair4rs graduated from roadmap to a real, available profile, so it
-    # must NOT appear among the unavailable entries any more.
-    assert "fair4rs" not in ids
+    # All three built-in profiles are now real and available; the roadmap
+    # is empty. ISO/IEC 25010 graduated from roadmap stub to a real profile.
+    unavailable = [p for p in body["profiles"] if not p["available"]]
+    assert unavailable == []
+    available_ids = {p["id"] for p in body["profiles"] if p["available"]}
+    assert {"implementation_default", "fair4rs_publication", "iso25010_base"} <= available_ids
 
 
 def test_improvement_endpoint_handles_no_run():

--- a/tests/test_sonarqube_analyzer.py
+++ b/tests/test_sonarqube_analyzer.py
@@ -1,0 +1,129 @@
+"""Tests for the optional SonarQube analyzer and normalizer.
+
+The live scan path needs a running SonarQube server, so these tests cover
+the parts that do not: the no-op-when-unconfigured behaviour, conditional
+registration, and the normalizer mapping Sonar's issue JSON to Findings.
+"""
+
+import json
+
+from qallm.analysis.analysis_manager import AnalysisManager
+from qallm.analysis.analysis_model import RawToolResult
+from qallm.analysis.normalization.sonarqube_normalizer import SonarQubeNormalizer
+from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+from qallm.common.model import CodeUnit
+
+
+def _unit(src="def f():\n    return 1\n"):
+    from pathlib import Path
+    return CodeUnit(source_code=src, original_path=Path("cell.py"), cell_index=0)
+
+
+def test_unconfigured_is_noop(monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", None)
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", None)
+    assert SonarQubeAnalyzer.is_configured() is False
+    result = SonarQubeAnalyzer().analyze(_unit())
+    assert result.exit_code == 0
+    payload = json.loads(result.stdout)
+    assert payload["issues"] == []
+
+
+def test_not_registered_when_unconfigured(monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", None)
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", None)
+    names = [a.tool_name() for a in AnalysisManager().available_analyzers]
+    assert "sonarqube" not in names
+    assert "bandit" in names and "Radon" in names
+
+
+def test_registered_when_configured(monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://localhost:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+    assert SonarQubeAnalyzer.is_configured() is True
+    names = [a.tool_name() for a in AnalysisManager().available_analyzers]
+    assert "sonarqube" in names
+
+
+def test_normalizer_maps_issue_types_and_severities():
+    payload = {
+        "issues": [
+            {"type": "BUG", "severity": "BLOCKER", "component": "proj:cell.py",
+             "line": 3, "message": "null deref", "rule": "python:S1234"},
+            {"type": "VULNERABILITY", "severity": "MAJOR", "component": "proj:cell.py",
+             "line": 7, "message": "sql injection", "rule": "python:S5678"},
+            {"type": "CODE_SMELL", "severity": "MINOR", "component": "proj:cell.py",
+             "line": 9, "message": "rename me", "rule": "python:S9999"},
+        ]
+    }
+    result = RawToolResult(tool="sonarqube", exit_code=0,
+                           stdout=json.dumps(payload), stderr="")
+    findings = SonarQubeNormalizer().normalize(result)
+    assert len(findings) == 3
+    bug = findings[0]
+    assert bug.type == "RELIABILITY" and bug.severity == "CRITICAL"
+    assert bug.file == "cell.py" and bug.line == 3
+    assert findings[1].type == "SECURITY" and findings[1].severity == "HIGH"
+    assert findings[2].type == "MAINTAINABILITY" and findings[2].severity == "MEDIUM"
+
+
+def test_normalizer_empty_and_malformed():
+    assert SonarQubeNormalizer().normalize(
+        RawToolResult("sonarqube", 0, "", "")) == []
+    assert SonarQubeNormalizer().normalize(
+        RawToolResult("sonarqube", 0, "not json", "")) == []
+
+
+def test_sonar_rating_evaluators_skip_or_read():
+    from qallm.evaluation import (
+        _sonar_maintainability_rating,
+        _sonar_reliability_rating,
+        _sonar_security_rating,
+        resolve,
+    )
+    # Registered.
+    for eid in ("sonar.reliability_rating", "sonar.security_rating",
+                "sonar.maintainability_rating"):
+        assert resolve(eid) is not None
+    # Skip when no measures in context.
+    assert _sonar_reliability_rating("x", {}) is None
+    # Read when present (sqale_rating backs maintainability).
+    ctx = {"sonar_measures": {"reliability_rating": "1.0",
+                              "security_rating": "3.0", "sqale_rating": "2.0"}}
+    assert _sonar_reliability_rating("x", ctx) == 1.0
+    assert _sonar_security_rating("x", ctx) == 3.0
+    assert _sonar_maintainability_rating("x", ctx) == 2.0
+
+
+def test_orchestrator_threads_sonar_measures_into_context(monkeypatch):
+    """When configured, _sonar_measures_for returns measures the profile sees."""
+    import json as _json
+
+    from qallm.analysis.analysis_model import RawToolResult
+    from qallm.orchestrator import QALLMOrchestrator
+
+    orch = QALLMOrchestrator(rounds=1)
+
+    # Unconfigured -> no measures, profile falls back.
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", None)
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", None)
+    assert orch._sonar_measures_for(_unit()) is None
+
+    # Configured + analyzer returns measures -> they come through.
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://localhost:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+
+    def _fake_analyze(self, unit):
+        return RawToolResult(
+            tool="sonarqube", exit_code=0,
+            stdout=_json.dumps({"issues": [], "measures": {
+                "reliability_rating": "1.0", "security_rating": "2.0",
+                "sqale_rating": "1.0"}}),
+            stderr="")
+
+    monkeypatch.setattr(
+        "qallm.analysis.sonarqube_analyzer.SonarQubeAnalyzer.analyze",
+        _fake_analyze)
+    measures = orch._sonar_measures_for(_unit())
+    assert measures == {"reliability_rating": "1.0",
+                        "security_rating": "2.0", "sqale_rating": "1.0"}

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -354,6 +354,25 @@ export interface LLMCall {
   timestamp: number;
 }
 
+export interface BugTest {
+  name: string;
+  status: "passed" | "failed" | "error" | "skipped";
+  message: string | null;
+}
+
+export interface FunctionBugDetail {
+  function: string;
+  passed: number;
+  failed: number;
+  errors: number;
+  skipped: number;
+  total: number;
+  coverage_percent: number | null;
+  execution_error: string | null;
+  bug_tests: BugTest[];
+  all_tests: BugTest[];
+}
+
 export interface ImprovementUnit {
   unit_id: string;
   bucket: "lineage" | "abandoned";
@@ -363,6 +382,7 @@ export interface ImprovementUnit {
   profile: Record<string, unknown> | null;
   judge: Record<string, unknown> | null;
   llm_calls: LLMCall[];
+  bug_detail: FunctionBugDetail[];
 }
 
 export interface ImprovementRound {

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -115,8 +115,67 @@ function Field({ label, body, highlight }: { label: string; body: string; highli
   );
 }
 
+function BugDetailView({ functions }: { functions: import("../api").FunctionBugDetail[] }) {
+  if (!functions.length) {
+    return <div className="px-1 py-2 text-xs text-slate-400">No verification results recorded for this round.</div>;
+  }
+  return (
+    <div className="space-y-3">
+      {functions.map((fn) => {
+        const cov = fn.coverage_percent === null ? "n/a" : `${fn.coverage_percent.toFixed(0)}%`;
+        return (
+          <div key={fn.function} className="rounded-lg border border-slate-100">
+            <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2">
+              <span className="font-mono text-sm font-medium text-slate-700">{fn.function}()</span>
+              <span className="flex shrink-0 items-center gap-2 text-xs">
+                <span className="text-slate-400">{cov} cov</span>
+                {fn.passed > 0 && <span className="rounded bg-emerald-50 px-1.5 py-0.5 font-semibold text-emerald-700">{fn.passed} pass</span>}
+                {fn.failed > 0 && <span className="rounded bg-rose-50 px-1.5 py-0.5 font-semibold text-rose-700">{fn.failed} bug{fn.failed > 1 ? "s" : ""}</span>}
+                {fn.errors > 0 && <span className="rounded bg-amber-50 px-1.5 py-0.5 font-semibold text-amber-700">{fn.errors} err</span>}
+              </span>
+            </div>
+            <div className="divide-y divide-slate-50">
+              {fn.all_tests.length === 0 && (
+                <div className="px-3 py-2 text-xs text-slate-400">No tests executed.</div>
+              )}
+              {fn.all_tests.map((t, i) => {
+                const isBug = t.status === "failed";
+                const isErr = t.status === "error";
+                const dot = isBug ? "bg-rose-500" : isErr ? "bg-amber-500" : t.status === "passed" ? "bg-emerald-500" : "bg-slate-300";
+                return (
+                  <div key={i} className="px-3 py-2">
+                    <div className="flex items-center gap-2 text-xs">
+                      <span className={`h-2 w-2 shrink-0 rounded-full ${dot}`} />
+                      <span className="font-mono text-slate-700">{t.name}</span>
+                      <span className={`ml-auto shrink-0 font-semibold ${isBug ? "text-rose-600" : isErr ? "text-amber-600" : t.status === "passed" ? "text-emerald-600" : "text-slate-400"}`}>
+                        {t.status === "failed" ? "BUG" : t.status.toUpperCase()}
+                      </span>
+                    </div>
+                    {(isBug || isErr) && t.message && (
+                      <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-slate-900 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-100">
+                        {t.message}
+                      </pre>
+                    )}
+                  </div>
+                );
+              })}
+              {fn.execution_error && (
+                <div className="px-3 py-2">
+                  <div className="text-[11px] font-semibold uppercase tracking-wide text-amber-600">Execution error</div>
+                  <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-amber-50 px-2 py-1.5 font-mono text-[11px] text-amber-800">{fn.execution_error}</pre>
+                </div>
+              )}
+            </div>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 function UnitCard({ unit }: { unit: ImprovementUnit }) {
-  const [tab, setTab] = useState<"deltas" | "transcript">("deltas");
+  const totalBugs = unit.bug_detail.reduce((n, f) => n + f.failed, 0);
+  const [tab, setTab] = useState<"bugs" | "deltas" | "transcript">("bugs");
   const imp = unit.improvement;
   const accepted = unit.accepted;
 
@@ -143,11 +202,14 @@ function UnitCard({ unit }: { unit: ImprovementUnit }) {
       )}
 
       <div className="mb-3 flex gap-2 text-xs">
+        <button onClick={() => setTab("bugs")} className={`rounded-md px-2.5 py-1 font-medium ${tab === "bugs" ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600"}`}>Bugs found by tests{totalBugs > 0 ? ` (${totalBugs})` : ""}</button>
         <button onClick={() => setTab("deltas")} className={`rounded-md px-2.5 py-1 font-medium ${tab === "deltas" ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600"}`}>Indicator deltas</button>
         <button onClick={() => setTab("transcript")} className={`rounded-md px-2.5 py-1 font-medium ${tab === "transcript" ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600"}`}>LLM transcript ({unit.llm_calls.length})</button>
       </div>
 
-      {tab === "deltas" ? (
+      {tab === "bugs" ? (
+        <BugDetailView functions={unit.bug_detail} />
+      ) : tab === "deltas" ? (
         imp && imp.dimensions.length ? (
           <div className="space-y-3">
             {imp.dimensions.map((dim) => (
@@ -209,7 +271,7 @@ export default function ImprovementView({ sessionId }: { sessionId: string }) {
     <div className="space-y-3">
       <div>
         <h2 className="text-xl font-semibold text-slate-800">Improvement audit</h2>
-        <p className="mt-1 text-sm text-slate-500">Per round and per method: which indicators moved, the accept/abandon verdict, and the exact prompts sent to the model.</p>
+        <p className="mt-1 text-sm text-slate-500">Per round and per method: the bugs found by generated tests (discovered by execution, not static analysis), which quality indicators moved, the accept/abandon verdict, and the exact prompts sent to the model.</p>
       </div>
       {rounds.map((r) => {
         const isOpen = openRound === r.round;


### PR DESCRIPTION
**Quality profiles (3): the framework-generality thread**

- feat(profiles): FAIR4RS publication-stage profile (the second real profile).
- feat(profiles): ISO/IEC 25010:2023 base profile (the third). Declares all nine 2023 characteristics. Security/Maintainability measured statically; Functional Suitability measured by QALLM's execution-based verification (the characteristic static tools cannot assess); the other five declared-but-skipped via a qallm.not_measured evaluator. Establishes the thesis hierarchy: ISO/IEC 25010 (9 characteristics) is the parent; EVERSE is those nine plus FAIRness and Sustainability.

**SonarQube integration (2)**

- feat(analysis): optional SonarQubeAnalyzer + normalizer + sonar.*_rating evaluators. No-op when unconfigured (pipeline stays on Radon/Bandit); complements, never replaces. Self-hosted Docker server by default, SonarCloud as a config swap.
- feat(orchestrator): threads SonarQube measures into the evaluation context so the 25010 profile can prefer them, with Radon/Bandit fallback.

Research findings behind the profile/SonarQube work

ISO/IEC 25010 is the parent of EVERSE, not a separate framework. EVERSE's 11 dimensions are the nine ISO/IEC 25010:2023 product-quality characteristics plus FAIRness and Sustainability. The 2023 revision added Safety and renamed Usability/Portability to Interaction Capability/Flexibility.
SonarQube AI CodeFix is QALLM's static-only mirror. It suggests fixes for statically-discovered issues without executing the code to verify them, which is precisely the verification gap QALLM's execution-based approach addresses. This motivates the suggested thesis experiment (in docs/sonarqube-integration.md): run both on the buggy sample and show SonarQube's static fixes miss logic bugs QALLM catches by execution.