### PR TITLE
Review: SonarQube findings fix + strategy to surpass static analysers

### DIFF
--- a/docs/surpassing-static-analysers.md
+++ b/docs/surpassing-static-analysers.md
@@ -1,0 +1,159 @@
+# Learning from SonarQube and surpassing it: a design
+
+The goal is not to out-rule SonarQube. Sonar has hundreds of person-years
+of static rules; QALLM will never beat it at pattern-matching source code,
+and trying to is a losing game. QALLM's advantage is the thing static
+analysers structurally cannot do: it *executes* the code and *closes a
+loop with an LLM*. So "surpassing" the static tools means treating their
+findings as one input signal, then doing what they cannot: confirm or
+refute each finding by running the code, and repair with feedback until
+the evidence says the code is actually better.
+
+This document lays out how to get there, in three moves: consume the
+static tools as evidence, verify and out-perform them by execution, and
+turn fix quality and UX into the reasons people choose QALLM. It is a
+design to react to, not built yet.
+
+## The core reframe: static findings are hypotheses, execution is the judge
+
+A SonarQube or Bandit finding is a *hypothesis*: "this line may be a bug."
+Static tools can only ever assert the hypothesis; they cannot test it.
+QALLM can. For every static finding, QALLM can attempt to generate a test
+that *demonstrates* the finding is a real, triggerable defect.
+
+That single idea reorganises everything:
+
+* A finding QALLM can reproduce with a failing test is **confirmed**: real,
+  with a concrete reproduction. This is worth far more than Sonar's
+  assertion alone.
+* A finding QALLM cannot reproduce after honest effort is **unconfirmed**:
+  possibly a false positive, or untriggerable in practice. Sonar floods
+  users with these; QALLM can rank them down.
+* A failure QALLM finds by execution that *no* static tool flagged is the
+  **verification gap** made concrete: the thesis claim, per finding.
+
+So the headline capability is a **confirmation rate** and a **gap rate**
+per run: of the static findings, how many did execution confirm; and how
+many real defects did execution find that static analysis missed. Those
+two numbers are the case for QALLM over Sonar, in the product itself.
+
+## Move 1: consume the static tools as evidence (not as competitors)
+
+Right now QALLM runs Bandit, Radon, and (optionally) SonarQube and lists
+their findings. The next step is to *use* those findings as signal:
+
+* **Findings as test targets.** Feed each static finding to the
+  test-generation step as a hypothesis to try to trigger: "Sonar says line
+  42 may dereference None; write a test that makes it happen." This focuses
+  generation on the suspect code instead of the whole surface, which raises
+  bug-detection per token spent.
+* **Findings as repair priors.** Feed confirmed findings to the repair
+  prompt as known-good context: "the following defects are confirmed by
+  failing tests; fix these specifically." A repair guided by a reproduced
+  failure is far more likely to be correct than one guided by a static
+  warning alone.
+* **A unified evidence model.** Each finding carries where it came from
+  (which tool, or execution), whether execution confirmed it, the
+  reproducing test if any, and the repair outcome. This is the data
+  structure the whole product hangs off.
+
+## Move 2: out-perform the static tools by execution
+
+This is where QALLM does what Sonar cannot.
+
+* **Confirm/refute every static finding.** For each Sonar/Bandit finding,
+  attempt a reproducing test. Report the confirmation rate. A tool that
+  tells you "of Sonar's 40 findings, 12 are confirmed-reproducible, 28 we
+  could not trigger" is more useful than either tool alone, because it
+  triages the noise static analysers are notorious for.
+* **Find what they missed.** Keep generating tests beyond the static
+  findings (crash, property, metamorphic oracles) and surface every failure
+  no static tool predicted. This is the gap, and it is the differentiator.
+* **Prove the fix, do not assert it.** Sonar's AI CodeFix proposes a change
+  and tells you it looks right. QALLM proposes a change, *re-runs the
+  tests*, and tells you the previously-failing test now passes and nothing
+  else broke. A verified fix beats a suggested fix every time, and it is
+  the single clearest reason to choose QALLM.
+* **Mutation-tested confidence.** When QALLM reports "no bugs found,"
+  back it with a kill rate: mutate the code, confirm the generated tests
+  catch the mutants. This turns a weak "we found nothing" into a
+  quantified "the tests are sensitive enough to trust this verdict," which
+  is exactly the critique any test-generation tool must answer.
+
+## Move 3: make fix quality and UX the reason people stay
+
+A tool people *choose* has to be dramatically better to use, not just
+better on a metric. The following are aimed squarely at that.
+
+### Fix quality
+
+* **Minimal, reviewable diffs.** A repair should be the smallest change
+  that makes the failing test pass, not a rewrite. Constrain the repair
+  prompt to minimal diffs and reject repairs that change more than the
+  defect requires. Developers trust a three-line fix; they distrust a
+  fifty-line rewrite.
+* **Never regress.** Every repair is gated on the full test set, not just
+  the one failing test: the fix must turn the target test green *and* keep
+  every previously-passing test green. The judge already does accept/abandon;
+  make "no regression" an explicit, surfaced gate.
+* **Explain the fix.** For each accepted repair, a one or two sentence
+  rationale tied to the reproducing test: "the function returned the
+  product as 0 because the accumulator started at 0 instead of 1; the test
+  test_normal_positive_integers now passes." This is what turns a black-box
+  patch into something a researcher will cite and a developer will merge.
+* **Minimised counterexample.** Shrink each failing input to the smallest
+  that still fails. A one-line minimal reproduction is the most useful
+  artefact QALLM can hand a developer, and static tools have no equivalent.
+
+### User experience
+
+* **The gap dashboard.** Front and centre: confirmed findings, unconfirmed
+  (likely-false-positive) findings, and execution-found defects the static
+  tools missed, with the reproducing test one click away. This single view
+  is the product's argument for itself.
+* **Side-by-side with Sonar.** A column for "what Sonar said" next to "what
+  execution proved." Where they agree, confidence. Where execution found
+  more, that is the value. Where Sonar flagged and execution could not
+  trigger, that is noise QALLM saved the user from chasing.
+* **Trust signals.** Show the cost before a run, the mutation-kill-rate
+  behind a clean verdict, and the no-regression gate on every fix. People
+  adopt tools they trust; trust comes from the tool showing its work.
+* **Fast, incremental, in-workflow.** Run on a diff in CI and post the
+  confirmed defects plus minimal reproductions as a PR comment; run on a
+  cell from the notebook. The contrast with Sonar's static PR comments is
+  the pitch: QALLM's comments are execution-verified.
+
+## What this looks like as a metric story (for the thesis and the user)
+
+Per run, QALLM can report four numbers that no static tool can produce
+together:
+
+1. **Static-finding confirmation rate**: of the static findings, the
+   fraction execution reproduced. (Triage value.)
+2. **Verification-gap rate**: defects execution found that no static tool
+   flagged, over total defects. (The thesis claim.)
+3. **Verified-fix rate**: repairs that turned a reproduced failure green
+   with no regression. (Fix quality.)
+4. **Verdict confidence**: mutation kill rate behind a clean result. (Trust.)
+
+These four, shown in the UI and exported for a paper, are simultaneously
+the research contribution and the reason a developer would pick QALLM over
+running Sonar alone.
+
+## Suggested build order
+
+1. **Unified evidence model**: every finding carries source tool, execution
+   confirmation, reproducing test, repair outcome. The prerequisite.
+2. **Confirm/refute static findings**: feed static findings as test
+   targets; compute and surface the confirmation rate. Highest-value first
+   step, directly uses the SonarQube integration we just got working.
+3. **Verified-fix gating + explanations + minimal diffs**: make fix quality
+   visible and trustworthy.
+4. **The gap dashboard and the side-by-side-with-Sonar view**: make the
+   advantage legible in the UI.
+5. **Mutation-based confidence and minimised counterexamples**: the deeper
+   evidence that answers the hardest critiques.
+
+Each step is independently valuable and ships on its own. The through-line:
+static analysers guess, QALLM proves, and the product's job is to make that
+difference impossible to miss.

