### PR TITLE
Review: observability improvements + experiment-launch fixes

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,7 +47,7 @@ WORKDIR /home/qallm/app
 COPY pyproject.toml README.md ./
 COPY src ./src
 RUN pip install --no-cache-dir --upgrade pip \
-    && pip install --no-cache-dir .
+    && pip install --no-cache-dir ".[experiments]"
 
 # Drop build-essential now that pip install is done; it added ~250MB.
 RUN apt-get purge -y build-essential \

--- a/src/qallm/api/routers/experiments_control.py
+++ b/src/qallm/api/routers/experiments_control.py
@@ -192,6 +192,23 @@ async def launch_experiment(experiment_id: str, req: dict):
         raise HTTPException(status_code=400,
                             detail="models and strategies are required")
 
+    # Pre-flight: the experiment needs the datasets package to load its
+    # benchmark from the Hub. Check it here, before creating a run id,
+    # progress entry, or job, so a missing dependency fails cleanly and
+    # never leaves an empty run directory cluttering the history.
+    try:
+        import datasets  # noqa: F401
+    except ImportError as exc:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "This server cannot run experiments: the 'datasets' package "
+                "is not installed. Rebuild the API image (it now installs the "
+                "experiments extra), or install it with "
+                "pip install -e \".[experiments]\"."
+            ),
+        ) from exc
+
     sample_size = req.get("sample_size")
     # Estimate total problem-combinations for the progress bar.
     n_problems = sample_size if sample_size else spec.n_problems

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -121,18 +121,29 @@ def _summarise_bug_detail(verification: list | None) -> list[dict]:
         generated = last.get("generated_test") or {}
         bodies = _extract_test_bodies(generated.get("test_code"))
         details = execution.get("test_details") or []
