### PR TITLE
Feature/experiment UI

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -48,3 +48,16 @@ API_PORT=8000
 # Host port for the optional Ollama service. Only relevant with the
 # with-ollama profile.
 OLLAMA_PORT=11434
+# ---------- SonarQube (optional) ----------
+
+# Optional higher-fidelity static analysis. Leave unset to run on
+# Radon/Bandit only. To enable the in-stack server:
+#   docker compose --profile sonarqube up
+# then create a token at http://localhost:${SONARQUBE_PORT} (admin/admin
+# on first login) and set SONARQUBE_TOKEN below.
+# SONARQUBE_URL=http://sonarqube:9000
+# SONARQUBE_TOKEN=
+# For SonarCloud instead of the self-hosted server:
+#   SONARQUBE_URL=https://sonarcloud.io
+#   SONARQUBE_ORGANIZATION=your-org-key
+SONARQUBE_PORT=9000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,6 +2,7 @@
 #
 # Default:                docker compose up           # API only
 # With local LLM:         docker compose --profile with-ollama up
+# With SonarQube:         docker compose --profile sonarqube up
 # Rebuild after changes:  docker compose up --build
 #
 # Configuration lives in .env. Copy .env.example to .env first and fill
@@ -51,6 +52,38 @@ services:
 #    volumes:
 #      - ollama-models:/root/.ollama
 #    restart: unless-stopped
-#
-#volumes:
+
+  # Optional SonarQube server for higher-fidelity static analysis. Skipped
+  # by default; activate with:
+  #     docker compose --profile sonarqube up
+  # Then open http://localhost:${SONARQUBE_PORT:-9000} (admin/admin on
+  # first login), generate a token, and set SONARQUBE_URL and
+  # SONARQUBE_TOKEN in .env so the api service picks SonarQube up. When
+  # both run in this stack, set SONARQUBE_URL=http://sonarqube:9000.
+  sonarqube:
+    image: sonarqube:community
+    container_name: qallm-sonarqube
+    profiles: ["sonarqube"]
+    ports:
+      - "${SONARQUBE_PORT:-9000}:9000"
+    environment:
+      # Embedded H2 database: fine for local/single-node evaluation use,
+      # which is QALLM's case. Not for production multi-node SonarQube.
+      - SONAR_ES_BOOTSTRAP_CHECKS_DISABLE=true
+    volumes:
+      - sonarqube-data:/opt/sonarqube/data
+      - sonarqube-extensions:/opt/sonarqube/extensions
+      - sonarqube-logs:/opt/sonarqube/logs
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD-SHELL", "wget --no-verbose --tries=1 --spider http://localhost:9000/api/system/status || exit 1"]
+      interval: 30s
+      timeout: 5s
+      retries: 10
+      start_period: 90s
+
+volumes:
+  sonarqube-data:
+  sonarqube-extensions:
+  sonarqube-logs:
 #  ollama-models:

--- a/docs/experiments/humaneval.md
+++ b/docs/experiments/humaneval.md
@@ -86,7 +86,59 @@ The markdown report is the artefact to cite. It includes:
 - A per-problem detail table.
 - An errored-runs section listing any problems that failed mid-run.
 
-## Reproducibility
+## Viewing results in the Web-UI
+
+Completed runs are browsable in the QALLM Web-UI under the **Experiments**
+tab (top of the page, next to **Pipeline**). No experiment is launched
+from the browser: runs take hours and download datasets, so they run from
+the CLI as above. The UI reads the artefacts each run wrote.
+
+### Data flow
+
+```
+  CLI                          disk (QALLM_RUNS_DIR)              Web-UI
+  ───                          ────────────────────              ──────
+  run_humaneval.py
+     │ runs QALLM per
+     │ (problem, strategy,
+     │  model) combination
+     ▼
+  humaneval_runner          runs/<run-id>/
+     │  writes  ───────────►   manifest.json     ┐
+     │                         results.jsonl     │  GET /api/experiments
+     │                         aggregates.json   ├─────────────────────►  ExperimentsView
+     │                         report.md         ┘  GET /api/experiments/{id}
+     │                                              GET .../{id}/results     run list
+     ▼                                              GET .../{id}/report       │
+  (resumable: appends                                                        ▼
+   one JSONL line per                                              per-run detail:
+   completed combination)                                          - aggregate cards
+                                                                    (bug-detection +
+                                                                     repair-success
+                                                                     per strategy/model)
+                                                                   - per-problem table
+                                                                   - markdown report
+```
+
+The `experiments` API router (`src/qallm/api/routers/experiments.py`)
+reads the run directory; it never writes. Point it at a different
+location with the `QALLM_RUNS_DIR` environment variable (default `runs`).
+In the Docker stack, mount your runs directory into the api container and
+set `QALLM_RUNS_DIR` to the mount path so past runs appear in the UI.
+
+### What the UI shows
+
+- **Run list**: every run directory, newest first, with its strategies,
+  models, round count, and result count.
+- **Aggregate cards**: one per (strategy, model), with bug-detection rate
+  and repair-success rate (and the underlying counts), plus mean rounds,
+  cost, and time per problem. Comparing the cards is the headline result:
+  the feedback (RL) strategy is expected to detect more bugs than one-shot
+  or property-based generation.
+- **Per-problem table**: each task with bug-detected / repaired flags,
+  rounds, coverage, and cost. Errored problems are highlighted.
+- **Markdown report**: the full `report.md`, including the Wilcoxon
+  pairwise tests, viewable inline.
 
 The experiment is deterministic *up to* LLM non-determinism. The seed controls only the sampling step (when `--sample-size` is set); the underlying QALLM pipeline uses the LLM at its configured temperature, which on OpenAI providers introduces server-side randomness even at `temperature=0`.
 

--- a/docs/sonarqube-integration.md
+++ b/docs/sonarqube-integration.md
@@ -26,6 +26,32 @@ The integration targets a self-hosted SonarQube Server, which suits
 QALLM's access pattern (many short-lived, locally-analysed code variants
 per run) better than a CI/CD-oriented hosted service.
 