--- a/src/qallm/analysis/sonarqube_analyzer.py
+++ b/src/qallm/analysis/sonarqube_analyzer.py
@@ -115,13 +115,22 @@ class SonarQubeAnalyzer(StaticCodeAnalyzer):
 
     # ─── live scan path (exercised when a server is configured) ─────
     def _scan(self, unit: CodeUnit, project_key: str) -> tuple[list, dict]:
-        """Run the scanner and fetch issues + measures. Network-dependent."""
+        """Run the scanner and fetch issues + measures. Network-dependent.
+
+        SonarQube processes an upload asynchronously on its compute engine,
+        so after the scanner exits we wait for that background task to
+        finish before fetching, otherwise issues come back empty and
+        measures 404 because the project is not ready yet.
+        """
         with tempfile.TemporaryDirectory() as tmp:
             workspace = Path(tmp)
             filename = unit.original_path.name if unit.original_path else "cell.py"
             (workspace / filename).write_text(unit.source_code, encoding="utf-8")
             self._write_scanner_props(workspace, project_key)
             self._run_scanner(workspace)
+            # Wait for the compute-engine task the scan submitted, so the
+            # analysis is fully processed before we read it.
+            self._wait_for_processing(workspace)
             issues = self._fetch_issues(project_key)
             measures = self._fetch_measures(project_key)
             return issues, measures