+
+        def _bare_name(nodeid: str) -> str:
+            # test_details names are pytest nodeids like
+            # "test_generated.py::test_foo"; the body map is keyed by the
+            # bare function name. Take the part after the last "::".
+            return nodeid.rsplit("::", 1)[-1] if nodeid else ""
+
         tests = [
             {
                 "name": d.get("name", "?"),
                 "status": d.get("status", "?"),
                 "message": d.get("message"),
                 # The exact test method body; success is self-evident from it.
-                "body": bodies.get(d.get("name", ""), ""),
+                "body": bodies.get(_bare_name(d.get("name", "")), ""),
             }
             for d in details
         ]
         functions.append({
             "function": session.get("function") or session.get("function_name", "?"),
+            # The source of the function (code unit) under test. Shown
+            # alongside the tests so a reviewer can read the test against
+            # what it exercises; especially useful for passing tests.
+            "source_code": session.get("source_code", ""),
             "passed": execution.get("passed", 0),
             "failed": execution.get("failed", 0),
             "errors": execution.get("errors", 0),

--- a/src/qallm/verification/executor.py
+++ b/src/qallm/verification/executor.py
@@ -43,7 +43,9 @@ def _parse_pytest_json(report_path: Path) -> tuple[list[TestDetail], dict[str, i
         message = None
         call_info = test.get("call", {})
         if call_info and call_info.get("longrepr"):
-            message = str(call_info["longrepr"])[:500]
+            # Keep enough of the traceback for the detailed assertion diff
+            # (-v / --tb=long), not just the one-line summary.
+            message = str(call_info["longrepr"])[:2000]
 
         details.append(TestDetail(
             name=test.get("nodeid", "unknown"), status=status,
@@ -134,7 +136,10 @@ def run_tests(
             "--json-report", f"--json-report-file={json_report_path}",
             f"--cov={module_name}", "--cov-branch",
             f"--cov-report=json:{coverage_json_path}",
-            "--cov-report=", "--no-header", "--tb=short", "-q",
+            # -v and a long traceback give the detailed assertion diff the
+            # user needs to understand *why* a test failed (e.g. the full
+            # "At index 1 diff" breakdown), not just the one-line summary.
+            "--cov-report=", "--no-header", "--tb=long", "-v",
         ]
 
         logger.debug("Executing tests in %s (timeout=%ds)", work_dir, timeout)

--- a/tests/test_bug_detail.py
+++ b/tests/test_bug_detail.py
@@ -115,3 +115,34 @@ def test_bug_detail_attaches_body_and_reason():
     assert "assert f() == 2" in by_name["test_bug"]["body"]
     # The failing test carries the exact reason.
     assert by_name["test_bug"]["message"] == "assert 1 == 2"
+
+
+def test_bug_detail_matches_nodeid_to_body_and_includes_source():
+    """Test names are pytest nodeids (file::name); bodies are keyed by the
+    bare name. The summariser must reconcile them, and surface the function
+    source under test."""
+    from qallm.api.routers.results import _summarise_bug_detail
+    code = (
+        "from source import f\n"
+        "def test_ok():\n    assert f(1) == 1\n"
+        "def test_bug():\n    assert f(2) == 9\n"
+    )
+    v = [{
+        "function_name": "f",
+        "source_code": "def f(x):\n    return x\n",
+        "rounds": [{
+            "generated_test": {"test_code": code},
+            "execution": {
+                "passed": 1, "failed": 1, "errors": 0, "skipped": 0, "total": 2,
+                "test_details": [
+                    {"name": "test_generated.py::test_ok", "status": "passed",
+                     "message": None},
+                    {"name": "test_generated.py::test_bug", "status": "failed",
+                     "message": "assert 2 == 9"},
+                ]}}]}]
+    fn = _summarise_bug_detail(v)[0]
+    assert fn["source_code"] == "def f(x):\n    return x\n"
+    by_name = {t["name"]: t for t in fn["all_tests"]}
+    # Bodies resolved despite the nodeid prefix.
+    assert "assert f(1) == 1" in by_name["test_generated.py::test_ok"]["body"]
+    assert "assert f(2) == 9" in by_name["test_generated.py::test_bug"]["body"]

--- a/tests/test_experiments_control.py
+++ b/tests/test_experiments_control.py
@@ -107,3 +107,25 @@ def test_materialise_and_create_session():
     assert sid in sessions
     assert len(sessions[sid]["units"]) == 2
     assert sessions[sid]["orchestrator"].tags == ["heval"]
+
+
+def test_launch_without_datasets_returns_clear_400(monkeypatch):
+    """A server missing the datasets package fails the launch cleanly,
+    without creating a run id, progress entry, or empty run directory."""
+    import builtins
+
+    real_import = builtins.__import__
+
+    def fake_import(name, *a, **k):
+        if name == "datasets":
+            raise ImportError("no datasets")
+        return real_import(name, *a, **k)
+
+    before = dict(ec._progress)
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    r = client.post("/api/experiment-catalog/humanevalfix/run",
+                    json={"models": ["m"], "strategies": ["feedback"]})
+    assert r.status_code == 400
+    assert "datasets" in r.json()["detail"]
+    # No progress entry was created for a rejected launch.
+    assert dict(ec._progress) == before

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -366,6 +366,7 @@ export interface BugTest {
 
 export interface FunctionBugDetail {
   function: string;
+  source_code: string;
   passed: number;
   failed: number;
   errors: number;

--- a/web/frontend/src/screens/ExperimentsView.tsx
+++ b/web/frontend/src/screens/ExperimentsView.tsx
@@ -8,7 +8,7 @@
  * hours and download datasets), this surfaces what they produced.
  */
 
-import { useEffect, useState } from "react";
+import { useEffect, useState, useRef, useCallback } from "react";
 import {
   FlaskConical, ChevronRight, ChevronLeft, Bug, Wrench,
   Clock, DollarSign, AlertTriangle, FileText, Play,
@@ -218,24 +218,43 @@ function CatalogPanel({ onLaunched }: { onLaunched: () => void }) {
     return () => { alive = false; };
   }, []);
 
-  // Poll progress while a run is active.
+  // Keep a stable ref to onLaunched so the polling effect does not restart
+  // every time the parent re-renders (which created a fresh callback and,
+  // via setRuns -> re-render, an unbounded loop of polling requests).
+  const onLaunchedRef = useRef(onLaunched);
+  useEffect(() => { onLaunchedRef.current = onLaunched; }, [onLaunched]);
+
+  // Poll progress while a run is active. Restarts only when the run id
+  // changes, never on callback identity. Reschedules a tick ONLY while the
+  // run is genuinely still running; any terminal or untracked state stops
+  // the loop and (once) refreshes the historical run list.
   useEffect(() => {
     if (!progressRunId) return;
     let alive = true;
+    let notified = false;
+    const finish = () => {
+      if (notified) return;
+      notified = true;
+      onLaunchedRef.current();
+    };
     const tick = () => {
       api.getExperimentProgress(progressRunId).then((p) => {
         if (!alive) return;
         setProgress(p);
         if (p.tracked && p.status === "running") {
           setTimeout(tick, 1500);
-        } else if (p.status === "done" || p.status === "failed") {
-          onLaunched();  // refresh the run list when finished
+        } else {
+          // done, failed, or untracked: stop polling, refresh once.
+          finish();
         }
-      }).catch(() => {});
+      }).catch(() => {
+        // On a transient error, stop rather than hammering the server.
+        if (alive) finish();
+      });
     };
     tick();
     return () => { alive = false; };
-  }, [progressRunId, onLaunched]);
+  }, [progressRunId]);
 
   function toggleStrategy(s: string) {
     setStrategies((prev) => prev.includes(s) ? prev.filter((x) => x !== s) : [...prev, s]);
@@ -383,7 +402,7 @@ export default function ExperimentsView() {
       <p className="text-sm text-slate-500">
         HumanEvalFix benchmark runs: how well QALLM detects and repairs known bugs across strategies and models. Click a run to see its strategy comparison and per-problem detail.
       </p>
-      <CatalogPanel onLaunched={() => { api.listExperiments().then((r) => setRuns(r.runs)).catch(() => {}); }} />
+      <CatalogPanel onLaunched={useCallback(() => { api.listExperiments().then((r) => setRuns(r.runs)).catch(() => {}); }, [])} />
       <h3 className="pt-2 text-sm font-semibold text-slate-700">Historical runs</h3>
       {loading ? (
         <div className="py-8 text-center text-sm text-slate-400">Loading runs…</div>

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -134,6 +134,16 @@ function BugDetailView({ functions }: { functions: import("../api").FunctionBugD
                 {fn.errors > 0 && <span className="rounded bg-amber-50 px-1.5 py-0.5 font-semibold text-amber-700">{fn.errors} err</span>}
               </span>
             </div>
+            {fn.source_code && (
+              <details className="border-b border-slate-100 px-3 py-2">
+                <summary className="cursor-pointer text-[11px] font-semibold uppercase tracking-wide text-slate-400">
+                  Function under test
+                </summary>
+                <pre className="mt-1 max-h-72 overflow-auto whitespace-pre rounded bg-slate-50 px-2 py-1.5 font-mono text-[11px] leading-relaxed text-slate-700">
+                  {fn.source_code}
+                </pre>
+              </details>
+            )}
             <div className="divide-y divide-slate-50">
               {fn.all_tests.length === 0 && (
                 <div className="px-3 py-2 text-xs text-slate-400">No tests executed.</div>


### PR DESCRIPTION
Branch: `feature/experiment-fixes` (off `dev`, after the #72 merge)
**2 commits.** All green: **442 Python tests pass**, frontend type-checks and builds, ruff clean on changed files.

## Contents

- `observability-experiment-fixes.patch` (full diff vs `dev`)
- `commits/` (2 per-commit patches for `git am`)
- `changed-files/` (final versions, paths preserved)

## Commit 1: experiment-launch fixes

Two issues from launching an experiment in the deployed web UI:

1. **datasets missing in the container.** The Dockerfile installed the package without the experiments extra, so every launch failed with "the 'datasets' package is required". The image now installs `.[experiments]`. Added a pre-flight check in the launch endpoint so a server still missing it returns a clear 400 *before* creating a run id, progress entry, or empty run directory (those empty dirs were cluttering the historical-runs list).

2. **Progress-request flood.** The polling effect depended on the `onLaunched` callback, which the parent recreated every render; calling it re-rendered the parent, produced a new callback, restarted the effect, and started another polling loop without bound. Fixed: poll keyed only on the run id, `onLaunched` held in a ref (and memoised with `useCallback`), reschedule only while genuinely running, and stop on any terminal/untracked state or transient error.

## Commit 2: observability improvements

Your four asks, addressed:

1. **Function under test.** Each function's bug-detail panel now carries its `source_code`, shown as a collapsible "Function under test" block above the tests.
2. **Test method body.** Reliable now: test names are pytest nodeids (`test_generated.py::test_foo`) but the AST body map is keyed by the bare name, so the previous lookup silently missed and bodies were not showing. The summariser reconciles them by taking the part after `::`. (This means test bodies appear correctly now, where before they were blank.)
3. **Both benefit passing tests:** the source block plus the test body make a passing test self-evident.
4. **Verbose failures.** The executor runs pytest with `-v --tb=long` (was `-q --tb=short`), and the failure-message truncation rose from 500 to 2000 chars, so the detailed assertion diff (e.g. the full "At index 1 diff" breakdown) survives.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 442 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```

## Important: rebuild the API image

The datasets fix is in the Dockerfile, so the deployed API container must be **rebuilt** for experiment launches to work:

```
docker compose build api      # or: docker compose up --build
```

After the rebuild, launching an experiment needs network access and (for hosted models) LLM credentials, as before.