+### Option A: docker compose (recommended)
+
+QALLM's `docker-compose.yml` ships SonarQube as an optional profile, so
+the API and the SonarQube server come up together:
+
+```
+docker compose --profile sonarqube up
+```
+
+Then open http://localhost:9000 (admin/admin on first login, change the
+password), generate a token under My Account -> Security, and set in
+`.env`:
+
+```
+SONARQUBE_URL=http://sonarqube:9000
+SONARQUBE_TOKEN=<your token>
+```
+
+Because both services share the compose network, the API reaches the
+server at the `sonarqube` hostname. Restart the api service to pick up
+the new `.env` values.
+
+### Option B: standalone docker run
+
+If you are not using the compose stack:
+
 1. Start a server:
 
    ```

--- a/docs/web-ui-history.md
+++ b/docs/web-ui-history.md
@@ -1,0 +1,89 @@
+# QALLM web UI: history views (Experiments and Sessions)
+
+The QALLM web UI has three top-level views, selected from the switch in
+the header:
+
+- **Pipeline**: the step wizard that runs the pipeline on uploaded code.
+- **Experiments**: browse historical HumanEvalFix validation runs.
+- **Sessions**: browse every session the pipeline has ever processed.
+
+The Experiments and Sessions views are read-only browsers over artefacts
+already written to disk. Neither launches work; they reflect what the CLI
+and the pipeline produced. This separation matters for a research tool:
+the durable record is on disk, and the UI is a lens over it that survives
+server restarts.
+
+## Where the data lives
+
+```
+  producer                    on disk                         UI view
+  ────────                    ───────                         ───────
+  scripts/run_humaneval.py    $QALLM_RUNS_DIR/<run>/          Experiments
+    (CLI, hours-long)           manifest.json                   tab
+                                results.jsonl
+                                aggregates.json
+                                report.md
+
+  orchestrator.run()          $QALLM_SESSIONS_DIR/<id>/       Sessions
+    (Pipeline tab, or           summary.json                    tab
+     CLI run_qallm.py)          report.md
+                                round_00_baseline/
+                                lineage/round_NN/...
+                                abandoned/round_NN/...
+```
+
+Both directories are configurable by environment variable:
+
+- `QALLM_RUNS_DIR` (default `runs`) for experiments.
+- `QALLM_SESSIONS_DIR` (default `outputs/quality_reporter`) for sessions;
+  this must match the `base_dir` the orchestrator gives its
+  `QualityReporter`.
+
+In the Docker stack, mount the host directory holding these into the api
+container and set the variables so past runs and sessions appear.
+
+## Request flow
+
+```
+  Browser (SessionsView / ExperimentsView)
+     │
+     │  GET /api/library                 GET /api/experiments
+     │  GET /api/library/{id}            GET /api/experiments/{id}
+     │  GET /api/library/{id}/report     GET /api/experiments/{id}/results
+     │                                   GET /api/experiments/{id}/report
+     ▼
+  sessions_library router /              experiments router
+  experiments router
+     │  read-only:
+     │    - index dirs (newest first)
+     │    - parse summary.json / manifest.json / aggregates.json
+     │    - stream report.md text
+     │  guarded: id must be a single path segment (no traversal)
+     ▼
+  disk (QALLM_SESSIONS_DIR / QALLM_RUNS_DIR)
+```
+
+## Sessions view
+
+- **List**: one card per session directory, newest first, showing the
+  source file, the session id (the reporter's timestamp run-id), strategy,
+  model, profile, and the accept/abandon round totals at a glance.
+- **Detail**: a stats grid (strategy, model, profile, oracle, functions
+  verified, rounds accepted/abandoned, halt reason), a cost line (total
+  USD and tokens), and the full `report.md` inline.
+
+## Experiments view
+
+- **List**: one card per run directory, with strategies, models, round
+  count, and result count.
+- **Detail**: per-(strategy, model) aggregate cards (bug-detection and
+  repair-success rates with counts, plus mean rounds/cost/time), a
+  per-problem results table, and the markdown report inline.
+
+## Why read-only
+
+Experiment runs take hours and download datasets, and pipeline sessions
+are launched either from the Pipeline tab or the CLI. Making these views
+read-only keeps a clean separation: producing results is an explicit,
+resource-aware action; reviewing them is cheap and safe. It also means the
+history views never mutate the record an examiner or co-author is auditing.

--- a/src/qallm/api/main.py
+++ b/src/qallm/api/main.py
@@ -31,6 +31,7 @@ from qallm.api.routers import (
     repair,
     results,
     sessions as sessions_router,
+    sessions_library,
     verification,
 )
 
@@ -57,6 +58,7 @@ app.include_router(repair.router)
 app.include_router(verification.router)
 app.include_router(results.router)
 app.include_router(experiments.router)
+app.include_router(sessions_library.router)
 
 
 # ─── Favicon ────────────────────────────────────────────────────────

--- a/src/qallm/api/main.py
+++ b/src/qallm/api/main.py
@@ -27,6 +27,7 @@ from qallm.api.core import app
 from qallm.api.routers import (
     analysis,
     config,
+    experiments,
     repair,
     results,
     sessions as sessions_router,
@@ -55,6 +56,7 @@ app.include_router(analysis.router)
 app.include_router(repair.router)
 app.include_router(verification.router)
 app.include_router(results.router)
+app.include_router(experiments.router)
 
 
 # ─── Favicon ────────────────────────────────────────────────────────

--- a/src/qallm/api/routers/experiments.py
+++ b/src/qallm/api/routers/experiments.py
@@ -1,0 +1,154 @@
+"""API router: HumanEvalFix experiment results.
+
+Makes historical experiment runs accessible and auditable through the
+Web-UI. Each run is a directory under QALLM_RUNS_DIR containing the
+artefacts the runner writes: manifest.json (parameters), aggregates.json
+(per-strategy/model headline numbers), results.jsonl (one line per
+problem), and report.md.
+
+This router only reads those artefacts; it never launches a run (full
+experiments take hours and download datasets, so they run from the CLI in
+the user's environment, not from a web request). The endpoints:
+
+  GET /api/experiments               list runs with a manifest summary
+  GET /api/experiments/{run}         one run: manifest + aggregates
+  GET /api/experiments/{run}/results per-problem detail (results.jsonl)
+  GET /api/experiments/{run}/report  the markdown report text
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from fastapi import APIRouter, HTTPException
+
+from qallm.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _runs_dir() -> str:
+    return settings.QALLM_RUNS_DIR
+
+
+def _read_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _read_jsonl(path: str) -> list[dict]:
+    rows: list[dict] = []
+    try:
+        with open(path, encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    except OSError:
+        return []
+    return rows
+
+
+def _is_run_dir(path: str) -> bool:
+    """A run directory is one that has at least a manifest or results file."""
+    return (
+        os.path.isfile(os.path.join(path, "manifest.json"))
+        or os.path.isfile(os.path.join(path, "results.jsonl"))
+    )
+
+
+@router.get("/api/experiments")
+async def list_experiments():
+    """List experiment runs with a compact summary for each.
+
+    Degrades gracefully: an empty list when the runs directory does not
+    exist or holds no runs, so the UI shows an empty state rather than an
+    error.
+    """
+    runs_dir = _runs_dir()
+    if not os.path.isdir(runs_dir):
+        return {"runs_dir": runs_dir, "runs": []}
+
+    runs = []
+    for name in sorted(os.listdir(runs_dir), reverse=True):
+        run_path = os.path.join(runs_dir, name)
+        if not os.path.isdir(run_path) or not _is_run_dir(run_path):
+            continue
+        manifest = _read_json(os.path.join(run_path, "manifest.json")) or {}
+        aggregates = _read_json(os.path.join(run_path, "aggregates.json")) or []
+        # results.jsonl can be large; just count lines for the summary.
+        results_path = os.path.join(run_path, "results.jsonl")
+        n_results = 0
+        if os.path.isfile(results_path):
+            try:
+                with open(results_path, encoding="utf-8") as fh:
+                    n_results = sum(1 for line in fh if line.strip())
+            except OSError:
+                n_results = 0
+        runs.append({
+            "id": name,
+            "models": manifest.get("models", []),
+            "strategies": manifest.get("strategies", []),
+            "rounds": manifest.get("rounds"),
+            "sample_size": manifest.get("sample_size"),
+            "created": manifest.get("started_at") or manifest.get("created"),
+            "n_results": n_results,
+            "n_combinations": len(aggregates),
+            "has_report": os.path.isfile(os.path.join(run_path, "report.md")),
+        })
+    return {"runs_dir": runs_dir, "runs": runs}
+
+
+def _run_path_or_404(run_id: str) -> str:
+    # Guard against path traversal: run_id must be a single path segment.
+    if "/" in run_id or "\\" in run_id or run_id in ("", ".", ".."):
+        raise HTTPException(status_code=400, detail="Invalid run id")
+    run_path = os.path.join(_runs_dir(), run_id)
+    if not os.path.isdir(run_path) or not _is_run_dir(run_path):
+        raise HTTPException(status_code=404, detail="Experiment run not found")
+    return run_path
+
+
+@router.get("/api/experiments/{run_id}")
+async def get_experiment(run_id: str):
+    """One run: manifest parameters plus the per-(strategy, model) aggregates."""
+    run_path = _run_path_or_404(run_id)
+    return {
+        "id": run_id,
+        "manifest": _read_json(os.path.join(run_path, "manifest.json")) or {},
+        "aggregates": _read_json(os.path.join(run_path, "aggregates.json")) or [],
+        "has_report": os.path.isfile(os.path.join(run_path, "report.md")),
+    }
+
+
+@router.get("/api/experiments/{run_id}/results")
+async def get_experiment_results(run_id: str):
+    """Per-problem results for a run (the parsed results.jsonl)."""
+    run_path = _run_path_or_404(run_id)
+    return {"id": run_id,
+            "results": _read_jsonl(os.path.join(run_path, "results.jsonl"))}
+
+
+@router.get("/api/experiments/{run_id}/report")
+async def get_experiment_report(run_id: str):
+    """The markdown report text for a run, for inline display/download."""
+    run_path = _run_path_or_404(run_id)
+    report_path = os.path.join(run_path, "report.md")
+    if not os.path.isfile(report_path):
+        raise HTTPException(status_code=404, detail="No report.md for this run")
+    try:
+        with open(report_path, encoding="utf-8") as fh:
+            return {"id": run_id, "markdown": fh.read()}
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/qallm/api/routers/sessions_library.py
+++ b/src/qallm/api/routers/sessions_library.py
@@ -1,0 +1,128 @@
+"""API router: session library.
+
+QALLM is a research tool, so being able to load every session the pipeline
+has ever processed, with its results and report, is valuable. Each
+orchestrator run writes a report directory under QALLM_SESSIONS_DIR
+(summary.json plus the lineage/abandoned round artefacts). This router
+indexes those directories and serves them read-only.
+
+This is distinct from the in-memory ``sessions`` dict in core.py, which
+holds *live* sessions for the current server process. The library here is
+the durable, on-disk history that survives restarts.
+
+  GET /api/library                  list processed sessions (summary)
+  GET /api/library/{session}        one session's full summary.json
+  GET /api/library/{session}/report the session's report.md
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+from fastapi import APIRouter, HTTPException
+
+from qallm.config import settings
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+def _sessions_dir() -> str:
+    return settings.QALLM_SESSIONS_DIR
+
+
+def _read_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _is_session_dir(path: str) -> bool:
+    """A session directory is one that has a summary.json."""
+    return os.path.isfile(os.path.join(path, "summary.json"))
+
+
+def _summarise(session_id: str, summary: dict) -> dict:
+    """Compact card for the session list, derived from summary.json."""
+    profile = summary.get("profile") or {}
+    cost = summary.get("cost") or {}
+    return {
+        "id": session_id,
+        "source": summary.get("source"),
+        "strategy": summary.get("strategy"),
+        "model": summary.get("model"),
+        "profile_id": profile.get("profile_id"),
+        "lifecycle_stage": summary.get("lifecycle_stage"),
+        "oracle": summary.get("oracle"),
+        "rounds_per_function": summary.get("rounds_per_function"),
+        "units_analyzed": summary.get("units_analyzed"),
+        "functions_verified": summary.get("functions_verified"),
+        "rounds_accepted_total": summary.get("rounds_accepted_total"),
+        "rounds_abandoned_total": summary.get("rounds_abandoned_total"),
+        "total_cost_usd": cost.get("total_cost_usd"),
+        "halt_reason": summary.get("halt_reason"),
+    }
+
+
+@router.get("/api/library")
+async def list_sessions():
+    """List every processed session with a compact summary card.
+
+    Empty list when the sessions directory does not exist, so the UI shows
+    an empty state rather than an error.
+    """
+    base = _sessions_dir()
+    if not os.path.isdir(base):
+        return {"sessions_dir": base, "sessions": []}
+
+    sessions = []
+    for name in sorted(os.listdir(base), reverse=True):
+        path = os.path.join(base, name)
+        if not os.path.isdir(path) or not _is_session_dir(path):
+            continue
+        summary = _read_json(os.path.join(path, "summary.json")) or {}
+        card = _summarise(name, summary)
+        card["has_report"] = os.path.isfile(os.path.join(path, "report.md"))
+        sessions.append(card)
+    return {"sessions_dir": base, "sessions": sessions}
+
+
+def _session_path_or_404(session_id: str) -> str:
+    # Guard against path traversal: session id must be one path segment.
+    if "/" in session_id or "\\" in session_id or session_id in ("", ".", ".."):
+        raise HTTPException(status_code=400, detail="Invalid session id")
+    path = os.path.join(_sessions_dir(), session_id)
+    if not os.path.isdir(path) or not _is_session_dir(path):
+        raise HTTPException(status_code=404, detail="Session not found")
+    return path
+
+
+@router.get("/api/library/{session_id}")
+async def get_session(session_id: str):
+    """One session's full summary.json (profile, tracks, sessions, cost)."""
+    path = _session_path_or_404(session_id)
+    summary = _read_json(os.path.join(path, "summary.json")) or {}
+    return {
+        "id": session_id,
+        "summary": summary,
+        "has_report": os.path.isfile(os.path.join(path, "report.md")),
+    }
+
+
+@router.get("/api/library/{session_id}/report")
+async def get_session_report(session_id: str):
+    """The session's report.md text, for inline display/download."""
+    path = _session_path_or_404(session_id)
+    report_path = os.path.join(path, "report.md")
+    if not os.path.isfile(report_path):
+        raise HTTPException(status_code=404, detail="No report.md for this session")
+    try:
+        with open(report_path, encoding="utf-8") as fh:
+            return {"id": session_id, "markdown": fh.read()}
+    except OSError as exc:
+        raise HTTPException(status_code=500, detail=str(exc)) from exc

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -40,6 +40,11 @@ class Settings:
         os.getenv("SONARQUBE_TIMEOUT_SECONDS", "180")
     )
 
+    # Directory where HumanEvalFix experiment runs are written and read
+    # back for the Web-UI. Each subdirectory is one run (manifest.json,
+    # results.jsonl, aggregates.json, report.md). Defaults to ./runs.
+    QALLM_RUNS_DIR: str = os.getenv("QALLM_RUNS_DIR", "runs")
+
     # Budget caps. All are floors, not ceilings: code-level ceilings in
     # `qallm.cost` override these if they are too large. The intent is
     # that a typo in this file or an .env cannot blow the budget.

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -45,6 +45,15 @@ class Settings:
     # results.jsonl, aggregates.json, report.md). Defaults to ./runs.
     QALLM_RUNS_DIR: str = os.getenv("QALLM_RUNS_DIR", "runs")
 
+    # Directory where per-session reports are written by the orchestrator's
+    # QualityReporter and read back for the Web-UI session library. Each
+    # subdirectory is one processed session (summary.json, report.md, the
+    # lineage/abandoned round artefacts). Must match the base_dir the
+    # orchestrator uses for its reporter.
+    QALLM_SESSIONS_DIR: str = os.getenv(
+        "QALLM_SESSIONS_DIR", "outputs/quality_reporter"
+    )
+
     # Budget caps. All are floors, not ceilings: code-level ceilings in
     # `qallm.cost` override these if they are too large. The intent is
     # that a typo in this file or an .env cannot blow the budget.

--- a/tests/test_experiments_endpoints.py
+++ b/tests/test_experiments_endpoints.py
@@ -1,0 +1,86 @@
+"""Tests for the experiment-results browsing endpoints."""
+
+import json
+import os
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qallm.api.main import app
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def runs_dir(tmp_path, monkeypatch):
+    run = tmp_path / "heval_demo"
+    run.mkdir()
+    (run / "manifest.json").write_text(json.dumps({
+        "models": ["openai:gpt-4o-mini"], "strategies": ["rl"],
+        "rounds": 5, "sample_size": 10, "started_at": "2026-05-30T10:00:00"}))
+    (run / "aggregates.json").write_text(json.dumps([{
+        "strategy": "rl", "model": "openai:gpt-4o-mini", "n_problems": 10,
+        "n_bug_detected": 8, "n_repair_successful": 6, "n_errored": 0,
+        "mean_rounds": 3.0, "mean_cost_usd": 0.1, "mean_elapsed_seconds": 30.0,
+        "bug_detection_rate": 0.8, "repair_success_rate": 0.6}]))
+    (run / "results.jsonl").write_text(
+        json.dumps({"task_id": "Python/0", "strategy": "rl",
+                    "model": "openai:gpt-4o-mini", "bug_detected": True,
+                    "repair_successful": True, "rounds_run": 3,
+                    "final_coverage": 90.0, "cost_usd": 0.1,
+                    "elapsed_seconds": 30.0, "error": None}) + "\n")
+    (run / "report.md").write_text("# Report\n\nbody\n")
+    # Point both the config and the already-imported router module at tmp.
+    monkeypatch.setattr("qallm.config.settings.QALLM_RUNS_DIR", str(tmp_path))
+    monkeypatch.setattr("qallm.api.routers.experiments.settings.QALLM_RUNS_DIR",
+                        str(tmp_path))
+    return tmp_path
+
+
+def test_list_runs(runs_dir):
+    r = client.get("/api/experiments")
+    assert r.status_code == 200
+    runs = r.json()["runs"]
+    assert len(runs) == 1
+    assert runs[0]["id"] == "heval_demo"
+    assert runs[0]["n_results"] == 1
+    assert runs[0]["has_report"] is True
+
+
+def test_list_empty_when_no_dir(monkeypatch):
+    monkeypatch.setattr("qallm.api.routers.experiments.settings.QALLM_RUNS_DIR",
+                        "/nonexistent/path/xyz")
+    r = client.get("/api/experiments")
+    assert r.status_code == 200
+    assert r.json()["runs"] == []
+
+
+def test_get_one_run(runs_dir):
+    r = client.get("/api/experiments/heval_demo")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["manifest"]["rounds"] == 5
+    assert body["aggregates"][0]["bug_detection_rate"] == 0.8
+
+
+def test_get_results(runs_dir):
+    r = client.get("/api/experiments/heval_demo/results")
+    assert r.status_code == 200
+    results = r.json()["results"]
+    assert len(results) == 1
+    assert results[0]["task_id"] == "Python/0"
+
+
+def test_get_report(runs_dir):
+    r = client.get("/api/experiments/heval_demo/report")
+    assert r.status_code == 200
+    assert "# Report" in r.json()["markdown"]
+
+
+def test_unknown_run_404(runs_dir):
+    assert client.get("/api/experiments/nope").status_code == 404
+
+
+def test_path_traversal_blocked(runs_dir):
+    # Encoded traversal must not escape the runs dir.
+    assert client.get("/api/experiments/..%2f..%2fetc").status_code in (400, 404)

--- a/tests/test_sessions_library.py
+++ b/tests/test_sessions_library.py
@@ -1,0 +1,80 @@
+"""Tests for the session-library endpoints."""
+
+import json
+
+import pytest
+from fastapi import HTTPException
+from fastapi.testclient import TestClient
+
+from qallm.api.main import app
+from qallm.api.routers.sessions_library import _session_path_or_404
+
+client = TestClient(app)
+
+
+@pytest.fixture
+def sessions_dir(tmp_path, monkeypatch):
+    s = tmp_path / "20260530_120000"
+    s.mkdir()
+    (s / "summary.json").write_text(json.dumps({
+        "source": "buggy.py", "strategy": "feedback", "model": "gpt-4o-mini",
+        "lifecycle_stage": "implementation", "oracle": "crash",
+        "rounds_per_function": 5, "units_analyzed": 1, "functions_verified": 3,
+        "rounds_accepted_total": 4, "rounds_abandoned_total": 2,
+        "halt_reason": "MAX_ROUNDS",
+        "profile": {"profile_id": "implementation_default"},
+        "cost": {"total_cost_usd": 0.34}}))
+    (s / "report.md").write_text("# QALLM session report\n\nbody\n")
+    monkeypatch.setattr("qallm.config.settings.QALLM_SESSIONS_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "qallm.api.routers.sessions_library.settings.QALLM_SESSIONS_DIR",
+        str(tmp_path))
+    return tmp_path
+
+
+def test_list_sessions(sessions_dir):
+    r = client.get("/api/library")
+    assert r.status_code == 200
+    sessions = r.json()["sessions"]
+    assert len(sessions) == 1
+    card = sessions[0]
+    assert card["id"] == "20260530_120000"
+    assert card["strategy"] == "feedback"
+    assert card["profile_id"] == "implementation_default"
+    assert card["total_cost_usd"] == 0.34
+    assert card["has_report"] is True
+
+
+def test_list_empty_when_no_dir(monkeypatch):
+    monkeypatch.setattr(
+        "qallm.api.routers.sessions_library.settings.QALLM_SESSIONS_DIR",
+        "/nonexistent/xyz")
+    r = client.get("/api/library")
+    assert r.status_code == 200
+    assert r.json()["sessions"] == []
+
+
+def test_get_one_session(sessions_dir):
+    r = client.get("/api/library/20260530_120000")
+    assert r.status_code == 200
+    summary = r.json()["summary"]
+    assert summary["strategy"] == "feedback"
+    assert summary["functions_verified"] == 3
+
+
+def test_get_report(sessions_dir):
+    r = client.get("/api/library/20260530_120000/report")
+    assert r.status_code == 200
+    assert "QALLM session report" in r.json()["markdown"]
+
+
+def test_unknown_session_404(sessions_dir):
+    assert client.get("/api/library/nope").status_code == 404
+
+
+def test_path_traversal_guard_blocks_escapes():
+    # Unit-level: the guard rejects traversal and multi-segment ids.
+    for bad in ["../etc", "..", ".", "", "a/b", "a\\b"]:
+        with pytest.raises(HTTPException) as exc:
+            _session_path_or_404(bad)
+        assert exc.value.status_code == 400

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Shield, FlaskConical } from "lucide-react";
+import { Shield, FlaskConical, Library } from "lucide-react";
 import StepRail from "./components/StepRail";
 import { NextBar } from "./components/Shared";
 import { useSession } from "./hooks/useSession";
@@ -11,6 +11,7 @@ import ReanalyseScreen from "./screens/ReanalyseScreen";
 import TestGenScreen from "./screens/TestGenScreen";
 import ResultsScreen from "./screens/ResultsScreen";
 import ExperimentsView from "./screens/ExperimentsView";
+import SessionsView from "./screens/SessionsView";
 
 const STEPS_MANUAL = 6;
 const STEPS_AUTO = 4;
@@ -18,7 +19,7 @@ const STEPS_AUTO = 4;
 export default function App() {
   const { state, patch, setStep } = useSession();
   const [mode, setMode] = useState<"manual" | "auto">("manual");
-  const [view, setView] = useState<"pipeline" | "experiments">("pipeline");
+  const [view, setView] = useState<"pipeline" | "experiments" | "sessions">("pipeline");
   const autoRunner = useAutoRunner(state, patch, setStep);
 
   // Called by UploadScreen after successful upload. We accept the
@@ -121,6 +122,12 @@ export default function App() {
           >
             <FlaskConical className="h-3.5 w-3.5" /> Experiments
           </button>
+          <button
+            onClick={() => setView("sessions")}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 font-medium ${view === "sessions" ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-50"}`}
+          >
+            <Library className="h-3.5 w-3.5" /> Sessions
+          </button>
         </div>
         {/* Step navigation: locked while an auto run is in flight to
             prevent the user from disrupting the pipeline. Once the run
@@ -130,6 +137,10 @@ export default function App() {
         {view === "experiments" ? (
           <div className="min-h-[400px]">
             <ExperimentsView />
+          </div>
+        ) : view === "sessions" ? (
+          <div className="min-h-[400px]">
+            <SessionsView />
           </div>
         ) : (
           <>

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Shield } from "lucide-react";
+import { Shield, FlaskConical } from "lucide-react";
 import StepRail from "./components/StepRail";
 import { NextBar } from "./components/Shared";
 import { useSession } from "./hooks/useSession";
@@ -10,6 +10,7 @@ import RepairScreen from "./screens/RepairScreen";
 import ReanalyseScreen from "./screens/ReanalyseScreen";
 import TestGenScreen from "./screens/TestGenScreen";
 import ResultsScreen from "./screens/ResultsScreen";
+import ExperimentsView from "./screens/ExperimentsView";
 
 const STEPS_MANUAL = 6;
 const STEPS_AUTO = 4;
@@ -17,6 +18,7 @@ const STEPS_AUTO = 4;
 export default function App() {
   const { state, patch, setStep } = useSession();
   const [mode, setMode] = useState<"manual" | "auto">("manual");
+  const [view, setView] = useState<"pipeline" | "experiments">("pipeline");
   const autoRunner = useAutoRunner(state, patch, setStep);
 
   // Called by UploadScreen after successful upload. We accept the
@@ -103,53 +105,78 @@ export default function App() {
             </div>
           )}
         </div>
+
+        {/* Top-level view switch: the step-based pipeline vs read-only
+            browsing of historical validation experiments. */}
+        <div className="flex gap-1 rounded-xl border border-slate-200 bg-white p-1 text-sm shadow-sm w-fit">
+          <button
+            onClick={() => setView("pipeline")}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 font-medium ${view === "pipeline" ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-50"}`}
+          >
+            <Shield className="h-3.5 w-3.5" /> Pipeline
+          </button>
+          <button
+            onClick={() => setView("experiments")}
+            className={`flex items-center gap-1.5 rounded-lg px-3 py-1.5 font-medium ${view === "experiments" ? "bg-slate-900 text-white" : "text-slate-600 hover:bg-slate-50"}`}
+          >
+            <FlaskConical className="h-3.5 w-3.5" /> Experiments
+          </button>
+        </div>
         {/* Step navigation: locked while an auto run is in flight to
             prevent the user from disrupting the pipeline. Once the run
             ends (success OR failure), navigation is re-enabled so the
             user can review or retry. Without this, an auto-mode run
             that errors out leaves the user trapped on the failed step. */}
-        <StepRail
-          currentStep={state.step}
-          mode={mode}
-          onStepClick={(mode === "auto" && state.loading) ? () => {} : setStep}
-        />
-        {/* Manual-mode preview banner. In manual mode, steps 2 to 4 let
-            the user inspect a static-analysis baseline and a single LLM
-            repair pass. These are a teaching preview: the full pipeline,
-            with all rounds and judge accept/abandon decisions, runs in the
-            "Run pipeline" step. Auto mode has no such preview, it runs the
-            real loop directly, so this banner is manual-only. */}
-        {mode === "manual" && state.step >= 2 && state.step <= 4 && (
-          <div className="rounded-xl border border-blue-200 bg-blue-50 p-3 text-xs text-blue-800">
-            <span className="font-semibold">Preview stages.</span>{" "}
-            Steps 2 to 4 let you inspect a static-analysis baseline and a
-            single LLM repair pass, so you can confirm your code parses and
-            see what one repair looks like. The full QALLM pipeline (all
-            rounds of repair, verification, and judge accept/abandon) runs
-            in the "Run pipeline" step against its own baseline. To run the
-            real pipeline directly, start a new session in Auto mode.
+        {view === "experiments" ? (
+          <div className="min-h-[400px]">
+            <ExperimentsView />
           </div>
-        )}
-        {state.error && (
-          <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
-            <div>{state.error}</div>
-            {mode === "auto" && (
-              <div className="mt-2 text-xs text-red-600">
-                Auto mode halted. Use the step rail above to navigate back
-                and review earlier stages, or refresh the page to start over.
+        ) : (
+          <>
+            <StepRail
+              currentStep={state.step}
+              mode={mode}
+              onStepClick={(mode === "auto" && state.loading) ? () => {} : setStep}
+            />
+            {/* Manual-mode preview banner. In manual mode, steps 2 to 4 let
+                the user inspect a static-analysis baseline and a single LLM
+                repair pass. These are a teaching preview: the full pipeline,
+                with all rounds and judge accept/abandon decisions, runs in the
+                "Run pipeline" step. Auto mode has no such preview, it runs the
+                real loop directly, so this banner is manual-only. */}
+            {mode === "manual" && state.step >= 2 && state.step <= 4 && (
+              <div className="rounded-xl border border-blue-200 bg-blue-50 p-3 text-xs text-blue-800">
+                <span className="font-semibold">Preview stages.</span>{" "}
+                Steps 2 to 4 let you inspect a static-analysis baseline and a
+                single LLM repair pass, so you can confirm your code parses and
+                see what one repair looks like. The full QALLM pipeline (all
+                rounds of repair, verification, and judge accept/abandon) runs
+                in the "Run pipeline" step against its own baseline. To run the
+                real pipeline directly, start a new session in Auto mode.
               </div>
             )}
-          </div>
-        )}
-        <div className="min-h-[400px]">{screen}</div>
-        {/* NextBar visible whenever navigation is allowed. */}
-        {!(mode === "auto" && state.loading) && (
-          <NextBar
-            step={state.step} maxStep={maxStep}
-            onPrev={() => setStep(Math.max(1, state.step - 1))}
-            onNext={() => canNext && setStep(Math.min(maxStep, state.step + 1))}
-            nextDisabled={!canNext}
-          />
+            {state.error && (
+              <div className="rounded-xl border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                <div>{state.error}</div>
+                {mode === "auto" && (
+                  <div className="mt-2 text-xs text-red-600">
+                    Auto mode halted. Use the step rail above to navigate back
+                    and review earlier stages, or refresh the page to start over.
+                  </div>
+                )}
+              </div>
+            )}
+            <div className="min-h-[400px]">{screen}</div>
+            {/* NextBar visible whenever navigation is allowed. */}
+            {!(mode === "auto" && state.loading) && (
+              <NextBar
+                step={state.step} maxStep={maxStep}
+                onPrev={() => setStep(Math.max(1, state.step - 1))}
+                onNext={() => canNext && setStep(Math.min(maxStep, state.step + 1))}
+                nextDisabled={!canNext}
+              />
+            )}
+          </>
         )}
       </div>
     </div>

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -425,3 +425,64 @@ export interface SampleFile {
 export async function getSampleData(): Promise<{ samples: SampleFile[] }> {
   return req<{ samples: SampleFile[] }>("/api/sample-data");
 }
+
+// ─── Experiments (HumanEvalFix validation runs) ───
+export interface ExperimentRunSummary {
+  id: string;
+  models: string[];
+  strategies: string[];
+  rounds: number | null;
+  sample_size: number | null;
+  created: string | null;
+  n_results: number;
+  n_combinations: number;
+  has_report: boolean;
+}
+
+export interface ExperimentAggregate {
+  strategy: string;
+  model: string;
+  n_problems: number;
+  n_bug_detected: number;
+  n_repair_successful: number;
+  n_errored: number;
+  mean_rounds: number;
+  mean_cost_usd: number;
+  mean_elapsed_seconds: number;
+  bug_detection_rate: number;
+  repair_success_rate: number;
+}
+
+export interface ExperimentProblemResult {
+  task_id: string;
+  strategy: string;
+  model: string;
+  bug_detected: boolean;
+  repair_successful: boolean;
+  rounds_run: number;
+  final_coverage: number;
+  cost_usd: number;
+  elapsed_seconds: number;
+  error: string | null;
+}
+
+export async function listExperiments(): Promise<{ runs_dir: string; runs: ExperimentRunSummary[] }> {
+  return req<{ runs_dir: string; runs: ExperimentRunSummary[] }>("/api/experiments");
+}
+
+export async function getExperiment(id: string): Promise<{
+  id: string;
+  manifest: Record<string, unknown>;
+  aggregates: ExperimentAggregate[];
+  has_report: boolean;
+}> {
+  return req(`/api/experiments/${encodeURIComponent(id)}`);
+}
+
+export async function getExperimentResults(id: string): Promise<{ id: string; results: ExperimentProblemResult[] }> {
+  return req(`/api/experiments/${encodeURIComponent(id)}/results`);
+}
+
+export async function getExperimentReport(id: string): Promise<{ id: string; markdown: string }> {
+  return req(`/api/experiments/${encodeURIComponent(id)}/report`);
+}

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -486,3 +486,38 @@ export async function getExperimentResults(id: string): Promise<{ id: string; re
 export async function getExperimentReport(id: string): Promise<{ id: string; markdown: string }> {
   return req(`/api/experiments/${encodeURIComponent(id)}/report`);
 }
+
+// ─── Session library (past processed sessions) ───
+export interface SessionCard {
+  id: string;
+  source: string | null;
+  strategy: string | null;
+  model: string | null;
+  profile_id: string | null;
+  lifecycle_stage: string | null;
+  oracle: string | null;
+  rounds_per_function: number | null;
+  units_analyzed: number | null;
+  functions_verified: number | null;
+  rounds_accepted_total: number | null;
+  rounds_abandoned_total: number | null;
+  total_cost_usd: number | null;
+  halt_reason: string | null;
+  has_report: boolean;
+}
+
+export async function listLibrarySessions(): Promise<{ sessions_dir: string; sessions: SessionCard[] }> {
+  return req<{ sessions_dir: string; sessions: SessionCard[] }>("/api/library");
+}
+
+export async function getLibrarySession(id: string): Promise<{
+  id: string;
+  summary: Record<string, unknown>;
+  has_report: boolean;
+}> {
+  return req(`/api/library/${encodeURIComponent(id)}`);
+}
+
+export async function getLibrarySessionReport(id: string): Promise<{ id: string; markdown: string }> {
+  return req(`/api/library/${encodeURIComponent(id)}/report`);
+}

--- a/web/frontend/src/screens/ExperimentsView.tsx
+++ b/web/frontend/src/screens/ExperimentsView.tsx
@@ -1,0 +1,234 @@
+/**
+ * ExperimentsView: browse historical HumanEvalFix validation runs.
+ *
+ * Makes experiment results accessible and auditable in the UI. Three
+ * levels: a list of runs, a selected run's per-(strategy, model)
+ * aggregate comparison plus per-problem detail, and the run's markdown
+ * report. Read-only; experiments are launched from the CLI (they take
+ * hours and download datasets), this surfaces what they produced.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  FlaskConical, ChevronRight, ChevronLeft, Bug, Wrench,
+  Clock, DollarSign, AlertTriangle, FileText,
+} from "lucide-react";
+import * as api from "../api";
+import type {
+  ExperimentRunSummary, ExperimentAggregate, ExperimentProblemResult,
+} from "../api";
+
+function pct(x: number): string {
+  return `${(x * 100).toFixed(0)}%`;
+}
+
+function RunList({ runs, onSelect }: {
+  runs: ExperimentRunSummary[];
+  onSelect: (id: string) => void;
+}) {
+  if (!runs.length) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6 text-sm text-slate-500">
+        No experiment runs found yet. Run one from the CLI (see
+        <span className="font-mono"> docs/experiments/humaneval.md</span>), then it appears here.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {runs.map((r) => (
+        <button
+          key={r.id}
+          onClick={() => onSelect(r.id)}
+          className="flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm hover:border-indigo-300 hover:bg-indigo-50/30"
+        >
+          <div className="min-w-0">
+            <div className="truncate font-semibold text-slate-800">{r.id}</div>
+            <div className="mt-1 flex flex-wrap gap-1.5 text-xs text-slate-500">
+              {r.strategies.map((s) => (
+                <span key={s} className="rounded bg-slate-100 px-1.5 py-0.5 font-medium text-slate-600">{s}</span>
+              ))}
+              <span className="text-slate-300">·</span>
+              <span>{r.models.join(", ")}</span>
+              {r.rounds != null && <><span className="text-slate-300">·</span><span>{r.rounds} rounds</span></>}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-3 text-xs text-slate-400">
+            <span>{r.n_results} results</span>
+            <ChevronRight className="h-4 w-4" />
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function AggregateCard({ agg }: { agg: ExperimentAggregate }) {
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="mb-3 flex items-center justify-between">
+        <span className="rounded-md bg-slate-900 px-2 py-0.5 text-xs font-semibold text-white">{agg.strategy}</span>
+        <span className="truncate text-xs text-slate-500">{agg.model}</span>
+      </div>
+      <div className="grid grid-cols-2 gap-3">
+        <div className="rounded-lg bg-emerald-50 p-2.5">
+          <div className="flex items-center gap-1 text-xs font-medium text-emerald-700"><Bug className="h-3.5 w-3.5" /> Bug detection</div>
+          <div className="mt-0.5 text-xl font-semibold text-emerald-800">{pct(agg.bug_detection_rate)}</div>
+          <div className="text-[11px] text-emerald-600">{agg.n_bug_detected}/{agg.n_problems - agg.n_errored}</div>
+        </div>
+        <div className="rounded-lg bg-indigo-50 p-2.5">
+          <div className="flex items-center gap-1 text-xs font-medium text-indigo-700"><Wrench className="h-3.5 w-3.5" /> Repair success</div>
+          <div className="mt-0.5 text-xl font-semibold text-indigo-800">{pct(agg.repair_success_rate)}</div>
+          <div className="text-[11px] text-indigo-600">{agg.n_repair_successful}/{agg.n_problems - agg.n_errored}</div>
+        </div>
+      </div>
+      <div className="mt-3 flex flex-wrap gap-3 text-[11px] text-slate-500">
+        <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> {agg.mean_rounds.toFixed(1)} rounds</span>
+        <span className="flex items-center gap-1"><DollarSign className="h-3 w-3" /> {agg.mean_cost_usd.toFixed(3)}/problem</span>
+        <span className="flex items-center gap-1"><Clock className="h-3 w-3" /> {agg.mean_elapsed_seconds.toFixed(0)}s/problem</span>
+        {agg.n_errored > 0 && <span className="flex items-center gap-1 text-amber-600"><AlertTriangle className="h-3 w-3" /> {agg.n_errored} errored</span>}
+      </div>
+    </div>
+  );
+}
+
+function ProblemTable({ results }: { results: ExperimentProblemResult[] }) {
+  if (!results.length) return <div className="text-xs text-slate-400">No per-problem results.</div>;
+  return (
+    <div className="overflow-x-auto rounded-xl border border-slate-200">
+      <table className="w-full text-xs">
+        <thead className="bg-slate-50 text-slate-500">
+          <tr>
+            <th className="px-3 py-2 text-left font-medium">Task</th>
+            <th className="px-3 py-2 text-left font-medium">Strategy</th>
+            <th className="px-3 py-2 text-center font-medium">Bug detected</th>
+            <th className="px-3 py-2 text-center font-medium">Repaired</th>
+            <th className="px-3 py-2 text-right font-medium">Rounds</th>
+            <th className="px-3 py-2 text-right font-medium">Cov</th>
+            <th className="px-3 py-2 text-right font-medium">Cost</th>
+          </tr>
+        </thead>
+        <tbody className="divide-y divide-slate-100">
+          {results.map((r, i) => (
+            <tr key={i} className={r.error ? "bg-amber-50/50" : ""}>
+              <td className="px-3 py-1.5 font-mono text-slate-700">{r.task_id}</td>
+              <td className="px-3 py-1.5 text-slate-500">{r.strategy}</td>
+              <td className="px-3 py-1.5 text-center">{r.error ? "—" : r.bug_detected ? <span className="text-emerald-600 font-semibold">yes</span> : <span className="text-slate-400">no</span>}</td>
+              <td className="px-3 py-1.5 text-center">{r.error ? "—" : r.repair_successful ? <span className="text-indigo-600 font-semibold">yes</span> : <span className="text-slate-400">no</span>}</td>
+              <td className="px-3 py-1.5 text-right text-slate-500">{r.rounds_run}</td>
+              <td className="px-3 py-1.5 text-right text-slate-500">{r.final_coverage?.toFixed(0)}%</td>
+              <td className="px-3 py-1.5 text-right text-slate-500">${r.cost_usd?.toFixed(3)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function RunDetail({ id, onBack }: { id: string; onBack: () => void }) {
+  const [aggregates, setAggregates] = useState<ExperimentAggregate[]>([]);
+  const [manifest, setManifest] = useState<Record<string, unknown>>({});
+  const [results, setResults] = useState<ExperimentProblemResult[]>([]);
+  const [report, setReport] = useState<string | null>(null);
+  const [showReport, setShowReport] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    Promise.all([api.getExperiment(id), api.getExperimentResults(id)])
+      .then(([run, res]) => {
+        if (!alive) return;
+        setAggregates(run.aggregates);
+        setManifest(run.manifest);
+        setResults(res.results);
+      })
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [id]);
+
+  function loadReport() {
+    if (report !== null) { setShowReport(!showReport); return; }
+    api.getExperimentReport(id).then((r) => { setReport(r.markdown); setShowReport(true); }).catch(() => setReport(""));
+  }
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onBack} className="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800">
+        <ChevronLeft className="h-4 w-4" /> All runs
+      </button>
+      <div>
+        <h2 className="text-xl font-semibold text-slate-800">{id}</h2>
+        <p className="mt-1 text-sm text-slate-500">
+          {String(manifest.sample_size ?? "all")} problems · {(manifest.strategies as string[] || []).join(", ")} · {(manifest.models as string[] || []).join(", ")}
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="py-8 text-center text-sm text-slate-400">Loading run…</div>
+      ) : (
+        <>
+          <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+            {aggregates.map((a, i) => <AggregateCard key={i} agg={a} />)}
+          </div>
+
+          {aggregates.length >= 2 && (
+            <p className="rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-500">
+              Compare bug-detection rates across strategies above. The thesis claim is that the feedback (RL) strategy detects more bugs than one-shot or property-based generation, evidence that LLM-guided, execution-based test generation does real work over static analysis.
+            </p>
+          )}
+
+          <div>
+            <h3 className="mb-2 text-sm font-semibold text-slate-700">Per-problem results</h3>
+            <ProblemTable results={results} />
+          </div>
+
+          <div>
+            <button onClick={loadReport} className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">
+              <FileText className="h-3.5 w-3.5" /> {showReport ? "Hide" : "View"} markdown report
+            </button>
+            {showReport && report !== null && (
+              <pre className="mt-2 max-h-[28rem] overflow-auto whitespace-pre-wrap rounded-xl bg-slate-900 p-4 font-mono text-[11px] leading-relaxed text-slate-100">
+                {report || "(no report.md for this run)"}
+              </pre>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function ExperimentsView() {
+  const [runs, setRuns] = useState<ExperimentRunSummary[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    api.listExperiments()
+      .then((r) => alive && setRuns(r.runs))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, []);
+
+  if (selected) return <RunDetail id={selected} onBack={() => setSelected(null)} />;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <FlaskConical className="h-5 w-5 text-indigo-500" />
+        <h2 className="text-xl font-semibold text-slate-800">Validation experiments</h2>
+      </div>
+      <p className="text-sm text-slate-500">
+        HumanEvalFix benchmark runs: how well QALLM detects and repairs known bugs across strategies and models. Click a run to see its strategy comparison and per-problem detail.
+      </p>
+      {loading ? (
+        <div className="py-8 text-center text-sm text-slate-400">Loading runs…</div>
+      ) : (
+        <RunList runs={runs} onSelect={setSelected} />
+      )}
+    </div>
+  );
+}

--- a/web/frontend/src/screens/SessionsView.tsx
+++ b/web/frontend/src/screens/SessionsView.tsx
@@ -1,0 +1,184 @@
+/**
+ * SessionsView: browse every session the pipeline has processed.
+ *
+ * QALLM is a research tool, so the durable on-disk history of past runs is
+ * valuable. This lists each session's report directory (summary.json) and
+ * lets the user open any one's headline stats and full markdown report.
+ * Read-only; it reflects what the orchestrator wrote to QALLM_SESSIONS_DIR.
+ */
+
+import { useEffect, useState } from "react";
+import {
+  Library, ChevronRight, ChevronLeft, FileText, CheckCircle2,
+  XCircle, DollarSign, FileCode,
+} from "lucide-react";
+import * as api from "../api";
+import type { SessionCard } from "../api";
+
+function basename(path: string | null): string {
+  if (!path) return "(unknown source)";
+  const parts = path.split(/[\\/]/);
+  return parts[parts.length - 1] || path;
+}
+
+function SessionList({ sessions, onSelect }: {
+  sessions: SessionCard[];
+  onSelect: (id: string) => void;
+}) {
+  if (!sessions.length) {
+    return (
+      <div className="rounded-2xl border border-slate-200 bg-slate-50 p-6 text-sm text-slate-500">
+        No processed sessions found yet. Run the pipeline (Pipeline tab) and
+        completed sessions will appear here.
+      </div>
+    );
+  }
+  return (
+    <div className="space-y-2">
+      {sessions.map((s) => (
+        <button
+          key={s.id}
+          onClick={() => onSelect(s.id)}
+          className="flex w-full items-center justify-between gap-3 rounded-2xl border border-slate-200 bg-white p-4 text-left shadow-sm hover:border-indigo-300 hover:bg-indigo-50/30"
+        >
+          <div className="min-w-0">
+            <div className="flex items-center gap-2 truncate font-semibold text-slate-800">
+              <FileCode className="h-4 w-4 shrink-0 text-slate-400" />
+              {basename(s.source)}
+            </div>
+            <div className="mt-1 flex flex-wrap items-center gap-1.5 text-xs text-slate-500">
+              <span className="font-mono text-slate-400">{s.id}</span>
+              {s.strategy && <><span className="text-slate-300">·</span><span className="rounded bg-slate-100 px-1.5 py-0.5 font-medium text-slate-600">{s.strategy}</span></>}
+              {s.model && <span>{s.model}</span>}
+              {s.profile_id && <><span className="text-slate-300">·</span><span>{s.profile_id}</span></>}
+            </div>
+          </div>
+          <div className="flex shrink-0 items-center gap-3 text-xs text-slate-400">
+            {s.rounds_accepted_total != null && (
+              <span className="flex items-center gap-1 text-emerald-600"><CheckCircle2 className="h-3.5 w-3.5" />{s.rounds_accepted_total}</span>
+            )}
+            {s.rounds_abandoned_total != null && s.rounds_abandoned_total > 0 && (
+              <span className="flex items-center gap-1 text-rose-500"><XCircle className="h-3.5 w-3.5" />{s.rounds_abandoned_total}</span>
+            )}
+            <ChevronRight className="h-4 w-4" />
+          </div>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function Stat({ label, value }: { label: string; value: string | number | null | undefined }) {
+  return (
+    <div className="rounded-lg border border-slate-100 bg-white p-3">
+      <div className="text-[11px] font-medium uppercase tracking-wide text-slate-400">{label}</div>
+      <div className="mt-0.5 text-sm font-semibold text-slate-700">{value ?? "—"}</div>
+    </div>
+  );
+}
+
+function SessionDetail({ id, onBack }: { id: string; onBack: () => void }) {
+  const [summary, setSummary] = useState<Record<string, any>>({});
+  const [report, setReport] = useState<string | null>(null);
+  const [showReport, setShowReport] = useState(false);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    api.getLibrarySession(id)
+      .then((r) => alive && setSummary(r.summary))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [id]);
+
+  function loadReport() {
+    if (report !== null) { setShowReport(!showReport); return; }
+    api.getLibrarySessionReport(id)
+      .then((r) => { setReport(r.markdown); setShowReport(true); })
+      .catch(() => setReport(""));
+  }
+
+  const cost = (summary.cost as Record<string, any>) || {};
+
+  return (
+    <div className="space-y-4">
+      <button onClick={onBack} className="flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800">
+        <ChevronLeft className="h-4 w-4" /> All sessions
+      </button>
+      <div>
+        <h2 className="text-xl font-semibold text-slate-800">{basename(summary.source as string)}</h2>
+        <p className="mt-1 font-mono text-xs text-slate-400">{id}</p>
+      </div>
+
+      {loading ? (
+        <div className="py-8 text-center text-sm text-slate-400">Loading session…</div>
+      ) : (
+        <>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3 lg:grid-cols-4">
+            <Stat label="Strategy" value={summary.strategy} />
+            <Stat label="Model" value={summary.model} />
+            <Stat label="Profile" value={(summary.profile as any)?.profile_id} />
+            <Stat label="Oracle" value={summary.oracle} />
+            <Stat label="Functions verified" value={summary.functions_verified} />
+            <Stat label="Rounds accepted" value={summary.rounds_accepted_total} />
+            <Stat label="Rounds abandoned" value={summary.rounds_abandoned_total} />
+            <Stat label="Halt reason" value={summary.halt_reason} />
+          </div>
+
+          <div className="flex flex-wrap gap-3 rounded-lg bg-slate-50 px-3 py-2 text-xs text-slate-600">
+            {cost.total_cost_usd != null && (
+              <span className="flex items-center gap-1"><DollarSign className="h-3 w-3" /> {Number(cost.total_cost_usd).toFixed(4)} total</span>
+            )}
+            {cost.total_tokens != null && <span>{cost.total_tokens} tokens</span>}
+            {summary.lifecycle_stage != null && <span>stage: {String(summary.lifecycle_stage)}</span>}
+          </div>
+
+          <div>
+            <button onClick={loadReport} className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50">
+              <FileText className="h-3.5 w-3.5" /> {showReport ? "Hide" : "View"} session report
+            </button>
+            {showReport && report !== null && (
+              <pre className="mt-2 max-h-[28rem] overflow-auto whitespace-pre-wrap rounded-xl bg-slate-900 p-4 font-mono text-[11px] leading-relaxed text-slate-100">
+                {report || "(no report.md for this session)"}
+              </pre>
+            )}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}
+
+export default function SessionsView() {
+  const [sessions, setSessions] = useState<SessionCard[]>([]);
+  const [selected, setSelected] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let alive = true;
+    api.listLibrarySessions()
+      .then((r) => alive && setSessions(r.sessions))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, []);
+
+  if (selected) return <SessionDetail id={selected} onBack={() => setSelected(null)} />;
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center gap-2">
+        <Library className="h-5 w-5 text-indigo-500" />
+        <h2 className="text-xl font-semibold text-slate-800">Session library</h2>
+      </div>
+      <p className="text-sm text-slate-500">
+        Every session the pipeline has processed, newest first. Click one to see its configuration, accept/abandon totals, cost, and full report.
+      </p>
+      {loading ? (
+        <div className="py-8 text-center text-sm text-slate-400">Loading sessions…</div>
+      ) : (
+        <SessionList sessions={sessions} onSelect={setSelected} />
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
# Review: SonarQube compose, Experiments UI, Session library
 
Branch: `feature/experiment-ui` (off `dev`, after the #69 merge)
**5 commits.** All checks green: **416 Python tests pass**, frontend type-checks (`tsc --noEmit`) and builds, ruff clean on changed files.
 
This bundle adds the validation-and-history layer: SonarQube in compose, a Web-UI for browsing HumanEvalFix experiment runs, and a Web-UI session library for every processed pipeline run.
 
## Contents
 
- `experiment-session-ui.patch`: full diff vs `dev`, all 5 commits.
- `commits/`: 5 per-commit `.patch` files (apply with `git am`).
- `changed-files/`: final version of every changed file, paths preserved.
## The five commits
 
1. `feat(docker)`: SonarQube as an optional `--profile sonarqube` compose service (community image, embedded H2, persistent volumes, healthcheck). `.env.example` + the integration doc updated; docker compose is now the recommended setup path.
2. `feat(experiments)`: **Experiments Web-UI**. Backend `experiments` router reads runs from `QALLM_RUNS_DIR` (manifest + results.jsonl + aggregates + report.md, path-traversal-guarded, read-only). Frontend `ExperimentsView`: run list → per-(strategy, model) aggregate cards (bug-detection + repair-success rates) → per-problem table → inline report. New top-level Pipeline/Experiments view switch.
3. `docs(experiments)`: Web-UI browsing section + data-flow diagram in the HumanEvalFix doc.
4. `feat(library)`: **Session library Web-UI**. Backend `sessions_library` router reads sessions from `QALLM_SESSIONS_DIR` (default `outputs/quality_reporter`, matching the orchestrator's reporter). Frontend `SessionsView`: session list → stats grid + cost + inline report. Third nav tab (Pipeline / Experiments / Sessions).
5. `docs(web-ui)`: `docs/web-ui-history.md`: the three views, producer→disk→view and request-flow diagrams, and why the history views are read-only.
## New configuration
 
| Variable | Default | Purpose |
|---|---|---|
| `QALLM_RUNS_DIR` | `runs` | where experiment runs are read from |
| `QALLM_SESSIONS_DIR` | `outputs/quality_reporter` | where processed sessions are read from |
| `SONARQUBE_PORT` | `9000` | host port for the optional compose SonarQube service |
 
In Docker, mount the host directories holding runs/sessions into the api container and set these so past results appear in the UI.
 
## Important operational note
 
The HumanEvalFix **experiment itself cannot run inside the build sandbox** (huggingface.co is network-blocked there), so the experiment run happens in your environment. The runner/loader/metrics/report code already existed; this bundle adds the *viewing* layer and was verified against synthetic run artefacts. To produce real runs:
 
```
pip install -e ".[experiments]" --break-system-packages
python scripts/run_humaneval.py --help     # see docs/experiments/humaneval.md
```
 
Runs land in `QALLM_RUNS_DIR` and then appear under the Experiments tab.
 
## Verify locally
 
```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 416 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build