@@ -141,13 +150,64 @@ class SonarQubeAnalyzer(StaticCodeAnalyzer):
         )
 
     def _run_scanner(self, workspace: Path) -> None:
-        subprocess.run(
+        """Run sonar-scanner, surfacing its output and failing loudly.
+
+        Previously the output was captured and the exit code ignored, so a
+        failed scan looked like a success and only surfaced later as an
+        empty issue list or a 404 when fetching measures. Now a non-zero
+        exit raises with the scanner's own stderr/stdout, so the real cause
+        is visible.
+        """
+        proc = subprocess.run(
             [settings.SONARQUBE_SCANNER],
             cwd=str(workspace),
             capture_output=True,
             text=True,
             timeout=settings.SONARQUBE_TIMEOUT_SECONDS,
             check=False,
+        )
+        if proc.returncode != 0:
+            tail = (proc.stderr or proc.stdout or "").strip()[-1500:]
+            raise RuntimeError(
+                f"sonar-scanner exited {proc.returncode}: {tail}"
+            )
+        logger.debug("sonar-scanner output:\n%s", proc.stdout)
+
+    def _wait_for_processing(self, workspace: Path) -> None:
+        """Block until the compute-engine task for this scan completes.
+
+        The scanner writes report-task.txt containing the ceTaskId; we poll
+        /api/ce/task until it is SUCCESS (or fail on FAILED/CANCELED). If the
+        report file or task id is missing we skip waiting rather than hang.
+        """
+        import time
+
+        report = workspace / ".scannerwork" / "report-task.txt"
+        if not report.exists():
+            logger.warning("No report-task.txt; skipping processing wait.")
+            return
+        ce_task_id = None
+        for line in report.read_text(encoding="utf-8").splitlines():
+            if line.startswith("ceTaskId="):
+                ce_task_id = line.split("=", 1)[1].strip()
+                break
+        if not ce_task_id:
+            return
+
+        deadline = time.monotonic() + settings.SONARQUBE_TIMEOUT_SECONDS
+        while time.monotonic() < deadline:
+            data = self._api_get("/api/ce/task", {"id": ce_task_id})
+            status = data.get("task", {}).get("status")
+            if status == "SUCCESS":
+                return
+            if status in ("FAILED", "CANCELED"):
+                raise RuntimeError(
+                    f"SonarQube compute-engine task {ce_task_id} {status}"
+                )
+            time.sleep(1.0)
+        logger.warning(
+            "SonarQube task %s did not finish within the timeout; "
+            "results may be incomplete.", ce_task_id
         )
 
     def _api_get(self, path: str, params: dict) -> dict:

--- a/tests/test_sonarqube_analyzer.py
+++ b/tests/test_sonarqube_analyzer.py
@@ -127,3 +127,97 @@ def test_orchestrator_threads_sonar_measures_into_context(monkeypatch):
     measures = orch._sonar_measures_for(_unit())
     assert measures == {"reliability_rating": "1.0",
                         "security_rating": "2.0", "sqale_rating": "1.0"}
+
+
+def test_run_scanner_raises_on_nonzero_exit(monkeypatch, tmp_path):
+    """A failed scan must raise with the scanner's output, not pass silently.
+
+    This is the fix for the long-standing silent failure: previously the
+    scanner ran with check=False and its output discarded, so a failed scan
+    looked successful and surfaced only later as empty issues / a 404."""
+    from unittest.mock import patch
+
+    from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_SCANNER", "sonar-scanner")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TIMEOUT_SECONDS", 5)
+    analyzer = SonarQubeAnalyzer()
+
+    class FakeProc:
+        returncode = 2
+        stdout = "INFO scanning"
+        stderr = "ERROR: project not authorized"
+
+    with patch("subprocess.run", return_value=FakeProc()):
+        try:
+            analyzer._run_scanner(tmp_path)
+            assert False, "expected RuntimeError on non-zero exit"
+        except RuntimeError as e:
+            assert "exited 2" in str(e)
+            assert "not authorized" in str(e)
+
+
+def test_wait_for_processing_polls_until_success(monkeypatch, tmp_path):
+    """After the scan, fetching must wait for the compute-engine task so the
+    analysis is processed before issues/measures are read."""
+    from unittest.mock import patch
+
+    from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://localhost:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TIMEOUT_SECONDS", 5)
+    analyzer = SonarQubeAnalyzer()
+
+    sw = tmp_path / ".scannerwork"
+    sw.mkdir()
+    (sw / "report-task.txt").write_text("ceTaskId=ABC123\nprojectKey=x\n")
+
+    calls = {"n": 0}
+
+    def fake_api_get(path, params):
+        assert path == "/api/ce/task"
+        assert params["id"] == "ABC123"
+        calls["n"] += 1
+        # PENDING first, then SUCCESS.
+        return {"task": {"status": "SUCCESS" if calls["n"] >= 2 else "PENDING"}}
+
+    with patch.object(analyzer, "_api_get", side_effect=fake_api_get), \
+         patch("time.sleep", lambda *_: None):
+        analyzer._wait_for_processing(tmp_path)
+    assert calls["n"] >= 2
+
+
+def test_wait_for_processing_raises_on_failed_task(monkeypatch, tmp_path):
+    from unittest.mock import patch
+
+    from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://localhost:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TIMEOUT_SECONDS", 5)
+    analyzer = SonarQubeAnalyzer()
+
+    sw = tmp_path / ".scannerwork"
+    sw.mkdir()
+    (sw / "report-task.txt").write_text("ceTaskId=BAD1\n")
+
+    with patch.object(analyzer, "_api_get",
+                      return_value={"task": {"status": "FAILED"}}), \
+         patch("time.sleep", lambda *_: None):
+        try:
+            analyzer._wait_for_processing(tmp_path)
+            assert False, "expected RuntimeError on FAILED task"
+        except RuntimeError as e:
+            assert "FAILED" in str(e)
+
+
+def test_wait_for_processing_skips_when_no_report(monkeypatch, tmp_path):
+    """No report-task.txt should skip waiting, not hang or crash."""
+    from qallm.analysis.sonarqube_analyzer import SonarQubeAnalyzer
+
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_URL", "http://localhost:9000")
+    monkeypatch.setattr("qallm.config.settings.SONARQUBE_TOKEN", "tok")
+    analyzer = SonarQubeAnalyzer()
+    # No .scannerwork dir present; should return without error.
+    analyzer._wait_for_processing(tmp_path)


