### PR TITLE
Review: verification observability fixes + run-mechanics doc

### DIFF
--- a/docs/run-mechanics-and-diagnostics.md
+++ b/docs/run-mechanics-and-diagnostics.md
@@ -1,0 +1,136 @@
+# Understanding a QALLM pipeline run: rounds, test accumulation, and statuses
+
+This explains what happens inside a QALLM run, written against a real
+session (the `domain.py` sample) so the log lines map to concepts. It also
+records three issues that reading that log surfaced, two of which were real
+bugs now fixed. The mechanics here are thesis material: they are exactly
+the kind of methodological detail a reader needs to trust the numbers.
+
+## The two round counters (and why a log said "Round 2" in round 1)
+
+There are two different "round" notions, and they are 1 apart by design:
+
+* **Pipeline round** (the orchestrator's): round 0 is the *baseline*
+  (analyse and verify the *original* code, no repair), and rounds 1..N are
+  *repair* rounds (repair, then verify the repaired variant, then judge
+  accept/abandon against the parent).
+* **Test-generation round** (the generator's): a 1-based count of how many
+  times tests have been generated for a function. The baseline is
+  generation 1, the first repair round is generation 2, and so on.
+
+So during pipeline round 1, the generator was on its 2nd generation and
+logged "Round 2". Harmless, but confusing. The generator now logs the
+pipeline round instead, so the two line up. (The prompt content was always
+correct; only the log label was off.)
+
+## What "FROZEN+GROW: running N accumulated test(s)" means
+
+This is the test-stability policy, and it is central to how QALLM judges
+improvement fairly. Two independent settings combine:
+
+* **Stability = FROZEN.** Once a test is generated and validated, it is
+  kept and re-run unchanged in later rounds. The alternative, PER_ROUND,
+  would regenerate tests each round. FROZEN matters because it keeps the
+  yardstick stable: if the tests changed every round, you could not tell
+  whether the code got better or the tests got easier.
+* **Policy = GROW.** Each round the generator produces *new* feedback-driven
+  tests (informed by the previous round's failures), and those are *added*
+  to the kept set rather than replacing it. The alternative, REPLAY_ONLY,
+  would only re-run the existing tests without adding new ones.
+
+So FROZEN+GROW means: keep every validated test from every prior round, add
+this round's new tests, and run the whole accumulated suite against the
+current code variant. "Running 6 accumulated test(s)" means six rounds of
+generation have each contributed tests and all of them now run together.
+
+Why this design: it makes the test suite a monotonically growing,
+stable oracle. A repair is judged against *all* tests found so far, so a
+fix that silences this round's failing test but breaks something an earlier
+round covered is caught. That is the no-regression principle, enforced by
+accumulation.
+
+The trade-off, visible in the log, is cost: the suite grows each round, so
+later rounds run more tests and generation prompts get longer (more prior
+context). For the `domain.py` run, `complex_branching` went from running a
+handful of tests in round 0 to many by round 5. This is the right
+trade-off for judging fairly, but it is worth surfacing the suite size and
+cost per round in the UI so the growth is legible.
+
+## "ERROR" vs "BUG" vs "PASS" on a test
+
+Three distinct outcomes, and the distinction matters:
+
+* **PASS**: the test ran and its assertions held. On the original (buggy)
+  code, a passing test is one the code already satisfies.
+* **BUG** (pytest "failed"): the test ran to completion and an assertion
+  failed. This is the valuable signal: a concrete, reproducible defect the
+  generated test caught by *executing* the code. The `complex_branching`
+  failures are real examples: `complex_branching(30)` returned 50 where the
+  test expected 43, with the exact diff shown.
+* **ERROR** (pytest "error"): the test did **not** run to completion. It
+  raised during collection, fixture setup, or teardown, before or around
+  the assertion. An error is not evidence about the code under test; it is
+  usually a problem with the *test itself*.
+
+In the `domain.py` run, every `dangerous` test showed ERROR. The cause was
+in the generated tests: they referenced a `fixed_obj` fixture that the
+generated file never defined. pytest could not set up the fixture, so each
+test errored during setup and never executed. That is why `dangerous`
+showed 0 passes, 0 bugs, and a flat 31% coverage every round: its tests
+never actually ran. The repaired code was being verified each round (the
+repair did happen), but the broken tests could not exercise it.
+
+Two bugs made this invisible and were fixed:
+
+1. **The error message was empty.** The executor read a test's traceback
+   only from pytest's "call" phase, but a setup error lands under "setup".
+   So errored tests displayed "ERROR" with no explanation. Now the setup
+   and teardown phases are read too, so the "fixture 'fixed_obj' not found"
+   message is surfaced.
+2. **Errored tests were counted as zero errors.** A singular/plural key
+   mismatch (`error` vs `errors`) meant the error tally never incremented,
+   so the count of errored tests was wrong. Fixed.
+
+The deeper issue this exposes is about **generation quality**: the local
+model (gemma4:e4b) produced tests referencing an undefined fixture. That is
+a generator-robustness problem, not a pipeline-logic problem, and it points
+at a worthwhile improvement: validate generated tests for undefined
+fixtures/names before running them (an AST check), and either repair or
+discard tests that reference symbols they never define. This would raise
+the signal of the verification step, especially on smaller local models.
+
+## Why round 1 looked like it used unrepaired code
+
+It did not; the repair ran (the log shows "Repair completed: CLEAN" before
+verification each round). The impression came entirely from the `dangerous`
+function: because its tests all errored, its numbers (0 bugs, 31% coverage)
+were identical every round, which reads as "nothing changed." With the
+error messages now visible, this is no longer mistakable: an errored test
+clearly shows a test-setup failure rather than a verification result.
+
+## What this gives the thesis
+
+These mechanics are reportable methodology:
+
+* The FROZEN+GROW accumulation is the mechanism behind the no-regression
+  guarantee, and explaining it justifies why QALLM's accept/abandon
+  decisions are trustworthy rather than noise.
+* The ERROR vs BUG distinction matters for the verification-gap claim: only
+  BUGs are evidence of the gap; ERRORs are test-quality noise that must be
+  filtered out before computing the false-confidence rate, or they would
+  contaminate it.
+* The generated-test fixture problem is itself a finding: it quantifies how
+  much generation robustness affects measured bug-detection, and motivates
+  the AST-validation improvement. Reporting that honestly strengthens the
+  work.
+
+## Follow-ups worth considering
+
+1. Validate generated tests for undefined names/fixtures before running
+   (AST check); repair or discard the rest. Highest-value, directly raises
+   verification signal.
+2. Surface per-round suite size and cost in the UI, so FROZEN+GROW's growth
+   is legible.
+3. Separate ERROR from BUG everywhere in the UI and metrics (errors are not
+   bugs and must not count toward bug-detection or the false-confidence
+   rate).

--- a/src/qallm/verification/executor.py
+++ b/src/qallm/verification/executor.py
@@ -37,15 +37,34 @@ def _parse_pytest_json(report_path: Path) -> tuple[list[TestDetail], dict[str, i
 
     for test in data.get("tests", []):
         outcome = test.get("outcome", "error")
-        status = {"passed": "passed", "failed": "failed", "skipped": "skipped"}.get(outcome, "error")
-        counts[status] = counts.get(status, 0) + 1
+        # TestDetail.status uses the singular "error"; the counts dict uses
+        # the plural "errors". Keep them distinct: a prior version wrote the
+        # singular status into the counts dict, creating a stray "error" key
+        # and leaving "errors" at zero, so errored tests were never counted.
+        status = {
+            "passed": "passed", "failed": "failed", "skipped": "skipped",
+        }.get(outcome, "error")
+        count_key = "errors" if status == "error" else status
+        counts[count_key] = counts.get(count_key, 0) + 1
 
         message = None
-        call_info = test.get("call", {})
-        if call_info and call_info.get("longrepr"):
-            # Keep enough of the traceback for the detailed assertion diff
-            # (-v / --tb=long), not just the one-line summary.
-            message = str(call_info["longrepr"])[:2000]
+        # A test can carry a longrepr in any of three phases. Failed
+        # assertions land in "call"; an error during fixture setup (e.g. a
+        # missing fixture like a referenced-but-undefined `fixed_obj`) or
+        # teardown lands in "setup"/"teardown" and never reaches "call".
+        # Reading only "call" left setup-errors with status=error and an
+        # empty message ("ERROR with no detail"). Check all three, in the
+        # order pytest runs them, and surface the first longrepr found.
+        call_info = test.get("call", {}) or {}
+        for phase in ("call", "setup", "teardown"):
+            phase_info = test.get(phase, {}) or {}
+            longrepr = phase_info.get("longrepr")
+            if longrepr:
+                prefix = "" if phase == "call" else f"[{phase} error] "
+                # Keep enough of the traceback for the detailed assertion
+                # diff (-v / --tb=long), not just the one-line summary.
+                message = (prefix + str(longrepr))[:2000]
+                break
 
         details.append(TestDetail(
             name=test.get("nodeid", "unknown"), status=status,

--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -69,15 +69,19 @@ class TestGenerator:
         # 1. Select the appropriate prompt builder based on session state
         if existing_session and len(existing_session.rounds) > 0:
             last_round = existing_session.rounds[-1]
-            logger.info("Generating feedback-based tests for %s (Round %d)",
-                        func.name, len(existing_session.rounds) + 1)
+            # Label by the pipeline round being verified (the count of prior
+            # generations), so the log matches the orchestrator's "Round N"
+            # instead of being one ahead.
+            gen_round = len(existing_session.rounds)
+            logger.info("Generating feedback-based tests for %s (round %d)",
+                        func.name, gen_round)
 
             user_prompt = build_feedback_prompt(
                 func=func,
                 previous_test_code=last_round.generated_test.test_code,
                 execution=last_round.execution,
                 reward=last_round.reward,
-                round_number=len(existing_session.rounds) + 1,
+                round_number=gen_round + 1,
             )
         else:
             builder = PROMPT_BUILDERS.get(oracle)

--- a/tests/test_executor_parsing.py
+++ b/tests/test_executor_parsing.py
@@ -1,0 +1,74 @@
+"""Tests for pytest-JSON parsing, especially error-phase message capture.
+
+A test that errors during fixture setup (e.g. it references a fixture the
+generated file never defines) lands its traceback under the "setup" phase,
+not "call". The parser must surface that, otherwise the UI shows
+"ERROR" with no explanation, which is exactly what was observed for the
+`dangerous` function's tests.
+"""
+
+import json
+from pathlib import Path
+
+from qallm.verification.executor import _parse_pytest_json
+
+
+def _write(tmp_path, data) -> Path:
+    p = tmp_path / "report.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+def test_setup_error_message_is_captured(tmp_path):
+    report = {
+        "tests": [{
+            "nodeid": "test_generated.py::test_uses_missing_fixture",
+            "outcome": "error",
+            "setup": {"longrepr": "fixture 'fixed_obj' not found",
+                      "duration": 0.01},
+        }]
+    }
+    details, counts = _parse_pytest_json(_write(tmp_path, report))
+    assert counts["errors"] == 1
+    assert details[0].status == "error"
+    assert details[0].message is not None
+    assert "fixed_obj" in details[0].message
+    assert details[0].message.startswith("[setup error]")
+
+
+def test_call_failure_message_unchanged(tmp_path):
+    report = {
+        "tests": [{
+            "nodeid": "test_generated.py::test_assert",
+            "outcome": "failed",
+            "call": {"longrepr": "assert 50 == 43", "duration": 0.02},
+        }]
+    }
+    details, counts = _parse_pytest_json(_write(tmp_path, report))
+    assert counts["failed"] == 1
+    assert details[0].status == "failed"
+    # Call-phase failures keep their raw message, no phase prefix.
+    assert details[0].message == "assert 50 == 43"
+
+
+def test_passed_test_has_no_message(tmp_path):
+    report = {"tests": [{
+        "nodeid": "test_generated.py::test_ok", "outcome": "passed",
+        "call": {"duration": 0.01},
+    }]}
+    details, counts = _parse_pytest_json(_write(tmp_path, report))
+    assert counts["passed"] == 1
+    assert details[0].status == "passed"
+    assert details[0].message is None
+
+
+def test_teardown_error_is_captured(tmp_path):
+    report = {"tests": [{
+        "nodeid": "test_generated.py::test_td", "outcome": "error",
+        "call": {"duration": 0.01},
+        "teardown": {"longrepr": "boom in teardown"},
+    }]}
+    details, _ = _parse_pytest_json(_write(tmp_path, report))
+    # call has no longrepr, so teardown is surfaced.
+    assert "boom in teardown" in details[0].message
+    assert details[0].message.startswith("[teardown error]")


### PR DESCRIPTION
Branch: `feature/observability-diagnostics` (off `dev`, after #76)
**2 commits.** All green: **452 Python tests pass**, ruff clean.

Came out of reading a real `domain.py` pipeline run. Your four observations were all on point; two were real bugs.

## Commit 1: three fixes (`fix`)

1. **ERROR tests now show why.** The executor read tracebacks only from pytest's "call" phase, but a test that errors during fixture *setup* (your `dangerous` tests referenced an undefined `fixed_obj` fixture) carries its message under "setup". Those showed "ERROR" with no detail. Now setup/call/teardown are all read; the "fixture not found" message is surfaced with a phase prefix.

2. **Errored tests were counted as zero.** A singular/plural key mismatch (`error` vs `errors`) meant the error tally never incremented. This is why errored tests had no visible impact. Fixed.

3. **Round label off-by-one.** The generator logged "Round 2" during pipeline round 1 (it counts test-generations, 1-based; the orchestrator counts pipeline rounds, 0=baseline). The log now reports the pipeline round so they align. Prompt content unchanged.

Tests: `test_executor_parsing.py` (setup + teardown error messages captured with phase prefix; call-failure message unchanged; passed test has no message; error count correct).

## Commit 2: run-mechanics doc (`docs`)

`docs/run-mechanics-and-diagnostics.md` answers your questions as thesis-grade methodology:

- **The two round counters** and why they differ by one.
- **What FROZEN+GROW accumulation is**: keep every validated test from every prior round, add this round's new feedback-driven tests, run the whole suite against the current variant. It's the mechanism behind the no-regression guarantee, with its cost trade-off (growing suite).
- **ERROR vs BUG vs PASS**: only BUG is verification-gap evidence; ERROR is a test that never ran and must be filtered out of the false-confidence rate, not counted as a bug.
- **Why round 1 looked unrepaired** (it wasn't; `dangerous`'s flat numbers came from its tests erroring every round).
- **Follow-ups**: AST-validate generated tests for undefined names/fixtures before running (the highest-value next improvement, it directly raises verification signal on local models), surface per-round suite size/cost, separate ERROR from BUG in UI and metrics.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 452 passed
ruff check src/qallm
```
