### PR TITLE
Review: feature session report view + Jupyter magic

### DIFF
--- a/docs/jupyter-magic.md
+++ b/docs/jupyter-magic.md
@@ -1,0 +1,111 @@
+# QALLM in Jupyter: the `%%qallm` magic
+
+QALLM ships an IPython magic so researchers can run the quality
+improvement pipeline without leaving the notebook. This is FEAT-10, the
+notebook frontend trigger.
+
+## Why a magic (and not a button or a separate CLI)
+
+Three options were considered for a notebook trigger:
+
+1. **An IPython magic** (`%%qallm`): chosen. It runs in classic Jupyter,
+   JupyterLab, and VS Code notebooks with nothing to install beyond the
+   package, it wraps the same orchestrator the CLI and web UI use (so
+   results are identical across entry points), and it is pure Python with
+   no JavaScript extension to package or keep working across frontend
+   versions.
+2. **A toolbar button (nbextension/labextension)**: rejected. It needs
+   per-frontend JavaScript packaging, the classic-notebook extension model
+   is deprecated, and it adds maintenance cost out of proportion to the
+   value over a magic.
+3. **A CLI targeting `.ipynb`**: already exists. `qallm analysis.ipynb`
+   works today, so this adds nothing new.
+
+The magic is the option that adds genuinely new capability (in-notebook
+invocation with inline results) at the lowest maintenance cost, which is
+why it is the most valuable for the supervisor and the research community.
+
+## Install and load
+
+```
+pip install -e ".[jupyter]"     # or just have ipython available
+```
+
+```python
+%load_ext qallm.jupyter
+```
+
+## Use
+
+Run on the code in the current cell with the **cell magic**:
+
+```python
+%%qallm --strategy feedback --rounds 3
+def divide(a, b):
+    return a / b
+```
+
+Run on an existing file, notebook, directory, zip, or GitHub URL with the
+**line magic**:
+
+```python
+%qallm path/to/analysis.ipynb --strategy oneshot
+```
+
+Capture the full summary for further analysis in the notebook:
+
+```python
+result = %qallm mymodule.py
+result["functions_verified"], result["cost"]["total_cost_usd"]
+```
+
+## Options
+
+The magic accepts a subset of the `qallm` CLI options:
+
+| Option | Default | Meaning |
+|---|---|---|
+| `--strategy` | `feedback` | `hypothesis`, `oneshot`, or `feedback` |
+| `--llm` | `openai` | `openai`, `anthropic`, or `ollama` |
+| `--model` | (provider default) | specific model name |
+| `--rounds` | `3` | iterative feedback rounds |
+| `--oracle` | `crash` | `crash`, `property`, or `metamorphic` |
+| `--stage` | `implementation` | lifecycle stage for the quality profile |
+| `--max-tokens` | budget default | token cap for the session |
+| `--max-cost-usd` | budget default | USD cap for the session |
+
+## What happens
+
+```
+  notebook cell                 qallm.jupyter                 pipeline
+  ─────────────                 ─────────────                 ────────
+  %%qallm --rounds 3
+  def divide(a, b):  ─────────►  cell body written
+      return a / b               to a temp .py file
+                                       │
+  (or)                                 ▼
+  %qallm file.ipynb ─────────►  QALLMOrchestrator.run(path)  ──►  baseline,
+                                       │                          repair rounds,
+                                       │                          verify, judge
+                                       ▼
+                                 inline HTML summary
+                                 (strategy, functions
+                                  verified, accept/abandon,
+                                  cost, per-function bugs)
+                                 + returns the summary dict
+```
+
+The cell magic writes the cell body to a temporary `.py` file and runs the
+pipeline on it; the line magic runs on the path you give. Either way the
+orchestrator is the same one the CLI and web UI use, so a notebook run
+produces the same artefacts on disk and the same numbers. Full session
+artefacts are saved to the session directory and show up in the web UI's
+Sessions tab.
+
+## Notes
+
+- The magic needs the LLM credentials the pipeline normally needs
+  (e.g. `OPENAI_API_KEY`), set in the environment before launching the
+  notebook.
+- Results render as inline HTML in the notebook, with a plain-text
+  fallback where rich display is unavailable.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,12 @@ dependencies = [
 experiments = [
     "datasets>=2.18.0",
 ]
+# Install with: pip install -e ".[jupyter]"
+# Needed only for the %%qallm notebook magic (qallm.jupyter). Most notebook
+# environments already provide ipython; this pins it for a clean install.
+jupyter = [
+    "ipython>=8.0",
+]
 
 [project.scripts]
 qallm = "qallm.run_qallm:main"

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -124,8 +124,19 @@ async def get_improvement(session_id: str):
     findings were tracked and improved, and what we asked the model".
     """
 
-    state = get_state(session_id)
+    # Soft lookup: a historical session opened from the library is not a
+    # live in-memory session, so get_state (which 404s) is wrong here. Read
+    # the in-memory state if present, otherwise fall through to disk.
+    state = sessions.get(session_id) or {}
     report_dir = state.get("report_dir")
+    # Fall back to the on-disk session directory for historical sessions
+    # that are not live in this process's memory (e.g. opened from the
+    # session library). The session id is the reporter run-id, which is the
+    # directory name under QALLM_SESSIONS_DIR.
+    if not report_dir or not os.path.isdir(report_dir):
+        candidate = os.path.join(settings.QALLM_SESSIONS_DIR, session_id)
+        if os.path.isdir(candidate):
+            report_dir = candidate
     if not report_dir or not os.path.isdir(report_dir):
         return {"available": False, "rounds": [],
                 "reason": "No run artefacts yet. Run the pipeline first."}

--- a/src/qallm/jupyter.py
+++ b/src/qallm/jupyter.py
@@ -1,0 +1,198 @@
+"""QALLM Jupyter integration: an IPython magic to run the pipeline.
+
+This is the FEAT-10 frontend trigger, built as an IPython magic because
+that is where the research community actually works: inside notebooks, in
+Jupyter, JupyterLab, and VS Code notebooks, all of which support IPython
+magics with no extension to install. It wraps the same
+:class:`QALLMOrchestrator` the CLI and web UI use, so results are
+consistent across every entry point, and it adds no JavaScript packaging
+to maintain.
+
+Usage, once loaded::
+
+    %load_ext qallm.jupyter
+
+    # Run on the code in this cell:
+    %%qallm --strategy feedback --rounds 3
+    def divide(a, b):
+        return a / b
+
+    # Or run on a notebook / file / directory by path:
+    %qallm path/to/analysis.ipynb --strategy oneshot
+
+The cell magic (``%%qallm``) writes the cell body to a temporary .py file
+and runs the pipeline on it. The line magic (``%qallm <path>``) runs the
+pipeline on an existing path (.py, .ipynb, directory, .zip, or GitHub
+URL), exactly like the ``qallm`` CLI.
+
+Results render as an inline HTML summary in the notebook (with a plain
+text fallback), and the full summary dict is returned so it can be
+captured for further analysis::
+
+    result = %qallm mymodule.py
+"""
+
+from __future__ import annotations
+
+import html
+import shlex
+import tempfile
+from pathlib import Path
+from typing import Any
+
+# The magic is only useful inside IPython. Importing IPython at module load
+# would make qallm depend on it, so the registration function imports it
+# lazily and raises a clear error if it is missing.
+
+
+def _build_orchestrator(args) -> Any:
+    """Construct an orchestrator from parsed magic arguments.
+
+    Mirrors run_qallm.main so the magic behaves like the CLI. Kept in one
+    place so the two entry points cannot drift apart.
+    """
+    from qallm.config import settings
+    from qallm.cost import BudgetCaps
+    from qallm.orchestrator import QALLMOrchestrator
+    from qallm.profiles import LifecycleStage
+
+    stage = LifecycleStage(args.stage)
+    caps = BudgetCaps.from_kwargs(
+        max_rounds=args.rounds,
+        max_tokens=args.max_tokens if args.max_tokens is not None else settings.TOKEN_BUDGET,
+        max_seconds=settings.QALLM_MAX_SECONDS,
+        max_round_seconds=settings.QALLM_MAX_ROUND_SECONDS,
+        max_cost_usd=args.max_cost_usd if args.max_cost_usd is not None else settings.QALLM_MAX_COST_USD,
+    )
+    return QALLMOrchestrator(
+        stage=stage,
+        strategy=args.strategy,
+        llm_type=args.llm,
+        model_name=args.model,
+        oracle=args.oracle,
+        rounds=args.rounds,
+        caps=caps,
+    )
+
+
+def _make_arg_parser():
+    """Argument parser for the magic, a subset of the CLI's options."""
+    import argparse
+
+    p = argparse.ArgumentParser(prog="%qallm", add_help=True)
+    p.add_argument("source", nargs="?", default=None,
+                   help="Path for the line magic; omitted for the cell magic.")
+    p.add_argument("--strategy", default="feedback",
+                   choices=["hypothesis", "oneshot", "feedback"])
+    p.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama"])
+    p.add_argument("--model", default=None)
+    p.add_argument("--rounds", type=int, default=3)
+    p.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])
+    p.add_argument("--stage", default="implementation",
+                   choices=["draft", "implementation", "publication"])
+    p.add_argument("--max-tokens", type=int, default=None, dest="max_tokens")
+    p.add_argument("--max-cost-usd", type=float, default=None, dest="max_cost_usd")
+    return p
+
+
+def _summary_html(summary: dict) -> str:
+    """Render a compact, readable HTML summary of a run for the notebook."""
+    cost = summary.get("cost", {}) or {}
+    rows = [
+        ("Source", summary.get("source")),
+        ("Strategy", summary.get("strategy")),
+        ("Model", summary.get("model")),
+        ("Units analyzed", summary.get("units_analyzed")),
+        ("Functions verified", summary.get("functions_verified")),
+        ("Rounds accepted", summary.get("rounds_accepted_total")),
+        ("Rounds abandoned", summary.get("rounds_abandoned_total")),
+        ("Halt reason", summary.get("halt_reason")),
+        ("Total cost (USD)", f"{cost.get('total_cost_usd', 0):.4f}"),
+    ]
+    body = "".join(
+        f"<tr><td style='padding:2px 12px 2px 0;color:#64748b'>{html.escape(str(k))}</td>"
+        f"<td style='padding:2px 0;font-weight:600;color:#0f172a'>{html.escape(str(v))}</td></tr>"
+        for k, v in rows
+    )
+    # Per-function coverage / bugs, if present.
+    fn_rows = ""
+    for s in summary.get("sessions", []) or []:
+        name = html.escape(str(s.get("function_name", "?")))
+        cov = s.get("final_coverage")
+        bugs = s.get("final_bugs")
+        cov_s = "n/a" if cov is None else f"{cov:.0f}%"
+        fn_rows += (
+            f"<tr><td style='padding:2px 12px 2px 0;font-family:monospace'>{name}</td>"
+            f"<td style='padding:2px 12px 2px 0;color:#64748b'>{cov_s} cov</td>"
+            f"<td style='padding:2px 0;color:{'#b91c1c' if bugs else '#15803d'}'>{bugs if bugs is not None else 0} bug(s)</td></tr>"
+        )
+    fn_block = (
+        f"<div style='margin-top:8px'><div style='font-size:12px;color:#64748b;"
+        f"text-transform:uppercase;letter-spacing:.05em'>Per function</div>"
+        f"<table style='font-size:13px;margin-top:4px'>{fn_rows}</table></div>"
+        if fn_rows else ""
+    )
+    return (
+        "<div style='border:1px solid #e2e8f0;border-radius:12px;padding:14px 16px;"
+        "font-family:system-ui,-apple-system,sans-serif;max-width:560px'>"
+        "<div style='font-weight:700;color:#4f46e5;margin-bottom:8px'>QALLM run complete</div>"
+        f"<table style='font-size:13px'>{body}</table>{fn_block}"
+        "<div style='margin-top:8px;font-size:11px;color:#94a3b8'>"
+        "Bugs found by execution, not static analysis. Full artefacts saved to the session directory.</div>"
+        "</div>"
+    )
+
+
+def _run_from_args(argv: list[str], cell: str | None) -> dict | None:
+    parser = _make_arg_parser()
+    try:
+        args = parser.parse_args(argv)
+    except SystemExit:
+        # argparse already printed help / the error to the cell output.
+        return None
+
+    if cell is not None:
+        # Cell magic: write the cell body to a temp .py and run on it.
+        tmp_dir = Path(tempfile.mkdtemp(prefix="qallm_cell_"))
+        source_path = tmp_dir / "cell.py"
+        source_path.write_text(cell, encoding="utf-8")
+        target = str(source_path)
+    else:
+        if not args.source:
+            print("Provide a path: %qallm <path> [options], or use the "
+                  "%%qallm cell magic to run on the cell's code.")
+            return None
+        target = args.source
+
+    orchestrator = _build_orchestrator(args)
+    summary = orchestrator.run(target)
+
+    # Render inline. Use IPython's display when available; fall back to text.
+    try:
+        from IPython.display import HTML, display
+        display(HTML(_summary_html(summary)))
+    except Exception:  # noqa: BLE001 - display is best-effort
+        cost = summary.get("cost", {}) or {}
+        print("QALLM run complete")
+        print(f"  strategy: {summary.get('strategy')}  model: {summary.get('model')}")
+        print(f"  verified: {summary.get('functions_verified')}  "
+              f"accepted: {summary.get('rounds_accepted_total')}  "
+              f"cost: ${cost.get('total_cost_usd', 0):.4f}")
+    return summary
+
+
+def load_ipython_extension(ipython) -> None:
+    """Register the %qallm line magic and %%qallm cell magic.
+
+    Called by IPython for ``%load_ext qallm.jupyter``.
+    """
+    from IPython.core.magic import register_line_cell_magic
+
+    @register_line_cell_magic
+    def qallm(line: str, cell: str | None = None):  # noqa: D401
+        """Run the QALLM pipeline on a cell (%%qallm) or a path (%qallm)."""
+        argv = shlex.split(line) if line else []
+        return _run_from_args(argv, cell)
+
+    # Keep a reference so static analysers do not flag it as unused.
+    ipython.user_ns.setdefault("_qallm_magic", qallm)