### PR DESCRIPTION
Branch: `feature/sonar-findings-fix` (off `dev`, after #75)
**2 commits.** All green: **448 Python tests pass**, ruff clean.

## Commit 1: SonarQube findings now appear (`fix`)

You reported SonarQube findings weren't in the UI and re-analysis showed no server activity. Two causes, both in the analyzer's scan path:

1. **Async race.** SonarQube processes the upload on its compute engine *after* `sonar-scanner` exits, but the analyzer fetched issues and measures immediately, before the project was ready, so issues came back empty and measures 404'd. Added `_wait_for_processing`: read the `ceTaskId` from `.scannerwork/report-task.txt` and poll `/api/ce/task` until `SUCCESS` before fetching (raise on `FAILED`/`CANCELED`, skip if no report file).

2. **Silent scanner failures.** `_run_scanner` ran with `check=False` and discarded output, so a failed scan looked successful. It now raises with the scanner's own output on a non-zero exit. `analyze()` still catches and falls back, but the warning now carries the real reason. (This is the same silent-failure pattern that made the whole scanner/architecture debugging so painful.)

Tests: scanner raises on non-zero exit; processing-wait polls to SUCCESS, raises on FAILED, skips with no report.

**After deploying this:** your next analysis will either show SonarQube findings merged into the list (if it was the race, most likely), or a *specific* error in the logs (if the scan is failing for another reason) instead of silence. Either way you'll finally know.

## Commit 2: strategy doc (`docs`)

`docs/surpassing-static-analysers.md`: how QALLM learns from SonarQube and surpasses it. The core reframe: **a static finding is a hypothesis; execution is the judge.** QALLM will never out-rule Sonar, but it can do what Sonar structurally cannot, confirm or refute each finding by running the code, and prove fixes instead of asserting them.

Three moves: consume static findings as test targets and repair priors; out-perform by execution (confirm/refute findings, find the gap, verified fixes, mutation-backed confidence); make fix quality and UX the reason people stay (minimal diffs, no-regression gate, fix explanations, minimised counterexamples, a gap dashboard, side-by-side-with-Sonar). Defines four per-run metrics that are both the thesis contribution and the user-facing argument, with a build order.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 448 passed
ruff check src/qallm
```