### PR TITLE
Review: SonarQube/analyser/experiment fixes + ideas roadmap

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -61,3 +61,9 @@ OLLAMA_PORT=11434
 #   SONARQUBE_URL=https://sonarcloud.io
 #   SONARQUBE_ORGANIZATION=your-org-key
 SONARQUBE_PORT=9000
+
+# Bake the SonarQube scanner CLI into the api image. Required for the
+# SonarQube analyzer to actually run (without it, the analyzer no-ops and
+# the pipeline falls back to Radon/Bandit). Adds a JRE (~200MB), so it is
+# off by default. Set to 1 and rebuild: docker compose build api
+WITH_SONAR_SCANNER=0

--- a/Dockerfile
+++ b/Dockerfile
@@ -54,6 +54,27 @@ RUN apt-get purge -y build-essential \
     && apt-get autoremove -y \
     && rm -rf /var/lib/apt/lists/*
 
+# Optional: the SonarQube scanner CLI. Off by default to keep the image
+# lean (it pulls a JRE, ~200MB). Build with --build-arg WITH_SONAR_SCANNER=1
+# (the compose api service sets this) when you intend to use the optional
+# SonarQube analyzer. Without it, the SonarQube analyzer simply no-ops and
+# the pipeline runs on Radon/Bandit, as designed.
+ARG WITH_SONAR_SCANNER=0
+ARG SONAR_SCANNER_VERSION=5.0.1.3006
+USER root
+RUN if [ "$WITH_SONAR_SCANNER" = "1" ]; then \
+        apt-get update \
+        && apt-get install -y --no-install-recommends default-jre-headless unzip curl \
+        && curl -fsSL -o /tmp/scanner.zip \
+            "https://binaries.sonarsource.com/Distribution/sonar-scanner-cli/sonar-scanner-cli-${SONAR_SCANNER_VERSION}-linux.zip" \
+        && unzip -q /tmp/scanner.zip -d /opt \
+        && ln -s "/opt/sonar-scanner-${SONAR_SCANNER_VERSION}-linux/bin/sonar-scanner" /usr/local/bin/sonar-scanner \
+        && rm /tmp/scanner.zip \
+        && apt-get purge -y unzip curl \
+        && apt-get autoremove -y \
+        && rm -rf /var/lib/apt/lists/* ; \
+    fi
+
 # Copy the built frontend into the location FastAPI will serve from.
 # Vite's outDir is configured as ../dist (i.e. web/dist), so the build
 # stage's output sits at /app/dist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,6 +14,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Set WITH_SONAR_SCANNER=1 in your environment (or .env) and rebuild
+        # to bake the SonarQube scanner CLI into the image, needed for the
+        # optional SonarQube analyzer. Defaults off to keep the image lean.
+        WITH_SONAR_SCANNER: ${WITH_SONAR_SCANNER:-0}
     image: qallm:latest
     container_name: qallm-api
     ports:

--- a/docs/ideas-research-developer-kit.md
+++ b/docs/ideas-research-developer-kit.md
@@ -1,0 +1,195 @@
+# QALLM as a kit for researchers and developers: ideas
+
+This is a wide-ranging set of ideas for turning QALLM from a thesis
+artefact into a tool people reach for. It is grounded in what QALLM
+already is: an execution-based, quality-model-guided code improvement loop
+whose central empirical claim is the verification gap, that static
+analysis passes code which still fails at runtime, and that running
+generated tests catches what reading the code cannot.
+
+The ideas are organised by the question they answer, not by component, so
+each one starts from a real user need. Each is tagged with a rough effort
+(S/M/L) and who it serves (researcher / developer / both). Nothing here is
+a commitment; it is a menu to prioritise from. None of it is built yet.
+
+A guiding principle runs through all of it: QALLM's distinctive value is
+execution-based evidence. Ideas that deepen, surface, or make that
+evidence more trustworthy are worth more than ideas that add surface area.
+
+---
+
+## 1. Make the core claim impossible to miss
+
+The verification gap is the reason QALLM exists, yet a new user has to
+infer it. Make it the first thing they see and feel.
+
+* **Gap-front-and-centre dashboard** (M, both). A single headline on the
+  results and session views: "N functions passed static analysis; M of
+  those failed under execution." That ratio is the false-confidence rate,
+  the thesis's number. Showing it per session turns every run into
+  evidence for the claim.
+* **Static-vs-execution diff view** (M, both). Side by side: what Bandit
+  and Radon (and SonarQube, when on) reported, versus what the generated
+  tests found by running the code. The cases where the right column has
+  bugs the left column missed are the product in one screen.
+* **"Why static analysis was not enough" explainer per bug** (S,
+  researcher). For each execution-found bug, a one-line statement of why no
+  static tool could have caught it (it depends on a runtime value, a state
+  interaction, a specific input). This is thesis-grade material and also
+  teaches developers what they are getting.
+
+## 2. Deepen the evidence (the moat)
+
+These make the execution evidence richer and more trustworthy, which is
+where QALLM is differentiated.
+
+* **Minimised failing input** (M, both). When a generated test fails,
+  shrink the input to the smallest one that still fails (delta-debugging /
+  Hypothesis-style shrinking). A one-line minimal counterexample is far
+  more useful than a complex one, and it is exactly the kind of artefact a
+  developer pastes into a bug report.
+* **Root-cause localisation** (L, both). Combine the failing test, the
+  coverage trace, and the source to point at the most suspect line(s)
+  (spectrum-based fault localisation: lines executed by failing-but-not-
+  passing tests rank highest). "The bug is most likely here" is a large
+  step up from "a test failed".
+* **Mutation testing as a confidence score** (L, researcher). Run the
+  accepted tests against mutated versions of the code; the kill rate tells
+  you how much to trust a "no bugs found" verdict. This directly addresses
+  the obvious critique of any test-generation tool: absence of failures is
+  weak evidence unless the tests are known to be sensitive.
+* **Differential testing against the canonical** (M, researcher). Where a
+  reference implementation exists (as in HumanEvalFix), run both on the
+  same inputs and report divergences. This is a stronger oracle than
+  crash-only and is already partly modelled by the metamorphic/property
+  oracles.
+* **Flaky-test detection** (S, both). Re-run a passing/failing test a few
+  times; flag non-determinism. A flaky generated test is noise that
+  pollutes the false-confidence number, so detecting it protects the core
+  metric.
+
+## 3. Meet developers where they work
+
+QALLM is most useful if it fits an existing workflow rather than asking for
+a detour.
+
+* **CI / pre-commit integration** (M, developer). A `qallm check` mode that
+  runs the pipeline on changed files and fails CI (or a pre-commit hook)
+  when execution finds a regression a static linter would have passed.
+  This is the verification gap as a guardrail, the most natural developer
+  adoption path.
+* **GitHub Action + PR comment** (M, developer). On a pull request, run
+  QALLM on the diff and post a comment: bugs found by execution, with the
+  minimal failing input and suggested fix. SonarQube's AI CodeFix posts
+  static suggestions; QALLM would post execution-verified ones, the direct
+  contrast.
+* **LSP / editor surfacing** (L, developer). Surface execution-found issues
+  inline in the editor, not just in a separate UI. Heavier, but it is where
+  developers actually live.
+* **Deepen the Jupyter magic** (S, researcher). Build on the existing
+  `%%qallm` magic: a `%qallm_watch` that re-runs on cell change, and
+  rendering the minimal failing input inline. Notebooks are where research
+  software is written; this is high-leverage for the thesis audience.
+
+## 4. Serve the researcher's actual job
+
+Researchers need to produce defensible claims, reproduce results, and
+write them up.
+
+* **The quality loop** (L, researcher). Already designed in
+  `docs/quality-loop-design.md`: regression-catching plus prompt/strategy
+  search over a fixed benchmark. This is the single most valuable research
+  feature, because it turns QALLM's own improvement into measured,
+  defensible evidence and produces the thesis's trajectory data.
+* **Experiment reproducibility bundle** (M, researcher). One click to
+  export a run as a self-contained bundle: the exact config, seeds, model
+  versions, dataset slice, the per-problem results, and the environment
+  (a lock file). A reviewer can re-run it. This is what makes an
+  experiment citable rather than anecdotal.
+* **Cross-run comparison view** (M, researcher). Pick two runs (or two
+  QALLM versions) and see the metric deltas with the pairwise significance
+  test already used in the report. This is the manual companion to the
+  automated regression mode.
+* **Notebook-corpus benchmark** (L, researcher). Beyond HumanEvalFix, run
+  against Li's notebook corpus (the research-software distribution the
+  thesis targets) so the numbers reflect the real population, not only
+  curated single-function bugs. Already noted as QLOOP-04.
+* **LaTeX / figure export** (S, researcher). Export the aggregate tables
+  and the bug-detection comparison as LaTeX tables and publication-quality
+  figures, straight into the thesis. Small effort, disproportionate
+  goodwill from the one user who matters most right now.
+
+## 5. Make it trustworthy and safe to run
+
+Adoption depends on people trusting the tool with their code and their
+budget.
+
+* **Cost preflight and hard caps** (S, both). Before a run, estimate the
+  token/USD cost from the unit count and rounds, and show it. The budget
+  caps exist; surfacing the estimate up front prevents surprise bills and
+  builds trust.
+* **Sandbox hardening transparency** (M, both). Document and surface that
+  generated code runs in an isolated subprocess, what it can and cannot
+  reach (network, filesystem), and let the user tighten it. Researchers
+  running untrusted-ish generated code need to know the blast radius.
+* **Deterministic replay** (M, researcher). Persist enough (prompts,
+  responses, seeds) to replay a session without calling the LLM again, for
+  debugging the pipeline and for cheap re-analysis. The transcript capture
+  already exists; this builds on it.
+* **Offline-first mode** (M, both). A configuration that runs entirely on
+  local models (Ollama) and local analysers, no hosted API, for users who
+  cannot send code to a third party. Important for institutional and
+  privacy-sensitive users.
+
+## 6. Lower the floor for new users
+
+* **One-command quickstart with a worked example** (S, both). `qallm demo`
+  runs the bundled buggy sample end to end and opens the result, so a new
+  user sees the verification gap in 60 seconds without configuring
+  anything.
+* **Guided interpretation** (S, both). On the results view, a short
+  plain-language reading of what happened ("3 bugs were found by execution
+  that static analysis missed; 2 were repaired; 1 remains"), so a
+  non-expert understands the output without learning the vocabulary.
+* **Profile chooser guidance** (S, both). When picking a quality profile,
+  explain in one line what each measures and when to use it (EVERSE for
+  research software, ISO 25010 for general software, FAIR4RS for a
+  publication check), so the choice is informed.
+
+## 7. Longer-horizon, higher-risk bets
+
+* **Multi-language support** (L, developer). The pipeline is Python-shaped
+  (AST extraction, pytest). A second language (JavaScript/TypeScript with
+  its own test runner) would widen the audience substantially, but it is a
+  large, structural undertaking.
+* **Repair-strategy library** (L, researcher). A catalogue of repair
+  prompting strategies (chain-of-thought, test-first, minimal-diff) that
+  the research mode of the quality loop can search over, turning QALLM into
+  a platform for studying LLM repair, not just a tool that does it one way.
+* **Human-in-the-loop repair review** (M, both). Let a user accept,
+  reject, or edit a proposed repair before it becomes the next round's
+  baseline, with their decision recorded. This makes QALLM a collaborator
+  rather than a black box, and the decisions are themselves research data.
+
+---
+
+## Suggested first moves (if I had to choose)
+
+If the goal is maximum usefulness per unit effort, weighted toward the
+near-term thesis and a real user base forming around it:
+
+1. **Static-vs-execution diff view + gap-front-and-centre dashboard**
+   (section 1). Makes the core claim visible; mostly UI over data QALLM
+   already has.
+2. **Minimised failing input** (section 2). The single most useful
+   per-bug improvement for both audiences, and a strong thesis artefact.
+3. **The quality loop** (section 4 / QLOOP issues). The highest-value
+   research feature, already designed.
+4. **CI / PR-comment integration** (section 3). The most natural developer
+   adoption path, and the cleanest head-to-head with SonarQube AI CodeFix.
+5. **Reproducibility bundle + LaTeX export** (section 4). Cheap, and aimed
+   squarely at the person whose opinion matters most this year.
+
+Everything here keeps faith with the one idea that makes QALLM worth using:
+execution is evidence that reading the code is not. The best additions are
+the ones that make that evidence richer, more visible, and more trusted.

--- a/docs/sonarqube-integration.md
+++ b/docs/sonarqube-integration.md
@@ -35,6 +35,19 @@ the API and the SonarQube server come up together:
 docker compose --profile sonarqube up
 ```
 
+The API also needs the `sonar-scanner` CLI baked into its image to run
+SonarQube analysis. It is off by default (it adds a JRE, about 200MB), so
+enable it and rebuild:
+
+```
+WITH_SONAR_SCANNER=1 docker compose build api
+docker compose --profile sonarqube up
+```
+
+Without the scanner the SonarQube analyzer logs a warning and falls back
+to Radon/Bandit, which is why a server that is up but has no scanner shows
+"No such file or directory: 'sonar-scanner'".
+
 Then open http://localhost:9000 (admin/admin on first login, change the
 password), generate a token under My Account -> Security, and set in
 `.env`:

--- a/src/qallm/api/routers/config.py
+++ b/src/qallm/api/routers/config.py
@@ -155,7 +155,23 @@ async def get_quality_profiles():
 
 @router.get("/api/analysis/tools")
 async def get_analysis_tools():
-    return {"tools": ["bandit", "radon", "ruff", "trufflehog"]}
+    """List the static analysers actually active in this deployment.
+
+    Derived from the AnalysisManager rather than hardcoded, so optional
+    analysers (SonarQube, included only when SONARQUBE_URL and
+    SONARQUBE_TOKEN are set) appear when they are active and not otherwise.
+    Ruff and TruffleHog are part of the analysis pipeline regardless, so
+    they are always listed.
+    """
+    from qallm.analysis.analysis_manager import AnalysisManager
+
+    manager = AnalysisManager()
+    tools = [a.tool_name() for a in manager.available_analyzers]
+    lower = {t.lower() for t in tools}
+    for always_on in ("ruff", "trufflehog"):
+        if always_on not in lower:
+            tools.append(always_on)
+    return {"tools": tools}
 
 
 @router.get("/api/session/{session_id}/config")

--- a/src/qallm/api/routers/experiments_control.py
+++ b/src/qallm/api/routers/experiments_control.py
@@ -240,6 +240,22 @@ async def launch_experiment(experiment_id: str, req: dict):
     return {"run_id": run_id, "job_id": job.job_id, "status": job.status.value}
 
 
+@router.get("/api/experiment-runs/active")
+async def active_experiment_runs():
+    """List runs currently tracked in this process, running first.
+
+    Lets the UI resume showing progress after the user navigates away and
+    back: the run keeps going server-side in a background job, but the
+    component lost its local state, so on mount it asks here which run (if
+    any) is still running and reattaches its progress polling.
+    """
+    with _progress_lock:
+        snaps = [p.to_dict() for p in _progress.values()]
+    # Running first, then most recently started.
+    snaps.sort(key=lambda s: (s["status"] != "running", -(s["started_at"] or 0)))
+    return {"runs": snaps}
+
+
 @router.get("/api/experiment-runs/{run_id}/progress")
 async def experiment_progress(run_id: str):
     """Live progress for a launched run.

--- a/tests/test_analysis_tools_dynamic.py
+++ b/tests/test_analysis_tools_dynamic.py
@@ -1,0 +1,26 @@
+"""The analysis-tools list must reflect active analysers dynamically."""
+
+from fastapi.testclient import TestClient
+
+from qallm.api.main import app
+
+client = TestClient(app)
+
+
+def test_tools_list_without_sonarqube(monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", None)
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", None)
+    tools = [t.lower() for t in client.get("/api/analysis/tools").json()["tools"]]
+    assert "bandit" in tools and "radon" in tools
+    assert "ruff" in tools and "trufflehog" in tools
+    assert "sonarqube" not in tools
+
+
+def test_tools_list_includes_sonarqube_when_configured(monkeypatch):
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://sonarqube:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+    tools = [t.lower() for t in client.get("/api/analysis/tools").json()["tools"]]
+    assert "sonarqube" in tools
+    # Still no duplicates of the always-on tools.
+    assert tools.count("ruff") == 1
+    assert tools.count("trufflehog") == 1

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -575,6 +575,10 @@ export async function getExperimentProgress(runId: string): Promise<ExperimentPr
   return req<ExperimentProgress>(`/api/experiment-runs/${encodeURIComponent(runId)}/progress`);
 }
 
+export async function listActiveExperimentRuns(): Promise<{ runs: ExperimentProgress[] }> {
+  return req<{ runs: ExperimentProgress[] }>("/api/experiment-runs/active");
+}
+
 export async function datasetToPipeline(id: string, params: {
   sample_size?: number; seed?: number; model?: string; strategy?: string;
   oracle?: string; rounds?: number; tags?: string[];

--- a/web/frontend/src/screens/ExperimentsView.tsx
+++ b/web/frontend/src/screens/ExperimentsView.tsx
@@ -215,6 +215,14 @@ function CatalogPanel({ onLaunched }: { onLaunched: () => void }) {
   useEffect(() => {
     let alive = true;
     api.listExperimentCatalog().then((r) => alive && setSpecs(r.experiments)).catch(() => {});
+    // Resume: a run launched earlier keeps going server-side. On mount, ask
+    // which run (if any) is still running and reattach its progress, so the
+    // user sees it after navigating away and back.
+    api.listActiveExperimentRuns().then((r) => {
+      if (!alive) return;
+      const running = r.runs.find((x) => x.status === "running");
+      if (running && running.run_id) setProgressRunId(running.run_id);
+    }).catch(() => {});
     return () => { alive = false; };
   }, []);
 
@@ -283,6 +291,25 @@ function CatalogPanel({ onLaunched }: { onLaunched: () => void }) {
   return (
     <div className="space-y-3">
       <h3 className="text-sm font-semibold text-slate-700">Available experiments</h3>
+      {/* Always-visible banner for an active run, so progress is shown even
+          when no experiment card is expanded (e.g. after navigating back
+          while a run continues in the background). */}
+      {progress && progress.tracked && progress.status === "running" && (
+        <div className="rounded-xl border border-indigo-200 bg-indigo-50 p-3">
+          <div className="flex items-center justify-between text-xs">
+            <span className="flex items-center gap-1.5 font-semibold text-indigo-800">
+              <span className="h-1.5 w-1.5 animate-pulse rounded-full bg-indigo-500" />
+              Experiment running in the background · {progress.completed}/{progress.total}
+            </span>
+            <span className="text-indigo-600">
+              {progress.bug_detected} bugs · {progress.repair_successful} repaired{progress.errored ? ` · ${progress.errored} errored` : ""}
+            </span>
+          </div>
+          <div className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-indigo-200">
+            <div className="h-full bg-indigo-500" style={{ width: `${progress.total ? (100 * (progress.completed || 0) / progress.total) : 0}%` }} />
+          </div>
+        </div>
+      )}
       {specs.map((spec) => {
         const open = openId === spec.id;
         return (


### PR DESCRIPTION
Branch: `feature/sonar-and-experiment-resume` (off `dev`, after #73)
**2 commits.** All green: **444 Python tests pass**, frontend type-checks and builds, ruff clean on changed files.

## Contents

- `fixes-and-ideas.patch` (full diff vs `dev`)
- `commits/` (2 per-commit patches for `git am`)
- `changed-files/` (final versions)

## Commit 1: three reported fixes

1. **SonarQube `sonar-scanner` missing.** The scanner CLI was never in the image, so analysis always failed with "No such file or directory: 'sonar-scanner'" and fell back. Added an optional `WITH_SONAR_SCANNER` build arg (off by default; it pulls a ~200MB JRE) that installs the scanner CLI, forwarded by the compose api service. Documented in `.env.example` and the sonar doc.

   **Action needed:** to actually use SonarQube, rebuild with the arg on:
   ```
   WITH_SONAR_SCANNER=1 docker compose build api
   docker compose --profile sonarqube up
   ```

2. **Analyser list not showing SonarQube.** `/api/analysis/tools` returned a hardcoded list. It is now derived from the `AnalysisManager` (SonarQube appears only when configured) plus the always-on ruff and trufflehog.

3. **Experiment progress lost on navigation.** The run continued in the background, but navigating away and back lost the display. Added `GET /api/experiment-runs/active`; on mount the Experiments view reattaches to any running run and shows an always-visible "running in the background" banner with a progress bar, regardless of which experiment card is open.

Tests: dynamic tools list (with/without SonarQube, no duplicates) and active-runs behaviour.

## Commit 2: ideas roadmap

`docs/ideas-research-developer-kit.md`: a prioritised menu of ideas to make QALLM genuinely useful to researchers and developers, organised by user need and grounded in QALLM's distinctive value (execution-based evidence, the verification gap). Seven themes, each idea tagged with rough effort and audience, plus a suggested first five:

1. Static-vs-execution diff view + gap dashboard (make the core claim visible)
2. Minimised failing input (the most useful per-bug improvement)
3. The quality loop (highest-value research feature, already designed)
4. CI / PR-comment integration (cleanest developer adoption path)
5. Reproducibility bundle + LaTeX export (aimed at the thesis)

Docs/roadmap only; no code changes in commit 2.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 444 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```