### PR TITLE
Review: pipeline quality improvements

### DIFF
--- a/docs/backlog-quality-loop.md
+++ b/docs/backlog-quality-loop.md
@@ -1,0 +1,110 @@
+# Backlog: pipeline quality loop (issues to create)
+
+These are the issues to open on `assaban/qallm-uva` for the quality-loop
+work described in `docs/quality-loop-design.md`. They are written here in
+the same way `backlog-audit-2026-05.md` records issues to create, because
+they cannot be opened directly from the build environment. Create them on
+GitHub when the backlog freeze lifts.
+
+The work is deliberately staged so the shared harness lands first and the
+two modes build on it. Suggested labels follow the existing scheme
+(`RQ1` for anything touching the strategy/quality claim, plus a new
+`quality-loop` label to group them).
+
+---
+
+## QLOOP-01: Quality harness (shared core)
+
+**Labels:** quality-loop, RQ1
+**Depends on:** the experiments runner (shipped).
+
+A thin wrapper over the existing experiment runner that turns a run into a
+labelled quality point: records the QALLM version (git SHA), the
+configuration, the date, and the metric vector (bug-detection rate,
+repair-success rate, false-confidence rate, mean rounds, cost), per
+(strategy, model). Stores points in a run history that later issues read.
+
+**Acceptance criteria**
+
+* A function/CLI that runs the benchmark and writes one labelled point
+  (SHA, config, date, metrics) to a history store.
+* The metric vector includes false-confidence rate explicitly.
+* History is append-only and readable by the regression and research
+  tooling.
+* Unit-tested with a stubbed runner (no network, no LLM).
+
+---
+
+## QLOOP-02: Regression mode
+
+**Labels:** quality-loop, RQ1
+**Depends on:** QLOOP-01.
+
+Compare a candidate (branch/PR) against the stored baseline on the fixed
+(non-held-out) benchmark slice, using the pairwise Wilcoxon test already in
+the report so a few percent of LLM noise does not trip a false alarm.
+
+**Acceptance criteria**
+
+* Baseline storage: the metric vector of the current `dev` tip as the
+  reference.
+* Candidate-vs-baseline comparison per metric, with significance via the
+  pairwise test.
+* A report with per-metric delta, significance, and a verdict
+  (pass / regression / inconclusive).
+* Runnable on a branch (documented invocation).
+* Tested with synthetic per-problem outcomes (no network).
+
+---
+
+## QLOOP-03: Research mode (prompt/strategy search)
+
+**Labels:** quality-loop, RQ1
+**Depends on:** QLOOP-01.
+
+A variant registry where each variant changes exactly one knob (repair
+prompt, test-generation prompt, judge strategy, or generation policy).
+Run a variant against the current default on the tuning slice, compare with
+the pairwise test, then confirm a winner once on the held-out slice before
+promotion.
+
+**Acceptance criteria**
+
+* A variant registry: one knob per variant, named.
+* Tuning-slice comparison (variant vs default) with the pairwise test.
+* Held-out confirmation step; a variant that wins on tuning but not on
+  held-out is rejected.
+* A promotion step that makes a confirmed winner the new default and the
+  new regression baseline.
+* Tested with stubbed variants and synthetic outcomes.
+
+---
+
+## QLOOP-04: Held-out and notebook benchmarks
+
+**Labels:** quality-loop, RQ1, RQ2
+**Depends on:** QLOOP-01.
+
+Reserve a held-out slice of HumanEvalFix that is never used for tuning
+(needed by QLOOP-03's confirmation step), and add a notebook-derived
+benchmark (Li's corpus) for the research-software distribution the thesis
+targets, so the harness measures the distribution that matters, not only
+curated single-function bugs.
+
+**Acceptance criteria**
+
+* A documented, fixed held-out split of HumanEvalFix.
+* A loader for the notebook-derived benchmark in the same problem shape the
+  harness consumes.
+* Both selectable by the harness.
+
+---
+
+## Notes for whoever opens these
+
+* QLOOP-01 is the only hard prerequisite; QLOOP-02 and QLOOP-03 can proceed
+  in parallel once it lands.
+* Keep one knob per variant in QLOOP-03; multi-knob changes make an effect
+  unattributable and are out of scope for the first version.
+* The pairwise test (Wilcoxon signed-rank over per-problem outcomes) is the
+  same one in the experiment report; reuse it rather than reimplementing.

--- a/docs/experiments/humaneval.md
+++ b/docs/experiments/humaneval.md
@@ -86,50 +86,64 @@ The markdown report is the artefact to cite. It includes:
 - A per-problem detail table.
 - An errored-runs section listing any problems that failed mid-run.
 
-## Viewing results in the Web-UI
+## Using the experiment from the Web-UI
 
-Completed runs are browsable in the QALLM Web-UI under the **Experiments**
-tab (top of the page, next to **Pipeline**). No experiment is launched
-from the browser: runs take hours and download datasets, so they run from
-the CLI as above. The UI reads the artefacts each run wrote.
+The QALLM Web-UI **Experiments** tab (next to **Pipeline**) is both a
+control surface and a browser. From it you can:
+
+1. **See the catalog**: each available experiment with its dataset id,
+   source URL, citation, problem count, and what it measures.
+2. **Launch a run**: pick a sample size, model, rounds, and strategies,
+   then start a run. The run executes as a background job on the server,
+   so a long run keeps going while you do other things.
+3. **Watch live progress**: a status line, a progress bar, running
+   bug/repair/error tallies, and a streaming tail of per-problem lines,
+   the user-friendly view of what would otherwise scroll past in a
+   terminal. When the run finishes, the historical run list refreshes.
+4. **Browse historical runs**: the same read-only view as before, run
+   list to per-run aggregate cards to per-problem table to markdown
+   report.
+5. **Send the dataset through the pipeline**: instead of the experiment
+   runner, materialise the dataset's buggy programs as files and create a
+   normal pipeline session over them, so the whole dataset flows through
+   QALLM exactly like any other uploaded code, and lands in the session
+   library tagged for retrieval.
+
+Launching from the browser still does real work: datasets download from
+Hugging Face and the run calls LLMs, so the server needs network access
+and (for hosted models) credentials. The CLI path below remains available
+and is the better choice for very long unattended runs.
 
 ### Data flow
 
 ```
-  CLI                          disk (QALLM_RUNS_DIR)              Web-UI
-  ───                          ────────────────────              ──────
-  run_humaneval.py
-     │ runs QALLM per
-     │ (problem, strategy,
-     │  model) combination
-     ▼
-  humaneval_runner          runs/<run-id>/
-     │  writes  ───────────►   manifest.json     ┐
-     │                         results.jsonl     │  GET /api/experiments
-     │                         aggregates.json   ├─────────────────────►  ExperimentsView
-     │                         report.md         ┘  GET /api/experiments/{id}
-     │                                              GET .../{id}/results     run list
-     ▼                                              GET .../{id}/report       │
-  (resumable: appends                                                        ▼
-   one JSONL line per                                              per-run detail:
-   completed combination)                                          - aggregate cards
-                                                                    (bug-detection +
-                                                                     repair-success
-                                                                     per strategy/model)
-                                                                   - per-problem table
-                                                                   - markdown report
+  launch source            disk (QALLM_RUNS_DIR)              Web-UI
+  ─────────────            ────────────────────              ──────
+  Experiments tab
+   POST .../{id}/run  ──┐
+  or run_humaneval.py   │  runs/<run-id>/
+  (CLI)                 ├─►  manifest.json     ┐
+     │ runs QALLM per   │    results.jsonl     │  GET /api/experiments
+     │ (problem,        │    aggregates.json   ├──────────────►  ExperimentsView
+     │  strategy,       │    report.md         ┘  GET .../{id}, /results, /report
+     │  model)          │                                          │ run list +
+     ▼                  │  (a launched run also reports live        │ per-run detail
+  humaneval_runner ─────┘   progress via on_problem_complete ──►  GET .../progress
+     │  (resumable: one                                            (status, tallies,
+     │   JSONL line per                                             streaming log tail)
+     │   completed combo)
 ```
 
-The `experiments` API router (`src/qallm/api/routers/experiments.py`)
-reads the run directory; it never writes. Point it at a different
-location with the `QALLM_RUNS_DIR` environment variable (default `runs`).
-In the Docker stack, mount your runs directory into the api container and
-set `QALLM_RUNS_DIR` to the mount path so past runs appear in the UI.
+The read-only browse endpoints live in
+`src/qallm/api/routers/experiments.py`; the catalog, launch, progress, and
+dataset-to-pipeline endpoints live in
+`src/qallm/api/routers/experiments_control.py`. Point the run directory
+elsewhere with `QALLM_RUNS_DIR` (default `runs`). In the Docker stack,
+mount your runs directory into the api container and set `QALLM_RUNS_DIR`
+to the mount path so past runs appear in the UI.
 
-### What the UI shows
+### What the run detail shows
 
-- **Run list**: every run directory, newest first, with its strategies,
-  models, round count, and result count.
 - **Aggregate cards**: one per (strategy, model), with bug-detection rate
   and repair-success rate (and the underlying counts), plus mean rounds,
   cost, and time per problem. Comparing the cards is the headline result:

--- a/docs/quality-loop-design.md
+++ b/docs/quality-loop-design.md
@@ -1,0 +1,126 @@
+# Pipeline quality loop: design
+
+This document sketches a continuous, iterative process for improving
+QALLM's own quality over time. It is a design, not an implementation: the
+backlog freeze means we are not adding unrelated features right now, so
+this records the plan and the issues to open, ready to build when the
+freeze lifts.
+
+The loop pulls in two complementary directions, both requested:
+
+1. **Catching regressions (engineering discipline).** Every change to
+   QALLM should be measured against a fixed yardstick so a change that
+   quietly makes the pipeline worse is caught before it ships.
+2. **Searching for improvements (research).** The pipeline should have a
+   repeatable way to try prompt and strategy variants and tell, with
+   evidence, whether a variant is actually better.
+
+These share most of their machinery (a fixed benchmark, the same metrics,
+the same runner), so they are two modes of one harness rather than two
+systems.
+
+## The shared core: a quality harness
+
+A single harness runs QALLM against a fixed, labelled benchmark and emits
+a small set of headline metrics. Both modes use it.
+
+* **Benchmark.** Start with HumanEvalFix (already integrated: buggy
+  programs, canonical fixes, hidden tests). Reserve a held-out slice that
+  is never used for tuning, so research-mode search cannot overfit to the
+  set it optimises against. Later, add a notebook-derived set (Li's corpus)
+  for the research-software distribution the thesis targets.
+* **Metrics.** The numbers the experiment already computes, treated as the
+  quality vector of a QALLM version: bug-detection rate, repair-success
+  rate, false-confidence rate (the verification-gap headline), mean rounds,
+  and cost. These are computed per (strategy, model) so a change's effect
+  is visible where it lands.
+* **A run is a labelled point.** Each harness run records the QALLM
+  version (git SHA), the configuration, the date, and the metric vector.
+  Runs accumulate into a history that both modes read.
+
+## Mode 1: regression catching
+
+Goal: a change to QALLM is measured against the last known-good baseline
+on the fixed (non-held-out) benchmark, and a drop beyond a tolerance is
+flagged.
+
+* **Baseline.** The metric vector of the current `dev` tip, stored as the
+  reference. A new candidate (a branch, a PR) is run against the same
+  benchmark slice with the same seed, model, and rounds.
+* **Comparison.** Per metric, compare candidate to baseline. Because LLM
+  calls are noisy, use the same pairwise approach the experiment report
+  already uses (Wilcoxon signed-rank over per-problem outcomes) rather than
+  comparing single aggregate numbers, so a few percent of noise does not
+  trip a false alarm. A regression is a statistically significant drop in a
+  primary metric (bug-detection or repair-success) or a significant rise in
+  cost without a matching quality gain.
+* **Surfacing.** A short report: per-metric delta, significance, and a
+  verdict (pass / regression / inconclusive). Designed to be run on a
+  branch before merge, the engineering yardstick.
+* **Determinism caveat.** The harness pins seed, model, and rounds, and
+  reports that absolute numbers still move a few percent across re-runs
+  because of provider-side non-determinism. The pairwise test is what makes
+  the verdict robust to that, not an attempt to remove the noise.
+
+## Mode 2: prompt and strategy search
+
+Goal: systematically try variants of the parts of QALLM we can change
+(repair prompts, test-generation prompts, judge strategy, generation
+policy) and tell whether a variant beats the current default.
+
+* **What varies.** A variant is a named change to one knob: a repair-prompt
+  template, a test-generation-prompt template, a judge strategy, or a
+  generation policy. Exactly one knob at a time, so an effect is
+  attributable.
+* **How it is judged.** Run the variant and the current default on the same
+  benchmark slice, same seed/model/rounds, and compare with the same
+  pairwise test as Mode 1. A variant is an improvement if it significantly
+  raises a primary metric without a disproportionate cost increase.
+* **Guarding against overfitting.** Variants are searched on the tuning
+  slice; the winner is then confirmed once on the held-out slice before it
+  becomes the new default. A variant that wins on tuning but not on
+  held-out is rejected. This is the discipline that keeps research-mode
+  honest.
+* **Promotion.** A confirmed winner becomes the new default and, in turn,
+  the new regression baseline for Mode 1. The two modes feed each other:
+  research raises the bar, regression-catching holds it.
+
+## How the two modes relate
+
+```
+   research mode                          regression mode
+   ─────────────                          ───────────────
+   try variant on tuning slice            run candidate vs baseline
+        │                                      │
+        ▼                                      ▼
+   pairwise test vs default               pairwise test vs baseline
+        │ wins?                                │ regressed?
+        ▼                                      ▼
+   confirm on held-out slice              flag before merge
+        │ confirmed?                           │
+        ▼                                      │
+   promote to default ───────────────────────►│  (new baseline)
+```
+
+## Build order (when the freeze lifts)
+
+1. Extract the harness: a thin wrapper over the existing experiment runner
+   that records the version SHA and the metric vector as a labelled point,
+   and stores the run history.
+2. Regression mode: baseline storage, candidate-vs-baseline comparison with
+   the pairwise test, and a pass/regression/inconclusive report. Wire it so
+   it can run on a branch.
+3. Research mode: a variant registry (one knob per variant), the
+   tuning-then-held-out confirmation flow, and a promotion step.
+4. A held-out benchmark slice, and later a notebook-derived benchmark for
+   the research-software distribution.
+
+## Why this serves the thesis
+
+The false-confidence rate is the thesis's empirical claim. A harness that
+tracks it over QALLM versions turns that claim into a living measurement:
+the thesis can report not just one number but the trajectory as the
+pipeline improved, and can show that prompt/strategy changes moved it in a
+measurable, statistically defensible way. Regression-catching keeps the
+reported numbers trustworthy; research-mode search is how the numbers get
+better.

--- a/src/qallm/api/main.py
+++ b/src/qallm/api/main.py
@@ -28,6 +28,7 @@ from qallm.api.routers import (
     analysis,
     config,
     experiments,
+    experiments_control,
     repair,
     results,
     sessions as sessions_router,
@@ -58,6 +59,7 @@ app.include_router(repair.router)
 app.include_router(verification.router)
 app.include_router(results.router)
 app.include_router(experiments.router)
+app.include_router(experiments_control.router)
 app.include_router(sessions_library.router)
 
 

--- a/src/qallm/api/routers/experiments_control.py
+++ b/src/qallm/api/routers/experiments_control.py
@@ -1,0 +1,338 @@
+"""API router: experiment catalog and run control.
+
+Complements the read-only experiments router (which browses historical
+runs) with the ability to see what experiments are available and to launch
+a new run from the UI with live progress.
+
+Launching is real work: a run downloads its dataset from Hugging Face and
+calls LLMs, so it needs network access and credentials, and a full run
+takes hours. The launch endpoint therefore submits the run as a background
+job (reusing the job store) and streams progress via a per-run progress
+registry the runner updates through its on_problem_complete callback. The
+UI polls the progress endpoint, the same shape as a terminal would show:
+which problem just finished, how many done, the running tallies.
+
+  GET  /api/experiment-catalog            available experiments (metadata)
+  POST /api/experiment-catalog/{id}/run   launch a run, returns job + run id
+  GET  /api/experiment-runs/{run}/progress live progress for a launched run
+"""
+
+from __future__ import annotations
+
+import logging
+import threading
+import time
+from datetime import datetime
+from pathlib import Path
+
+from fastapi import APIRouter, HTTPException
+
+from qallm.jobs import JobConflictError, get_store
+from qallm.config import settings
+from qallm.experiments.catalog import get_experiment, list_experiments
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+# ---------------------------------------------------------------------------
+# Progress registry: a launched run reports per-problem completion here, and
+# the progress endpoint reads it. Keyed by run id. Thread-safe because the
+# background job runs in a worker thread.
+# ---------------------------------------------------------------------------
+
+class RunProgress:
+    """Live progress for one experiment run."""
+
+    def __init__(self, run_id: str, total: int) -> None:
+        self.run_id = run_id
+        self.total = total
+        self.completed = 0
+        self.bug_detected = 0
+        self.repair_successful = 0
+        self.errored = 0
+        # A short tail of recent per-problem lines, like terminal output.
+        self.log: list[dict] = []
+        self.status = "running"   # running | done | failed
+        self.error: str | None = None
+        self.started_at = time.time()
+        self.finished_at: float | None = None
+        self._lock = threading.Lock()
+
+    def record(self, result: dict) -> None:
+        with self._lock:
+            self.completed += 1
+            if result.get("error"):
+                self.errored += 1
+            else:
+                if result.get("bug_detected"):
+                    self.bug_detected += 1
+                if result.get("repair_successful"):
+                    self.repair_successful += 1
+            line = {
+                "task_id": result.get("task_id"),
+                "strategy": result.get("strategy"),
+                "model": result.get("model"),
+                "bug_detected": result.get("bug_detected"),
+                "repair_successful": result.get("repair_successful"),
+                "error": result.get("error"),
+                "at": time.time(),
+            }
+            # Keep the last 100 lines so the registry stays bounded.
+            self.log.append(line)
+            if len(self.log) > 100:
+                self.log = self.log[-100:]
+
+    def finish(self, error: str | None = None) -> None:
+        with self._lock:
+            self.status = "failed" if error else "done"
+            self.error = error
+            self.finished_at = time.time()
+
+    def to_dict(self) -> dict:
+        with self._lock:
+            return {
+                "run_id": self.run_id,
+                "status": self.status,
+                "total": self.total,
+                "completed": self.completed,
+                "bug_detected": self.bug_detected,
+                "repair_successful": self.repair_successful,
+                "errored": self.errored,
+                "log": list(self.log),
+                "error": self.error,
+                "started_at": self.started_at,
+                "finished_at": self.finished_at,
+            }
+
+
+_progress: dict[str, RunProgress] = {}
+_progress_lock = threading.Lock()
+
+
+def _put_progress(p: RunProgress) -> None:
+    with _progress_lock:
+        _progress[p.run_id] = p
+
+
+def _get_progress(run_id: str) -> RunProgress | None:
+    with _progress_lock:
+        return _progress.get(run_id)
+
+
+# ---------------------------------------------------------------------------
+# Catalog
+# ---------------------------------------------------------------------------
+
+@router.get("/api/experiment-catalog")
+async def experiment_catalog():
+    """List available experiments with their dataset/citation metadata."""
+    return {"experiments": [e.to_dict() for e in list_experiments()]}
+
+
+# ---------------------------------------------------------------------------
+# Launch
+# ---------------------------------------------------------------------------
+
+def _run_experiment_work(run_id: str, spec_id: str, params: dict) -> dict:
+    """Background work: run the experiment, updating the progress registry.
+
+    Imported lazily so the experiments extra (datasets) is only needed when
+    a run is actually launched, not at import time.
+    """
+    from qallm.experiments.humaneval_runner import ExperimentConfig, run_experiment
+
+    progress = _get_progress(run_id)
+
+    def on_complete(result) -> None:
+        # ProblemResult is a dataclass; normalise to dict for the registry.
+        from dataclasses import asdict, is_dataclass
+        d = asdict(result) if is_dataclass(result) else dict(result)
+        if progress:
+            progress.record(d)
+
+    config = ExperimentConfig(
+        output_dir=Path(settings.QALLM_RUNS_DIR) / run_id,
+        models=params["models"],
+        strategies=params["strategies"],
+        sample_size=params.get("sample_size"),
+        seed=params.get("seed", 0),
+        rounds=params.get("rounds", 5),
+        oracle=params.get("oracle", "crash"),
+        judge_strategy=params.get("judge_strategy", "lexicographic"),
+    )
+    try:
+        results = run_experiment(config, on_problem_complete=on_complete)
+        if progress:
+            progress.finish()
+        return {"run_id": run_id, "n_results": len(results)}
+    except Exception as exc:  # noqa: BLE001 - surface to the job + progress
+        if progress:
+            progress.finish(error=str(exc))
+        raise
+
+
+@router.post("/api/experiment-catalog/{experiment_id}/run")
+async def launch_experiment(experiment_id: str, req: dict):
+    """Launch an experiment run as a background job.
+
+    Body: {models: [...], strategies: [...], sample_size?, seed?, rounds?,
+    oracle?, judge_strategy?}. Returns the run id (also the run directory
+    name) and a job id; poll /api/experiment-runs/{run}/progress for live
+    status and /api/experiments/{run} for the final artefacts.
+    """
+    spec = get_experiment(experiment_id)
+    if spec is None:
+        raise HTTPException(status_code=404, detail="Unknown experiment")
+
+    models = req.get("models") or []
+    strategies = req.get("strategies") or []
+    if not models or not strategies:
+        raise HTTPException(status_code=400,
+                            detail="models and strategies are required")
+
+    sample_size = req.get("sample_size")
+    # Estimate total problem-combinations for the progress bar.
+    n_problems = sample_size if sample_size else spec.n_problems
+    total = n_problems * len(strategies) * len(models)
+
+    run_id = f"{experiment_id}_{datetime.now().strftime('%Y%m%d_%H%M%S')}"
+    _put_progress(RunProgress(run_id, total))
+
+    params = {
+        "models": models,
+        "strategies": strategies,
+        "sample_size": sample_size,
+        "seed": req.get("seed", 0),
+        "rounds": req.get("rounds", 5),
+        "oracle": req.get("oracle", "crash"),
+        "judge_strategy": req.get("judge_strategy", "lexicographic"),
+    }
+
+    store = get_store()
+    try:
+        job = await store.submit_sync(
+            session_id=run_id,         # the run id keys the job
+            kind="experiment",
+            work=lambda: _run_experiment_work(run_id, experiment_id, params),
+        )
+    except JobConflictError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+
+    return {"run_id": run_id, "job_id": job.job_id, "status": job.status.value}
+
+
+@router.get("/api/experiment-runs/{run_id}/progress")
+async def experiment_progress(run_id: str):
+    """Live progress for a launched run.
+
+    Returns the registry snapshot if the run was launched in this process.
+    Falls back to a not-tracked response otherwise (e.g. a CLI run, or
+    after a server restart); the historical artefacts remain available via
+    the experiments browse endpoints.
+    """
+    p = _get_progress(run_id)
+    if p is None:
+        return {"run_id": run_id, "tracked": False}
+    snap = p.to_dict()
+    snap["tracked"] = True
+    return snap
+
+
+# ---------------------------------------------------------------------------
+# Dataset through the pipeline
+# ---------------------------------------------------------------------------
+
+@router.post("/api/experiment-catalog/{experiment_id}/to-pipeline")
+async def dataset_to_pipeline(experiment_id: str, req: dict):
+    """Load an experiment's dataset into the normal pipeline.
+
+    Instead of the experiment runner, this materialises the dataset's buggy
+    programs as .py files in a directory and creates a standard pipeline
+    session over that directory, so the whole dataset flows through QALLM
+    exactly like any other uploaded code. The returned session_id behaves
+    like any other: configure and run it from the pipeline, browse it in
+    the session library.
+
+    Body: {sample_size?, seed?, model?, strategy?, oracle?, rounds?, tags?}.
+    """
+    spec = get_experiment(experiment_id)
+    if spec is None:
+        raise HTTPException(status_code=404, detail="Unknown experiment")
+
+    # Lazy import: datasets extra only needed when this is actually called.
+    try:
+        from qallm.experiments.humaneval_dataset import load_humanevalfix
+    except Exception as exc:  # noqa: BLE001
+        raise HTTPException(
+            status_code=500,
+            detail=f"Could not load the experiments module: {exc}",
+        ) from exc
+
+    sample_size = req.get("sample_size")
+    seed = req.get("seed", 0)
+    try:
+        problems = load_humanevalfix(sample_size=sample_size, seed=seed)
+    except Exception as exc:  # noqa: BLE001 - dataset download can fail
+        raise HTTPException(
+            status_code=502,
+            detail=(f"Could not load the dataset ({spec.dataset_id}): {exc}. "
+                    "A network connection is required."),
+        ) from exc
+
+    materialised = _materialise_problems(problems)
+    session_id = _create_pipeline_session(materialised, req, experiment_id)
+    return {
+        "session_id": session_id,
+        "experiment_id": experiment_id,
+        "n_files": len(problems),
+        "directory": materialised,
+    }
+
+
+def _materialise_problems(problems: list) -> str:
+    """Write each problem's buggy program to its own .py file, return the dir."""
+    import tempfile
+
+    out = Path(tempfile.mkdtemp(prefix="qallm_dataset_"))
+    for p in problems:
+        # task_id like "Python/0" -> a safe file name.
+        safe = p.task_id.replace("/", "_")
+        (out / f"{safe}.py").write_text(p.buggy_full_source, encoding="utf-8")
+    return str(out)
+
+
+def _create_pipeline_session(directory: str, req: dict, experiment_id: str) -> str:
+    """Create a normal pipeline session over a directory of programs."""
+    import uuid
+
+    from qallm.api.core import parse_model_id, sessions
+    from qallm.orchestrator import QALLMOrchestrator
+
+    model = req.get("model", "openai:gpt-4o-mini")
+    llm_type, model_name = parse_model_id(model)
+    tags = req.get("tags") or [experiment_id, "dataset"]
+
+    session_id = str(uuid.uuid4())
+    run_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{session_id[:8]}"
+    orchestrator = QALLMOrchestrator(
+        stage=req.get("stage", "implementation"),
+        strategy=req.get("strategy", "feedback"),
+        llm_type=llm_type,
+        model_name=model_name,
+        oracle=req.get("oracle", "crash"),
+        rounds=req.get("rounds", 5),
+        run_id=run_id,
+        tags=tags,
+    )
+    units = orchestrator.ingestion_manager.collect(directory)
+    sessions[session_id] = {
+        "orchestrator": orchestrator,
+        "units": units,
+        "analysed_units": {},
+        "repaired_units": {},
+        "analysis_rounds": [],
+        "config": req,
+    }
+    return session_id

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -62,19 +62,52 @@ async def get_stats(session_id: str):
     }
 
 
+def _extract_test_bodies(test_code: str | None) -> dict[str, str]:
+    """Map each test function name to its exact source body.
+
+    Parsing the generated test file with AST lets the UI show the precise
+    method body for every test, so a passing test is self-evident from its
+    body and a failing one can be read alongside its failure reason. Falls
+    back to an empty map if the code does not parse.
+    """
+    if not test_code:
+        return {}
+    import ast
+
+    bodies: dict[str, str] = {}
+    try:
+        tree = ast.parse(test_code)
+    except SyntaxError:
+        return {}
+    lines = test_code.splitlines()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("test"):
+                continue
+            start = node.lineno - 1
+            end = getattr(node, "end_lineno", None)
+            if end is None:
+                continue
+            bodies[node.name] = "\n".join(lines[start:end])
+    return bodies
+
+
 def _summarise_bug_detail(verification: list | None) -> list[dict]:
     """Extract per-function, per-test bug detail from a round's verification.
 
     The web UI shows aggregate counts ("4 bugs") but not *which* generated
-    tests failed or why. This surfaces that: for each function verified in
-    the round, the final round's executed tests with their pytest status
-    (passed/failed/error/skipped) and the failure message. A failed test is
-    a bug the generated tests caught by execution, the thing static analysis
-    misses.
+    tests ran, their exact body, or why a failing one failed. This surfaces
+    all of that: for each function verified in the round, the final round's
+    executed tests with their pytest status (passed/failed/error/skipped),
+    the exact test body (extracted from the generated test file), and the
+    full failure reason. A failed test is a bug the generated tests caught
+    by execution, the thing static analysis misses; success is self-evident
+    from the presence of the test body.
 
     ``verification`` is the parsed verification.json: a list of session
     dicts (one per function), each with a ``rounds`` list whose last entry
-    holds the ``execution`` with ``test_details``.
+    holds the ``execution`` with ``test_details`` and a ``generated_test``
+    with the ``test_code``.
     """
     if not verification:
         return []
@@ -85,12 +118,16 @@ def _summarise_bug_detail(verification: list | None) -> list[dict]:
             continue
         last = rounds[-1]
         execution = last.get("execution") or {}
+        generated = last.get("generated_test") or {}
+        bodies = _extract_test_bodies(generated.get("test_code"))
         details = execution.get("test_details") or []
         tests = [
             {
                 "name": d.get("name", "?"),
                 "status": d.get("status", "?"),
                 "message": d.get("message"),
+                # The exact test method body; success is self-evident from it.
+                "body": bodies.get(d.get("name", ""), ""),
             }
             for d in details
         ]
@@ -103,6 +140,8 @@ def _summarise_bug_detail(verification: list | None) -> list[dict]:
             "total": execution.get("total", 0),
             "coverage_percent": execution.get("coverage_percent"),
             "execution_error": execution.get("execution_error"),
+            # The full generated test file, for reference / download.
+            "test_code": generated.get("test_code", ""),
             # The bugs: tests that ran and failed (not errored).
             "bug_tests": [t for t in tests if t["status"] == "failed"],
             "all_tests": tests,

--- a/src/qallm/api/routers/sessions.py
+++ b/src/qallm/api/routers/sessions.py
@@ -52,6 +52,9 @@ async def upload_session(
     max_seconds: Optional[float] = Form(None),
     max_round_seconds: Optional[float] = Form(None),
     max_cost_usd: Optional[float] = Form(None),
+    # Optional custom tags/names for grouping and retrieving sessions,
+    # supplied as a comma-separated string (e.g. "thesis,baseline,run-3").
+    tags: str = Form(""),
 ):
     """Upload files, create session, initialise orchestrator.
 
@@ -112,6 +115,7 @@ async def upload_session(
         # A short timestamp prefix is included for human readability when
         # browsing the outputs/ directory.
         run_id = f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{session_id[:8]}"
+        tag_list = [t.strip() for t in tags.split(",") if t.strip()]
         orchestrator = QALLMOrchestrator(
             stage=stage,
             strategy=strategy,
@@ -128,6 +132,7 @@ async def upload_session(
             testgen_llm_type=testgen_llm_type,
             testgen_model_name=testgen_model_name,
             run_id=run_id,
+            tags=tag_list,
         )
         units = orchestrator.ingestion_manager.collect(target)
 
@@ -187,6 +192,7 @@ async def ingest_source(req: dict):
             model_name=model_name,
             oracle=req.get("oracle", "crash"),
             rounds=req.get("rounds", 5),
+            tags=req.get("tags") or [],
         )
         units = orchestrator.ingestion_manager.collect(source_path)
 

--- a/src/qallm/api/routers/sessions_library.py
+++ b/src/qallm/api/routers/sessions_library.py
@@ -54,6 +54,7 @@ def _summarise(session_id: str, summary: dict) -> dict:
     return {
         "id": session_id,
         "source": summary.get("source"),
+        "tags": summary.get("tags") or [],
         "strategy": summary.get("strategy"),
         "model": summary.get("model"),
         "profile_id": profile.get("profile_id"),
@@ -70,17 +71,20 @@ def _summarise(session_id: str, summary: dict) -> dict:
 
 
 @router.get("/api/library")
-async def list_sessions():
+async def list_sessions(tag: str | None = None):
     """List every processed session with a compact summary card.
 
+    Optionally filter to sessions carrying a given ``tag``. Also returns
+    the set of all tags in use, so the UI can offer them as filter chips.
     Empty list when the sessions directory does not exist, so the UI shows
     an empty state rather than an error.
     """
     base = _sessions_dir()
     if not os.path.isdir(base):
-        return {"sessions_dir": base, "sessions": []}
+        return {"sessions_dir": base, "sessions": [], "all_tags": []}
 
     sessions = []
+    all_tags: set[str] = set()
     for name in sorted(os.listdir(base), reverse=True):
         path = os.path.join(base, name)
         if not os.path.isdir(path) or not _is_session_dir(path):
@@ -88,8 +92,14 @@ async def list_sessions():
         summary = _read_json(os.path.join(path, "summary.json")) or {}
         card = _summarise(name, summary)
         card["has_report"] = os.path.isfile(os.path.join(path, "report.md"))
+        all_tags.update(card.get("tags") or [])
+        # Apply the tag filter after collecting all_tags, so the filter
+        # chips always reflect the full corpus, not the filtered view.
+        if tag and tag not in (card.get("tags") or []):
+            continue
         sessions.append(card)
-    return {"sessions_dir": base, "sessions": sessions}
+    return {"sessions_dir": base, "sessions": sessions,
+            "all_tags": sorted(all_tags)}
 
 
 def _session_path_or_404(session_id: str) -> str:

--- a/src/qallm/experiments/catalog.py
+++ b/src/qallm/experiments/catalog.py
@@ -1,0 +1,74 @@
+"""Catalog of validation experiments available in QALLM.
+
+The Experiments tab lists these so a user can see what each experiment is,
+the dataset it draws on, the citation and source URL, and what the code
+looks like, then launch a run or browse historical runs. Keeping the
+catalog as data (not hard-coded in the UI) means adding an experiment is a
+backend change in one place.
+
+Each entry is descriptive metadata only; the actual run is driven by
+``qallm.experiments.humaneval_runner``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass, field
+
+
+@dataclass(frozen=True)
+class ExperimentSpec:
+    """Descriptive metadata for one available experiment."""
+
+    id: str
+    name: str
+    summary: str
+    dataset_id: str          # the dataset identifier (e.g. a HF dataset)
+    dataset_url: str         # where to view the dataset
+    citation: str            # how to cite the dataset/benchmark
+    n_problems: int          # size of the full set
+    measures: list[str] = field(default_factory=list)  # what it measures
+    notes: str = ""
+
+    def to_dict(self) -> dict:
+        return asdict(self)
+
+
+# The HumanEvalFix benchmark: each task ships a buggy solution, the
+# canonical fix, and a hidden unit-test suite, so it measures both whether
+# QALLM detects the planted bug (by execution) and whether it repairs it.
+HUMANEVALFIX = ExperimentSpec(
+    id="humanevalfix",
+    name="HumanEvalFix (Python)",
+    summary=(
+        "Each task carries a buggy program, its canonical fix, and a hidden "
+        "unit-test suite. Measures whether QALLM detects the planted bug by "
+        "execution and whether the improvement loop repairs it, across "
+        "strategies and models."
+    ),
+    dataset_id="bigcode/humanevalpack",
+    dataset_url="https://huggingface.co/datasets/bigcode/humanevalpack",
+    citation=(
+        "Muennighoff et al. (2023), OctoPack: Instruction Tuning Code Large "
+        "Language Models. The HumanEvalPack/HumanEvalFix benchmark, Python "
+        "subset."
+    ),
+    n_problems=164,
+    measures=["bug detection rate", "repair success rate", "rounds", "cost"],
+    notes=(
+        "Datasets download from Hugging Face at run time, so a run needs "
+        "network access and (for hosted models) LLM credentials. A full run "
+        "over all 164 problems across several strategies/models takes hours; "
+        "use a sample size for quick checks."
+    ),
+)
+
+
+_CATALOG = {HUMANEVALFIX.id: HUMANEVALFIX}
+
+
+def list_experiments() -> list[ExperimentSpec]:
+    return list(_CATALOG.values())
+
+
+def get_experiment(experiment_id: str) -> ExperimentSpec | None:
+    return _CATALOG.get(experiment_id)

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -121,6 +121,7 @@ class QALLMOrchestrator:
             testgen_model_name: str | None = None,
             run_id: str | None = None,
             reporter: QualityReporter | None = None,
+            tags: list[str] | None = None,
     ) -> None:
         """Construct the orchestrator.
 
@@ -172,6 +173,16 @@ class QALLMOrchestrator:
         # session schema use the current vocabulary. Behaviour is identical.
         self.strategy = "feedback" if strategy == "rl" else strategy
         self.oracle = oracle
+        # User-supplied tags for grouping and retrieving sessions. Trimmed,
+        # de-duplicated, blanks dropped; order preserved.
+        self.tags: list[str] = []
+        if tags:
+            seen = set()
+            for raw in tags:
+                t = (raw or "").strip()
+                if t and t not in seen:
+                    seen.add(t)
+                    self.tags.append(t)
         self.profile = profile
 
         # Budget caps: if not supplied, construct from the legacy `rounds`
@@ -676,6 +687,7 @@ class QALLMOrchestrator:
 
         summary = {
             "source": source_path,
+            "tags": self.tags,
             "strategy": self.strategy,
             "judge_strategy": self.judge_strategy_name,
             "lifecycle_stage": self.stage.value,

--- a/tests/test_bug_detail.py
+++ b/tests/test_bug_detail.py
@@ -63,3 +63,55 @@ def test_uses_final_round():
     fn = _summarise_bug_detail(v)[0]
     assert fn["failed"] == 1  # from the LAST round
     assert len(fn["all_tests"]) == 2
+
+
+def test_extract_test_bodies():
+    from qallm.api.routers.results import _extract_test_bodies
+    code = (
+        "import pytest\n"
+        "def test_a():\n"
+        "    assert add(1, 2) == 3\n"
+        "def test_b():\n"
+        "    with pytest.raises(ValueError):\n"
+        "        add(None, 1)\n"
+        "def helper():\n"
+        "    return 1\n"
+    )
+    bodies = _extract_test_bodies(code)
+    assert set(bodies) == {"test_a", "test_b"}  # only test* functions
+    assert "assert add(1, 2) == 3" in bodies["test_a"]
+    assert "pytest.raises(ValueError)" in bodies["test_b"]
+    assert "helper" not in bodies
+
+
+def test_extract_test_bodies_handles_bad_code():
+    from qallm.api.routers.results import _extract_test_bodies
+    assert _extract_test_bodies(None) == {}
+    assert _extract_test_bodies("def (((") == {}
+
+
+def test_bug_detail_attaches_body_and_reason():
+    from qallm.api.routers.results import _summarise_bug_detail
+    code = (
+        "def test_ok():\n    assert f() == 1\n"
+        "def test_bug():\n    assert f() == 2\n"
+    )
+    v = [{
+        "function_name": "f",
+        "rounds": [{
+            "generated_test": {"test_code": code},
+            "execution": {
+                "passed": 1, "failed": 1, "errors": 0, "skipped": 0, "total": 2,
+                "test_details": [
+                    {"name": "test_ok", "status": "passed", "message": None},
+                    {"name": "test_bug", "status": "failed",
+                     "message": "assert 1 == 2"},
+                ]}}]}]
+    fn = _summarise_bug_detail(v)[0]
+    assert fn["test_code"] == code
+    by_name = {t["name"]: t for t in fn["all_tests"]}
+    # Every test carries its exact body; success is self-evident from it.
+    assert "assert f() == 1" in by_name["test_ok"]["body"]
+    assert "assert f() == 2" in by_name["test_bug"]["body"]
+    # The failing test carries the exact reason.
+    assert by_name["test_bug"]["message"] == "assert 1 == 2"

--- a/tests/test_experiments_control.py
+++ b/tests/test_experiments_control.py
@@ -1,0 +1,109 @@
+"""Tests for the experiment catalog, launch, progress, and dataset-to-pipeline."""
+
+from dataclasses import dataclass
+from unittest.mock import patch
+
+from fastapi.testclient import TestClient
+
+import qallm.api.routers.experiments_control as ec
+from qallm.api.main import app
+
+client = TestClient(app)
+
+
+def test_catalog_lists_experiments_with_metadata():
+    body = client.get("/api/experiment-catalog").json()
+    ids = [e["id"] for e in body["experiments"]]
+    assert "humanevalfix" in ids
+    hef = next(e for e in body["experiments"] if e["id"] == "humanevalfix")
+    assert hef["citation"]
+    assert hef["dataset_url"].startswith("https://")
+    assert hef["n_problems"] == 164
+
+
+def test_launch_requires_models_and_strategies():
+    r = client.post("/api/experiment-catalog/humanevalfix/run", json={})
+    assert r.status_code == 400
+
+
+def test_launch_unknown_experiment_404():
+    r = client.post("/api/experiment-catalog/nope/run",
+                    json={"models": ["m"], "strategies": ["rl"]})
+    assert r.status_code == 404
+
+
+def test_progress_untracked_run():
+    body = client.get("/api/experiment-runs/never_launched/progress").json()
+    assert body["tracked"] is False
+
+
+def test_progress_registry_records_results():
+    p = ec.RunProgress("rp_test", total=2)
+    p.record({"task_id": "Python/0", "strategy": "rl", "model": "m",
+              "bug_detected": True, "repair_successful": True, "error": None})
+    p.record({"task_id": "Python/1", "strategy": "rl", "model": "m",
+              "bug_detected": False, "repair_successful": False,
+              "error": "boom"})
+    snap = p.to_dict()
+    assert snap["completed"] == 2
+    assert snap["bug_detected"] == 1
+    assert snap["repair_successful"] == 1
+    assert snap["errored"] == 1
+    assert len(snap["log"]) == 2
+
+
+def test_run_work_drives_progress_to_done():
+    @dataclass
+    class FakeResult:
+        task_id: str
+        strategy: str
+        model: str
+        bug_detected: bool
+        repair_successful: bool
+        error: object
+
+    def fake_run(config, on_problem_complete=None):
+        out = []
+        for i in range(3):
+            r = FakeResult(f"Python/{i}", "rl", "stub", i != 1, i == 0, None)
+            if on_problem_complete:
+                on_problem_complete(r)
+            out.append(r)
+        return out
+
+    ec._put_progress(ec.RunProgress("rw_test", total=3))
+    with patch("qallm.experiments.humaneval_runner.run_experiment", fake_run), \
+         patch("qallm.experiments.humaneval_runner.ExperimentConfig",
+               lambda **k: type("C", (), k)):
+        out = ec._run_experiment_work("rw_test", "humanevalfix",
+                                      {"models": ["stub"], "strategies": ["rl"],
+                                       "sample_size": 3})
+    assert out["n_results"] == 3
+    snap = ec._get_progress("rw_test").to_dict()
+    assert snap["status"] == "done"
+    assert snap["completed"] == 3
+    assert snap["bug_detected"] == 2
+
+
+def test_materialise_and_create_session():
+    @dataclass
+    class P:
+        task_id: str
+        src: str
+
+        @property
+        def buggy_full_source(self):
+            return self.src
+
+    problems = [P("Python/0", "def f():\n    return 1\n"),
+                P("Python/1", "def g():\n    return 2\n")]
+    d = ec._materialise_problems(problems)
+    import os
+    assert set(os.listdir(d)) == {"Python_0.py", "Python_1.py"}
+
+    sid = ec._create_pipeline_session(
+        d, {"model": "openai:gpt-4o-mini", "tags": ["heval"]}, "humanevalfix")
+    from qallm.api.core import sessions
+    assert sid in sessions
+    assert len(sessions[sid]["units"]) == 2
+    assert sessions[sid]["orchestrator"].tags == ["heval"]

--- a/tests/test_session_tags.py
+++ b/tests/test_session_tags.py
@@ -1,0 +1,64 @@
+"""Tests for session tagging: orchestrator normalisation and library filter."""
+
+import json
+
+import pytest
+from fastapi.testclient import TestClient
+
+from qallm.api.main import app
+from qallm.orchestrator import QALLMOrchestrator
+
+client = TestClient(app)
+
+
+def test_orchestrator_normalises_tags():
+    o = QALLMOrchestrator(tags=["  thesis ", "baseline", "thesis", "", "baseline"])
+    # Trimmed, de-duplicated, blanks dropped, order preserved.
+    assert o.tags == ["thesis", "baseline"]
+
+
+def test_orchestrator_no_tags_is_empty_list():
+    assert QALLMOrchestrator().tags == []
+    assert QALLMOrchestrator(tags=None).tags == []
+
+
+@pytest.fixture
+def sessions_dir(tmp_path, monkeypatch):
+    specs = {
+        "s1": ["thesis", "run-1"],
+        "s2": ["baseline"],
+        "s3": ["thesis"],
+    }
+    for sid, tags in specs.items():
+        d = tmp_path / sid
+        d.mkdir()
+        (d / "summary.json").write_text(json.dumps({
+            "source": f"{sid}.py", "tags": tags, "strategy": "feedback",
+            "cost": {}}))
+    monkeypatch.setattr("qallm.config.settings.QALLM_SESSIONS_DIR", str(tmp_path))
+    monkeypatch.setattr(
+        "qallm.api.routers.sessions_library.settings.QALLM_SESSIONS_DIR",
+        str(tmp_path))
+    return tmp_path
+
+
+def test_library_lists_tags_and_all_tags(sessions_dir):
+    body = client.get("/api/library").json()
+    assert len(body["sessions"]) == 3
+    assert body["all_tags"] == ["baseline", "run-1", "thesis"]
+    by_id = {s["id"]: s for s in body["sessions"]}
+    assert by_id["s1"]["tags"] == ["thesis", "run-1"]
+
+
+def test_library_filters_by_tag(sessions_dir):
+    body = client.get("/api/library?tag=thesis").json()
+    ids = {s["id"] for s in body["sessions"]}
+    assert ids == {"s1", "s3"}
+    # all_tags still reflects the full corpus, not the filtered view.
+    assert body["all_tags"] == ["baseline", "run-1", "thesis"]
+
+
+def test_library_filter_unknown_tag_empty(sessions_dir):
+    body = client.get("/api/library?tag=nope").json()
+    assert body["sessions"] == []
+    assert body["all_tags"] == ["baseline", "run-1", "thesis"]

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -528,3 +528,55 @@ export async function getLibrarySession(id: string): Promise<{
 export async function getLibrarySessionReport(id: string): Promise<{ id: string; markdown: string }> {
   return req(`/api/library/${encodeURIComponent(id)}/report`);
 }
+
+// ─── Experiment catalog, launch, live progress ───
+export interface ExperimentSpec {
+  id: string;
+  name: string;
+  summary: string;
+  dataset_id: string;
+  dataset_url: string;
+  citation: string;
+  n_problems: number;
+  measures: string[];
+  notes: string;
+}
+
+export interface ExperimentProgress {
+  run_id: string;
+  tracked: boolean;
+  status?: "running" | "done" | "failed";
+  total?: number;
+  completed?: number;
+  bug_detected?: number;
+  repair_successful?: number;
+  errored?: number;
+  log?: Array<{
+    task_id: string; strategy: string; model: string;
+    bug_detected: boolean; repair_successful: boolean;
+    error: string | null; at: number;
+  }>;
+  error?: string | null;
+}
+
+export async function listExperimentCatalog(): Promise<{ experiments: ExperimentSpec[] }> {
+  return req<{ experiments: ExperimentSpec[] }>("/api/experiment-catalog");
+}
+
+export async function launchExperiment(id: string, params: {
+  models: string[]; strategies: string[]; sample_size?: number;
+  seed?: number; rounds?: number; oracle?: string; judge_strategy?: string;
+}): Promise<{ run_id: string; job_id: string; status: string }> {
+  return post(`/api/experiment-catalog/${encodeURIComponent(id)}/run`, params);
+}
+
+export async function getExperimentProgress(runId: string): Promise<ExperimentProgress> {
+  return req<ExperimentProgress>(`/api/experiment-runs/${encodeURIComponent(runId)}/progress`);
+}
+
+export async function datasetToPipeline(id: string, params: {
+  sample_size?: number; seed?: number; model?: string; strategy?: string;
+  oracle?: string; rounds?: number; tags?: string[];
+}): Promise<{ session_id: string; experiment_id: string; n_files: number; directory: string }> {
+  return post(`/api/experiment-catalog/${encodeURIComponent(id)}/to-pipeline`, params);
+}

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -358,6 +358,7 @@ export interface BugTest {
   name: string;
   status: "passed" | "failed" | "error" | "skipped";
   message: string | null;
+  body: string;
 }
 
 export interface FunctionBugDetail {
@@ -369,6 +370,7 @@ export interface FunctionBugDetail {
   total: number;
   coverage_percent: number | null;
   execution_error: string | null;
+  test_code: string;
   bug_tests: BugTest[];
   all_tests: BugTest[];
 }

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -28,6 +28,8 @@ export interface SessionConfig {
   model_name: string;
   oracle: string;
   rounds: number;
+  // Optional custom tags for grouping/retrieving the session later.
+  tags?: string;
   // Optional advanced settings (NEW-08). Undefined values fall back to
   // server defaults; the upload endpoint only forwards what's present.
   repair_model?: string;
@@ -61,6 +63,7 @@ export async function uploadFiles(files: FileList, config: SessionConfig) {
   if (config.max_seconds !== undefined) form.append("max_seconds", String(config.max_seconds));
   if (config.max_round_seconds !== undefined) form.append("max_round_seconds", String(config.max_round_seconds));
   if (config.max_cost_usd !== undefined) form.append("max_cost_usd", String(config.max_cost_usd));
+  if (config.tags) form.append("tags", config.tags);
 
   return req<{ session_id: string; files: string[]; config?: Record<string, unknown> }>("/api/session/upload", {
     method: "POST",
@@ -493,6 +496,7 @@ export async function getExperimentReport(id: string): Promise<{ id: string; mar
 export interface SessionCard {
   id: string;
   source: string | null;
+  tags: string[];
   strategy: string | null;
   model: string | null;
   profile_id: string | null;
@@ -508,8 +512,9 @@ export interface SessionCard {
   has_report: boolean;
 }
 
-export async function listLibrarySessions(): Promise<{ sessions_dir: string; sessions: SessionCard[] }> {
-  return req<{ sessions_dir: string; sessions: SessionCard[] }>("/api/library");
+export async function listLibrarySessions(tag?: string): Promise<{ sessions_dir: string; sessions: SessionCard[]; all_tags: string[] }> {
+  const q = tag ? `?tag=${encodeURIComponent(tag)}` : "";
+  return req<{ sessions_dir: string; sessions: SessionCard[]; all_tags: string[] }>(`/api/library${q}`);
 }
 
 export async function getLibrarySession(id: string): Promise<{

--- a/web/frontend/src/screens/ExperimentsView.tsx
+++ b/web/frontend/src/screens/ExperimentsView.tsx
@@ -11,7 +11,7 @@
 import { useEffect, useState } from "react";
 import {
   FlaskConical, ChevronRight, ChevronLeft, Bug, Wrench,
-  Clock, DollarSign, AlertTriangle, FileText,
+  Clock, DollarSign, AlertTriangle, FileText, Play,
 } from "lucide-react";
 import * as api from "../api";
 import type {
@@ -200,6 +200,165 @@ function RunDetail({ id, onBack }: { id: string; onBack: () => void }) {
   );
 }
 
+function CatalogPanel({ onLaunched }: { onLaunched: () => void }) {
+  const [specs, setSpecs] = useState<import("../api").ExperimentSpec[]>([]);
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [sampleSize, setSampleSize] = useState<string>("10");
+  const [strategies, setStrategies] = useState<string[]>(["feedback", "oneshot"]);
+  const [model, setModel] = useState("openai:gpt-4o-mini");
+  const [rounds, setRounds] = useState("3");
+  const [progressRunId, setProgressRunId] = useState<string | null>(null);
+  const [progress, setProgress] = useState<import("../api").ExperimentProgress | null>(null);
+  const [launching, setLaunching] = useState(false);
+  const [launchError, setLaunchError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    api.listExperimentCatalog().then((r) => alive && setSpecs(r.experiments)).catch(() => {});
+    return () => { alive = false; };
+  }, []);
+
+  // Poll progress while a run is active.
+  useEffect(() => {
+    if (!progressRunId) return;
+    let alive = true;
+    const tick = () => {
+      api.getExperimentProgress(progressRunId).then((p) => {
+        if (!alive) return;
+        setProgress(p);
+        if (p.tracked && p.status === "running") {
+          setTimeout(tick, 1500);
+        } else if (p.status === "done" || p.status === "failed") {
+          onLaunched();  // refresh the run list when finished
+        }
+      }).catch(() => {});
+    };
+    tick();
+    return () => { alive = false; };
+  }, [progressRunId, onLaunched]);
+
+  function toggleStrategy(s: string) {
+    setStrategies((prev) => prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]);
+  }
+
+  async function launch(id: string) {
+    setLaunching(true);
+    setLaunchError(null);
+    try {
+      const r = await api.launchExperiment(id, {
+        models: [model],
+        strategies,
+        sample_size: sampleSize ? Number(sampleSize) : undefined,
+        rounds: Number(rounds),
+      });
+      setProgressRunId(r.run_id);
+    } catch (e) {
+      setLaunchError(e instanceof Error ? e.message : "Launch failed");
+    } finally {
+      setLaunching(false);
+    }
+  }
+
+  if (!specs.length) return null;
+
+  return (
+    <div className="space-y-3">
+      <h3 className="text-sm font-semibold text-slate-700">Available experiments</h3>
+      {specs.map((spec) => {
+        const open = openId === spec.id;
+        return (
+          <div key={spec.id} className="rounded-2xl border border-slate-200 bg-white p-4 shadow-sm">
+            <div className="flex items-start justify-between gap-3">
+              <div>
+                <div className="font-semibold text-slate-800">{spec.name}</div>
+                <p className="mt-1 text-sm text-slate-500">{spec.summary}</p>
+              </div>
+              <button
+                onClick={() => setOpenId(open ? null : spec.id)}
+                className="shrink-0 rounded-lg border border-slate-200 px-3 py-1.5 text-xs font-medium text-slate-600 hover:bg-slate-50"
+              >
+                {open ? "Close" : "Details & run"}
+              </button>
+            </div>
+
+            {open && (
+              <div className="mt-4 space-y-4 border-t border-slate-100 pt-4">
+                {/* Dataset details + citation */}
+                <div className="grid gap-2 text-xs text-slate-600 sm:grid-cols-2">
+                  <div><span className="text-slate-400">Dataset:</span> <a href={spec.dataset_url} target="_blank" rel="noreferrer" className="text-indigo-600 underline">{spec.dataset_id}</a></div>
+                  <div><span className="text-slate-400">Problems:</span> {spec.n_problems}</div>
+                  <div className="sm:col-span-2"><span className="text-slate-400">Measures:</span> {spec.measures.join(", ")}</div>
+                  <div className="sm:col-span-2"><span className="text-slate-400">Citation:</span> {spec.citation}</div>
+                </div>
+                {spec.notes && <p className="rounded-lg bg-amber-50 px-3 py-2 text-xs text-amber-800">{spec.notes}</p>}
+
+                {/* Launch form */}
+                <div className="grid gap-3 sm:grid-cols-3">
+                  <label className="text-xs text-slate-600">Sample size
+                    <input value={sampleSize} onChange={(e) => setSampleSize(e.target.value)} placeholder="blank = all 164" className="mt-1 w-full rounded-lg border p-2 text-sm" />
+                  </label>
+                  <label className="text-xs text-slate-600">Model
+                    <input value={model} onChange={(e) => setModel(e.target.value)} className="mt-1 w-full rounded-lg border p-2 text-sm" />
+                  </label>
+                  <label className="text-xs text-slate-600">Rounds
+                    <input value={rounds} onChange={(e) => setRounds(e.target.value)} className="mt-1 w-full rounded-lg border p-2 text-sm" />
+                  </label>
+                </div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="text-xs text-slate-400">Strategies:</span>
+                  {["feedback", "oneshot", "hypothesis"].map((s) => (
+                    <button key={s} onClick={() => toggleStrategy(s)}
+                      className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${strategies.includes(s) ? "bg-indigo-600 text-white" : "bg-slate-100 text-slate-600"}`}>
+                      {s}
+                    </button>
+                  ))}
+                </div>
+
+                <div className="flex items-center gap-3">
+                  <button
+                    onClick={() => launch(spec.id)}
+                    disabled={launching || strategies.length === 0}
+                    className="flex items-center gap-1.5 rounded-lg bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+                  >
+                    <Play className="h-3.5 w-3.5" /> {launching ? "Launching…" : "Launch run"}
+                  </button>
+                  <span className="text-xs text-slate-400">Needs network and (for hosted models) credentials. Long runs continue in the background.</span>
+                </div>
+                {launchError && <p className="text-xs text-rose-600">{launchError}</p>}
+
+                {/* Live progress */}
+                {progress && progress.tracked && (
+                  <div className="rounded-xl border border-slate-200 bg-slate-50 p-3">
+                    <div className="flex items-center justify-between text-xs">
+                      <span className="font-semibold text-slate-700">
+                        {progress.status === "running" ? "Running" : progress.status === "done" ? "Complete" : "Failed"} · {progress.completed}/{progress.total}
+                      </span>
+                      <span className="text-slate-500">
+                        {progress.bug_detected} bugs · {progress.repair_successful} repaired{progress.errored ? ` · ${progress.errored} errored` : ""}
+                      </span>
+                    </div>
+                    <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-slate-200">
+                      <div className="h-full bg-indigo-500" style={{ width: `${progress.total ? (100 * (progress.completed || 0) / progress.total) : 0}%` }} />
+                    </div>
+                    {progress.error && <p className="mt-2 text-xs text-rose-600">{progress.error}</p>}
+                    {progress.log && progress.log.length > 0 && (
+                      <pre className="mt-2 max-h-44 overflow-auto whitespace-pre-wrap rounded bg-slate-900 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-100">
+                        {progress.log.slice(-20).map((l) =>
+                          `${l.task_id} [${l.strategy}/${l.model}] ${l.error ? "ERROR " + l.error : (l.bug_detected ? "bug" : "no-bug") + (l.repair_successful ? " repaired" : "")}`
+                        ).join("\n")}
+                      </pre>
+                    )}
+                  </div>
+                )}
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 export default function ExperimentsView() {
   const [runs, setRuns] = useState<ExperimentRunSummary[]>([]);
   const [selected, setSelected] = useState<string | null>(null);
@@ -224,6 +383,8 @@ export default function ExperimentsView() {
       <p className="text-sm text-slate-500">
         HumanEvalFix benchmark runs: how well QALLM detects and repairs known bugs across strategies and models. Click a run to see its strategy comparison and per-problem detail.
       </p>
+      <CatalogPanel onLaunched={() => { api.listExperiments().then((r) => setRuns(r.runs)).catch(() => {}); }} />
+      <h3 className="pt-2 text-sm font-semibold text-slate-700">Historical runs</h3>
       {loading ? (
         <div className="py-8 text-center text-sm text-slate-400">Loading runs…</div>
       ) : (

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -151,10 +151,23 @@ function BugDetailView({ functions }: { functions: import("../api").FunctionBugD
                         {t.status === "failed" ? "BUG" : t.status.toUpperCase()}
                       </span>
                     </div>
-                    {(isBug || isErr) && t.message && (
-                      <pre className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap rounded bg-slate-900 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-100">
-                        {t.message}
+                    {/* The exact test body. For a passing test this is the
+                        self-evident proof of success; for a failing one it
+                        sits above the failure reason so both read together. */}
+                    {t.body && (
+                      <pre className="mt-1 max-h-56 overflow-auto whitespace-pre rounded bg-slate-50 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-700">
+                        {t.body}
                       </pre>
+                    )}
+                    {(isBug || isErr) && t.message && (
+                      <div className="mt-1">
+                        <div className="text-[10px] font-semibold uppercase tracking-wide text-rose-500">
+                          {isBug ? "Why it failed" : "Error"}
+                        </div>
+                        <pre className="mt-0.5 max-h-56 overflow-auto whitespace-pre-wrap rounded bg-slate-900 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-100">
+                          {t.message}
+                        </pre>
+                      </div>
                     )}
                   </div>
                 );

--- a/web/frontend/src/screens/SessionsView.tsx
+++ b/web/frontend/src/screens/SessionsView.tsx
@@ -55,6 +55,13 @@ function SessionList({ sessions, onSelect }: {
               {s.model && <span>{s.model}</span>}
               {s.profile_id && <><span className="text-slate-300">·</span><span>{s.profile_id}</span></>}
             </div>
+            {s.tags && s.tags.length > 0 && (
+              <div className="mt-1.5 flex flex-wrap gap-1">
+                {s.tags.map((t) => (
+                  <span key={t} className="rounded-full bg-indigo-50 px-2 py-0.5 text-[11px] font-medium text-indigo-700">{t}</span>
+                ))}
+              </div>
+            )}
           </div>
           <div className="flex shrink-0 items-center gap-3 text-xs text-slate-400">
             {s.rounds_accepted_total != null && (
@@ -162,16 +169,24 @@ function SessionDetail({ id, onBack }: { id: string; onBack: () => void }) {
 
 export default function SessionsView() {
   const [sessions, setSessions] = useState<SessionCard[]>([]);
+  const [allTags, setAllTags] = useState<string[]>([]);
+  const [activeTag, setActiveTag] = useState<string | null>(null);
   const [selected, setSelected] = useState<string | null>(null);
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
     let alive = true;
-    api.listLibrarySessions()
-      .then((r) => alive && setSessions(r.sessions))
+    setLoading(true);
+    api.listLibrarySessions(activeTag || undefined)
+      .then((r) => {
+        if (!alive) return;
+        setSessions(r.sessions);
+        // Keep the full tag set stable so chips don't vanish when filtering.
+        if (r.all_tags.length) setAllTags(r.all_tags);
+      })
       .finally(() => alive && setLoading(false));
     return () => { alive = false; };
-  }, []);
+  }, [activeTag]);
 
   if (selected) return <SessionDetail id={selected} onBack={() => setSelected(null)} />;
 
@@ -184,6 +199,26 @@ export default function SessionsView() {
       <p className="text-sm text-slate-500">
         Every session the pipeline has processed, newest first. Click one to see its configuration, accept/abandon totals, cost, and full report.
       </p>
+      {allTags.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1.5">
+          <span className="text-xs font-medium text-slate-400">Filter by tag:</span>
+          <button
+            onClick={() => setActiveTag(null)}
+            className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${activeTag === null ? "bg-slate-900 text-white" : "bg-slate-100 text-slate-600 hover:bg-slate-200"}`}
+          >
+            All
+          </button>
+          {allTags.map((t) => (
+            <button
+              key={t}
+              onClick={() => setActiveTag(t)}
+              className={`rounded-full px-2.5 py-0.5 text-xs font-medium ${activeTag === t ? "bg-indigo-600 text-white" : "bg-indigo-50 text-indigo-700 hover:bg-indigo-100"}`}
+            >
+              {t}
+            </button>
+          ))}
+        </div>
+      )}
       {loading ? (
         <div className="py-8 text-center text-sm text-slate-400">Loading sessions…</div>
       ) : (

--- a/web/frontend/src/screens/UploadScreen.tsx
+++ b/web/frontend/src/screens/UploadScreen.tsx
@@ -69,6 +69,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
     oracle: "crash",
     rounds: 5,
     model_name: "",
+    tags: "",
   });
 
   // Advanced config (under expandable panel, all optional).
@@ -250,6 +251,19 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
             <input type="number" min={1} max={20} value={config.rounds} onChange={e => setConfig({ ...config, rounds: Number(e.target.value) })} className="w-full rounded-xl border p-2.5 text-sm" />
           </div>
         )}
+
+        {/* Tags: optional, comma-separated, for grouping/retrieving sessions. */}
+        <div className="space-y-1.5">
+          <label className="text-xs font-bold text-slate-500 uppercase">Tags (optional)</label>
+          <input
+            type="text"
+            value={config.tags}
+            onChange={e => setConfig({ ...config, tags: e.target.value })}
+            placeholder="e.g. thesis, baseline, run-3"
+            className="w-full rounded-xl border p-2.5 text-sm"
+          />
+          <p className="text-xs text-slate-400">Comma-separated. Use these to group and filter sessions in the library.</p>
+        </div>
 
         {/* Advanced settings, collapsible */}
         <div className="border-t pt-4">


### PR DESCRIPTION
Branch: `feature/test-observability` (off `dev`, after the #71 merge)
**5 commits.** All checks green: **440 Python tests pass**, frontend type-checks (`tsc --noEmit`) and builds, ruff clean on changed files.

This bundle delivers the quality-improvement requests: richer test-result observability, session tagging, experiments-from-the-tab (catalog, launch, live progress, dataset-through-pipeline), the quality-loop design plus backlog issues, and a refreshed experiment readme.

## Contents

- `quality-improvements.patch` (full diff vs `dev`)
- `commits/` (5 per-commit patches for `git am`)
- `changed-files/` (final versions, paths preserved)

## The five commits

1. `feat(observability)`: per round, per function, every generated test now carries its **exact source body** (extracted via AST), so a passing test is self-evident from its body, and failing/errored tests show the **precise reason** beneath under a "Why it failed" / "Error" label. Backend `_extract_test_bodies` + extended `_summarise_bug_detail`; frontend `ImprovementView`.

2. `feat(sessions)`: **custom tags** for sessions. Set comma-separated tags at upload; the session library shows tag chips per card and a filter-by-tag chip row; the API gained a `?tag=` filter and an `all_tags` aggregate. Orchestrator normalises and persists tags in `summary.json`.

3. `feat(experiments)`: the Experiments tab becomes a **control surface**. A catalog (dataset id, source URL, citation, problem count, measures); **launch** a run as a background job; **live progress** (status, progress bar, running bug/repair/error tallies, a streaming per-problem log tail, polled while active); and **dataset-through-pipeline** (materialise the dataset's buggy programs as files and create a normal pipeline session over them, tagged for retrieval). New `experiments/catalog.py` and `api/routers/experiments_control.py`.

4. `docs(experiments)`: **humaneval.md refreshed** to reflect launch-from-tab and dataset-to-pipeline (it previously said runs could not be launched from the browser), with an updated data-flow diagram.

5. `docs(quality-loop)`: the **quality-loop design** (`docs/quality-loop-design.md`) and **backlog issues** (`docs/backlog-quality-loop.md`). One shared harness, two modes: regression-catching (candidate vs baseline, pairwise Wilcoxon so LLM noise does not false-alarm) and prompt/strategy search (one-knob variants, tuning then held-out confirmation, promotion). Four issues to open (QLOOP-01..04). Design and backlog only, respecting the freeze on unrelated features.

## Important operational note

Experiments download datasets from Hugging Face and call LLMs, so a launched run needs network access and (for hosted models) credentials. The build sandbox blocks huggingface.co, so the launch/progress/dataset machinery is fully exercised here with **stubs and synthetic data**; real runs happen in your environment. The CLI path (`scripts/run_humaneval.py`) remains the better choice for long unattended runs.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 440 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```