--- a/tests/test_improvement_disk_fallback.py
+++ b/tests/test_improvement_disk_fallback.py
@@ -1,0 +1,51 @@
+"""The improvement endpoint must work for historical sessions on disk.
+
+When a session is opened from the session library it is not live in this
+process's memory, so the improvement audit has to resolve its report
+directory from QALLM_SESSIONS_DIR rather than from in-memory state. This
+is what lets the library detail show the same lineage/verdict view as the
+pipeline final report.
+"""
+
+import json
+import os
+
+from fastapi.testclient import TestClient
+
+from qallm.api.main import app
+
+client = TestClient(app)
+
+
+def _write_session(base, sid):
+    sdir = os.path.join(base, sid)
+    lineage_r1 = os.path.join(sdir, "lineage", "round_01", "myfunc")
+    os.makedirs(lineage_r1)
+    json.dump({"delta": []}, open(os.path.join(lineage_r1, "improvement.json"), "w"))
+    json.dump({"status": "pass"}, open(os.path.join(lineage_r1, "profile.json"), "w"))
+    json.dump({"outcome": "improvement"}, open(os.path.join(lineage_r1, "judge.json"), "w"))
+    json.dump([], open(os.path.join(lineage_r1, "transcript.json"), "w"))
+    json.dump([], open(os.path.join(lineage_r1, "verification.json"), "w"))
+
+
+def test_improvement_resolves_from_disk(tmp_path, monkeypatch):
+    base = str(tmp_path)
+    _write_session(base, "20260530_999999")
+    monkeypatch.setattr("qallm.config.settings.QALLM_SESSIONS_DIR", base)
+    monkeypatch.setattr("qallm.api.routers.results.settings.QALLM_SESSIONS_DIR", base)
+
+    # This session id is NOT a live in-memory session, only on disk.
+    r = client.get("/api/session/20260530_999999/improvement")
+    assert r.status_code == 200
+    body = r.json()
+    # The endpoint found the on-disk artefacts and built rounds.
+    assert body.get("available") is not False
+    assert any(rd.get("round") == 1 for rd in body.get("rounds", []))
+
+
+def test_improvement_absent_session_reports_unavailable(tmp_path, monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.QALLM_SESSIONS_DIR", str(tmp_path))
+    monkeypatch.setattr("qallm.api.routers.results.settings.QALLM_SESSIONS_DIR", str(tmp_path))
+    r = client.get("/api/session/does_not_exist/improvement")
+    assert r.status_code == 200
+    assert r.json()["available"] is False

--- a/tests/test_jupyter_magic.py
+++ b/tests/test_jupyter_magic.py
@@ -1,0 +1,83 @@
+"""Tests for the QALLM Jupyter magic (FEAT-10 frontend trigger).
+
+These cover the parts that do not need a running IPython kernel or a real
+LLM: argument parsing, HTML rendering, and the cell/line dispatch with a
+stubbed orchestrator. The module imports IPython lazily, so it loads and
+is testable even where IPython is not installed.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import qallm.jupyter as J
+
+_SUMMARY = {
+    "source": "cell.py", "strategy": "feedback", "model": "stub",
+    "units_analyzed": 1, "functions_verified": 1,
+    "rounds_accepted_total": 1, "rounds_abandoned_total": 0,
+    "halt_reason": "completed", "cost": {"total_cost_usd": 0.0},
+    "sessions": [{"function_name": "f", "final_coverage": 100.0, "final_bugs": 0}],
+}
+
+
+def test_module_imports_without_ipython():
+    # The magic must not hard-depend on IPython at import time.
+    assert hasattr(J, "load_ipython_extension")
+    assert hasattr(J, "_run_from_args")
+
+
+def test_arg_parser_defaults_and_overrides():
+    p = J._make_arg_parser()
+    a = p.parse_args([])
+    assert a.strategy == "feedback" and a.rounds == 3 and a.source is None
+    b = p.parse_args(["file.py", "--strategy", "oneshot", "--rounds", "5"])
+    assert b.source == "file.py" and b.strategy == "oneshot" and b.rounds == 5
+
+
+def test_summary_html_contains_key_fields():
+    h = J._summary_html(_SUMMARY)
+    assert "QALLM run complete" in h
+    assert "feedback" in h          # strategy
+    assert "divide" not in h        # only functions present are shown
+    assert "f" in h                 # the function name
+    assert "100%" in h              # coverage
+
+
+def test_cell_magic_writes_temp_and_runs():
+    fake = MagicMock()
+    fake.run.return_value = _SUMMARY
+    with patch.object(J, "_build_orchestrator", return_value=fake):
+        result = J._run_from_args(["--strategy", "feedback"], cell="def f():\n    return 1\n")
+    assert result["strategy"] == "feedback"
+    # Ran on a temp cell.py file.
+    assert fake.run.call_args[0][0].endswith("cell.py")
+
+
+def test_line_magic_runs_on_given_path():
+    fake = MagicMock()
+    fake.run.return_value = _SUMMARY
+    with patch.object(J, "_build_orchestrator", return_value=fake):
+        J._run_from_args(["some_file.py", "--strategy", "oneshot"], cell=None)
+    assert fake.run.call_args[0][0] == "some_file.py"
+
+
+def test_empty_invocation_is_friendly():
+    # No path and no cell: returns None, does not raise.
+    assert J._run_from_args([], cell=None) is None
+
+
+def test_load_extension_registers_magic():
+    # Stub IPython's register_line_cell_magic so we can verify registration
+    # without a real kernel.
+    fake_ipython = MagicMock()
+    fake_ipython.user_ns = {}
+    captured = {}
+
+    def fake_register(fn):
+        captured["fn"] = fn
+        return fn
+
+    with patch.dict("sys.modules", {"IPython.core.magic": MagicMock(
+            register_line_cell_magic=fake_register)}):
+        J.load_ipython_extension(fake_ipython)
+    assert "fn" in captured
+    assert "_qallm_magic" in fake_ipython.user_ns

--- a/web/frontend/src/screens/LineageReport.tsx
+++ b/web/frontend/src/screens/LineageReport.tsx
@@ -1,0 +1,143 @@
+/**
+ * Shared "Report lineage and verdict" rendering.
+ *
+ * Extracted from ResultsScreen so the session library can show the exact
+ * same per-unit lineage and verdict panels as the pipeline's final report.
+ * Both the live pipeline result and a historical session loaded from disk
+ * carry tracks in the same UnitTrackView shape, so one component serves
+ * both.
+ */
+
+import { CheckCircle2, XCircle, Minus } from "lucide-react";
+import type {
+  UnitTrackView, LineageEntryView, AbandonedEntryView,
+} from "../types";
+
+// Pretty-print the judge outcome with an icon and colour.
+export function OutcomeBadge({ outcome }: { outcome: string }) {
+  if (outcome === "improvement") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
+        <CheckCircle2 className="h-3 w-3" /> improvement
+      </span>
+    );
+  }
+  if (outcome === "regression") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700">
+        <XCircle className="h-3 w-3" /> regression
+      </span>
+    );
+  }
+  if (outcome === "no_change") {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
+        <Minus className="h-3 w-3" /> no change
+      </span>
+    );
+  }
+  return <span className="text-xs text-slate-500">{outcome}</span>;
+}
+
+// One per-unit panel: lineage and abandoned variants.
+export function UnitTrackPanel({ unitId, track }: { unitId: string; track: UnitTrackView }) {
+  return (
+    <div className="rounded-2xl border bg-white p-5 shadow-sm">
+      <div className="flex items-baseline justify-between">
+        <h4 className="text-sm font-medium font-mono text-slate-700">{unitId}</h4>
+        <div className="text-xs text-slate-500">
+          <span className="font-medium text-emerald-700">{track.lineage.length}</span> accepted
+          {" / "}
+          <span className="font-medium text-rose-700">{track.abandoned.length}</span> abandoned
+        </div>
+      </div>
+
+      {track.lineage.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs font-bold uppercase text-slate-500 mb-2">Accepted lineage</div>
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-slate-500">
+                <th className="py-1 pr-2">Round</th>
+                <th className="py-1 pr-2">Outcome</th>
+                <th className="py-1">Explanation</th>
+              </tr>
+            </thead>
+            <tbody>
+              {track.lineage.map((entry: LineageEntryView) => (
+                <tr key={`l-${entry.round_number}`} className="border-t border-slate-100">
+                  <td className="py-1.5 pr-2 font-medium">
+                    {entry.round_number === 0 ? (
+                      <span className="inline-flex items-center gap-1">
+                        <span>0</span>
+                        <span className="rounded bg-indigo-100 px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-700">
+                          baseline
+                        </span>
+                      </span>
+                    ) : (
+                      entry.round_number
+                    )}
+                  </td>
+                  <td className="py-1.5 pr-2">
+                    {entry.judge_verdict ? (
+                      <OutcomeBadge outcome={entry.judge_verdict.outcome} />
+                    ) : (
+                      <span className="text-xs italic text-slate-500">
+                        ground truth
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-1.5 text-slate-600">
+                    {entry.judge_verdict?.explanation || (
+                      "Original code, verified before any repair."
+                    )}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {track.abandoned.length > 0 && (
+        <div className="mt-4">
+          <div className="text-xs font-bold uppercase text-rose-700 mb-2">Abandoned variants</div>
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-left text-slate-500">
+                <th className="py-1 pr-2">Round</th>
+                <th className="py-1">Reason</th>
+              </tr>
+            </thead>
+            <tbody>
+              {track.abandoned.map((entry: AbandonedEntryView) => (
+                <tr key={`a-${entry.round_number}`} className="border-t border-slate-100">
+                  <td className="py-1.5 pr-2 font-medium">{entry.round_number}</td>
+                  <td className="py-1.5 text-slate-600">
+                    {entry.judge_verdict.explanation}
+                  </td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The full per-unit lineage section (header + panels), as shown on the
+// pipeline final report.
+export function LineageReport({ tracks }: { tracks: Record<string, UnitTrackView> }) {
+  if (!tracks || Object.keys(tracks).length === 0) {
+    return <div className="text-xs text-slate-400">No per-unit lineage recorded for this session.</div>;
+  }
+  return (
+    <div className="space-y-4">
+      <h3 className="text-sm font-bold uppercase text-slate-500">Per-unit lineage</h3>
+      {Object.entries(tracks).map(([unitId, track]) => (
+        <UnitTrackPanel key={unitId} unitId={unitId} track={track} />
+      ))}
+    </div>
+  );
+}

--- a/web/frontend/src/screens/ResultsScreen.tsx
+++ b/web/frontend/src/screens/ResultsScreen.tsx
@@ -17,11 +17,12 @@ import {
   CartesianGrid, Tooltip, ResponsiveContainer,
 } from "recharts";
 import {
-  Download, CheckCircle2, XCircle, Minus, AlertTriangle,
+  Download, CheckCircle2, AlertTriangle,
   Clock, DollarSign, Layers, Scale,
 } from "lucide-react";
 import type { SessionState } from "../hooks/useSession";
 import ImprovementView from "./ImprovementView";
+import { OutcomeBadge, UnitTrackPanel } from "./LineageReport";
 import type {
   VerificationFunction, RoundResult, UnitTrackView,
   LineageEntryView, AbandonedEntryView,
@@ -29,119 +30,6 @@ import type {
 import * as api from "../api";
 
 const COLORS = ["#6366f1", "#10b981", "#f59e0b", "#ef4444", "#38bdf8", "#ec4899"];
-
-// Pretty-print the judge outcome with an icon and colour.
-function OutcomeBadge({ outcome }: { outcome: string }) {
-  if (outcome === "improvement") {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-emerald-50 px-2 py-0.5 text-xs font-medium text-emerald-700">
-        <CheckCircle2 className="h-3 w-3" /> improvement
-      </span>
-    );
-  }
-  if (outcome === "regression") {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-rose-50 px-2 py-0.5 text-xs font-medium text-rose-700">
-        <XCircle className="h-3 w-3" /> regression
-      </span>
-    );
-  }
-  if (outcome === "no_change") {
-    return (
-      <span className="inline-flex items-center gap-1 rounded-md bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-700">
-        <Minus className="h-3 w-3" /> no change
-      </span>
-    );
-  }
-  return <span className="text-xs text-slate-500">{outcome}</span>;
-}
-
-// One per-unit panel: lineage and abandoned variants, side by side.
-function UnitTrackPanel({ unitId, track }: { unitId: string; track: UnitTrackView }) {
-  return (
-    <div className="rounded-2xl border bg-white p-5 shadow-sm">
-      <div className="flex items-baseline justify-between">
-        <h4 className="text-sm font-medium font-mono text-slate-700">{unitId}</h4>
-        <div className="text-xs text-slate-500">
-          <span className="font-medium text-emerald-700">{track.lineage.length}</span> accepted
-          {" / "}
-          <span className="font-medium text-rose-700">{track.abandoned.length}</span> abandoned
-        </div>
-      </div>
-
-      {track.lineage.length > 0 && (
-        <div className="mt-4">
-          <div className="text-xs font-bold uppercase text-slate-500 mb-2">Accepted lineage</div>
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="text-left text-slate-500">
-                <th className="py-1 pr-2">Round</th>
-                <th className="py-1 pr-2">Outcome</th>
-                <th className="py-1">Explanation</th>
-              </tr>
-            </thead>
-            <tbody>
-              {track.lineage.map((entry: LineageEntryView) => (
-                <tr key={`l-${entry.round_number}`} className="border-t border-slate-100">
-                  <td className="py-1.5 pr-2 font-medium">
-                    {entry.round_number === 0 ? (
-                      <span className="inline-flex items-center gap-1">
-                        <span>0</span>
-                        <span className="rounded bg-indigo-100 px-1 py-0.5 text-[10px] font-medium uppercase tracking-wide text-indigo-700">
-                          baseline
-                        </span>
-                      </span>
-                    ) : (
-                      entry.round_number
-                    )}
-                  </td>
-                  <td className="py-1.5 pr-2">
-                    {entry.judge_verdict ? (
-                      <OutcomeBadge outcome={entry.judge_verdict.outcome} />
-                    ) : (
-                      <span className="text-xs italic text-slate-500">
-                        ground truth
-                      </span>
-                    )}
-                  </td>
-                  <td className="py-1.5 text-slate-600">
-                    {entry.judge_verdict?.explanation || (
-                      "Original code, verified before any repair."
-                    )}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-
-      {track.abandoned.length > 0 && (
-        <div className="mt-4">
-          <div className="text-xs font-bold uppercase text-rose-700 mb-2">Abandoned variants</div>
-          <table className="w-full text-xs">
-            <thead>
-              <tr className="text-left text-slate-500">
-                <th className="py-1 pr-2">Round</th>
-                <th className="py-1">Reason</th>
-              </tr>
-            </thead>
-            <tbody>
-              {track.abandoned.map((entry: AbandonedEntryView) => (
-                <tr key={`a-${entry.round_number}`} className="border-t border-slate-100">
-                  <td className="py-1.5 pr-2 font-medium">{entry.round_number}</td>
-                  <td className="py-1.5 text-slate-600">
-                    {entry.judge_verdict.explanation}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  );
-}
 
 // Halt reason badge: green for completion, amber for budget caps.
 function HaltBadge({ reason }: { reason: string | null | undefined }) {

--- a/web/frontend/src/screens/SessionsView.tsx
+++ b/web/frontend/src/screens/SessionsView.tsx
@@ -14,6 +14,9 @@ import {
 } from "lucide-react";
 import * as api from "../api";
 import type { SessionCard } from "../api";
+import type { UnitTrackView } from "../types";
+import { LineageReport } from "./LineageReport";
+import ImprovementView from "./ImprovementView";
 
 function basename(path: string | null): string {
   if (!path) return "(unknown source)";
@@ -144,6 +147,13 @@ function SessionDetail({ id, onBack }: { id: string; onBack: () => void }) {
               </pre>
             )}
           </div>
+
+          {/* The same "Report lineage and verdict" view as the pipeline's
+              final report, reconstructed from this session's summary.json
+              tracks plus the on-disk improvement artefacts. */}
+          <LineageReport tracks={(summary.tracks as Record<string, UnitTrackView>) || {}} />
+
+          <ImprovementView sessionId={id} />
         </>
       )}
     </div>


### PR DESCRIPTION
# Review: session report view + Jupyter magic

Branch: `feature/session-report-view` (off `dev`, after the #70 merge)
**2 commits.** All checks green: **425 Python tests pass**, frontend type-checks (`tsc --noEmit`) and builds, ruff clean on changed files.

## Contents

- `session-report-jupyter.patch` (full diff vs `dev`)
- `commits/` (2 per-commit patches for `git am`)
- `changed-files/` (final versions, paths preserved)

## The two commits

### 1. `feat(library)`: full lineage and verdict report for a saved session

Opening a session from the library now shows the same "Report lineage and
verdict" view as the pipeline's final report, which is what you asked for.

- Frontend: extracted `OutcomeBadge`, `UnitTrackPanel`, and a new
  `LineageReport` wrapper into `screens/LineageReport.tsx`, shared by
  `ResultsScreen` and `SessionsView` so both render identical panels.
  `SessionDetail` now renders `LineageReport` (from the session's
  `summary.json` tracks) plus `ImprovementView` (the per-round,
  per-method audit).
- Backend: the improvement endpoint resolved its report directory only
  from live in-memory state, so it returned 404 for historical sessions.
  It now does a soft state lookup and falls back to
  `QALLM_SESSIONS_DIR/{id}` on disk. This one change is what makes the
  saved-session report view possible.
- Test: `test_improvement_disk_fallback.py` (resolves from disk for a
  non-live session; reports unavailable when truly absent).

### 2. `feat(jupyter)`: the `%%qallm` notebook magic (FEAT-10, issue #27)

The notebook frontend trigger, built as an IPython magic.

- `qallm/jupyter.py`: `%load_ext qallm.jupyter` registers a `%qallm` line
  magic (run on a path) and a `%%qallm` cell magic (run on the cell's
  code). Renders an inline HTML summary with a plain-text fallback and
  returns the summary dict. Wraps the same `QALLMOrchestrator` as the CLI
  and web UI; IPython is imported lazily so the module loads where IPython
  is absent.
- `pyproject`: optional `[jupyter]` extra.
- `docs/jupyter-magic.md`: rationale, install, usage, options, diagram.
- Test: `test_jupyter_magic.py` (7 tests, no IPython kernel needed).

**Why the magic over the alternatives** (documented in full in the doc): a
toolbar button needs per-frontend JavaScript packaging and the
nbextension model is deprecated; a notebook-targeting CLI already exists
(`qallm analysis.ipynb`). The magic is the only option that adds new
capability (in-notebook runs with inline results) at low maintenance cost,
and it works in Jupyter, JupyterLab, and VS Code notebooks.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 425 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```

To try the magic, in a notebook: `pip install -e ".[jupyter]"`, then
`%load_ext qallm.jupyter`, then `%%qallm` over a cell (needs the usual LLM
credentials, e.g. `OPENAI_API_KEY`).