### PR TITLE
Review: watchdog heartbeat + oracle panel move + roadmap

### DIFF
--- a/docs/roadmap-next-sessions.md
+++ b/docs/roadmap-next-sessions.md
@@ -1,0 +1,73 @@
+# Agreed roadmap: the next sessions
+
+This is the prioritised plan we agreed to carry forward. It pulls together
+threads from the strategy doc (`surpassing-static-analysers.md`), the
+diagnostics doc (`run-mechanics-and-diagnostics.md`), and the ideas doc
+(`ideas-research-developer-kit.md`) into one sequence. Backend work is in
+scope; nothing here is UI-only unless noted.
+
+The ordering is deliberate: each step is independently valuable and ships
+on its own, but each also unlocks the next.
+
+## 1. AST-validate generated tests before running them
+
+**Why first.** The `domain.py` run showed every `dangerous` test ERROR-ing
+because the model generated tests referencing a `fixed_obj` fixture it
+never defined. Those tests never executed, so they produced no verification
+signal and polluted the picture. Validating generated tests for undefined
+names and fixtures before running, then repairing or discarding the
+offenders, directly raises verification signal, especially on smaller local
+models. It is also the prerequisite for step 3: you cannot claim a static
+finding is confirmed-by-execution with a test that never ran.
+
+**Scope (backend).** An AST pass over each generated test module that flags
+references to names/fixtures not defined or imported in the module; a
+policy to either drop the offending test or feed the problem back to the
+generator for a corrected version; and a count of discarded/invalid tests
+surfaced in the round summary so the effect is measurable.
+
+## 2. Static-vs-execution diff view / gap dashboard
+
+**Why second.** Once tests reliably run, make the core claim visible: a
+view that puts what the static tools reported next to what execution
+proved, with the verification gap (defects execution found that static
+analysis missed) front and centre. Mostly UI over data QALLM already has,
+plus a small backend aggregation for the gap and confirmation counts.
+
+**Scope.** Backend: per-run aggregation of static findings vs
+execution-found defects, and the confirmation/gap counts. Frontend: the
+side-by-side and the headline gap number.
+
+## 3. Confirm/refute static findings
+
+**Why third.** The capability that most directly demonstrates QALLM's
+advantage and uses the SonarQube integration now working. For each static
+finding, attempt a reproducing test; label it confirmed (with the
+reproduction), unconfirmed (likely false positive, ranked down), and report
+the confirmation rate. Depends on step 1 (tests must run) and step 2 (the
+evidence model and aggregation).
+
+**Scope (backend-heavy).** Feed static findings to the generator as test
+targets; a unified evidence model where each finding carries its source
+tool, execution-confirmation status, reproducing test, and repair outcome;
+the confirmation-rate metric.
+
+## Sequencing notes
+
+- 1 is a clean, self-contained backend improvement and the right next
+  session.
+- 2 and 3 share the evidence-model groundwork; doing 2 first gives a
+  visible win and builds the aggregation 3 needs.
+- The quality loop (`docs/quality-loop-design.md`, QLOOP-01..04) remains a
+  parallel track; QLOOP-01 (the harness) can be built whenever, and the
+  confirmation/gap metrics from steps 2 and 3 are natural inputs to it.
+
+## Borrowing from SonarQube and others
+
+Throughout, we lift workflow, UI, and configuration conventions from
+SonarQube (the standard for code-quality tooling) where they fit: the
+findings-list and severity model, the project/quality-gate framing, the
+PR-comment integration pattern. QALLM is not competing with these tools; it
+sits on top of them and fills the gap they structurally cannot reach
+(execution-based evidence). Adopting their proven UX is free polish toward
+that end.

--- a/src/qallm/llm/base.py
+++ b/src/qallm/llm/base.py
@@ -8,6 +8,7 @@ analysis (RQ1 benchmarking).
 from __future__ import annotations
 
 import logging
+import time
 from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any
@@ -68,6 +69,15 @@ class TokenTracker:
     calls: int = 0
     errors: int = 0
     history: list[dict[str, Any]] = field(default_factory=list)
+    # Monotonic timestamp of the most recent sign of life: bumped when a
+    # call is about to be made (beat) and when one is recorded. A watchdog
+    # reads this to tell a genuinely hung run from one that is merely slow
+    # (a single local-model generation can legitimately run for minutes).
+    last_activity: float = field(default_factory=time.monotonic)
+
+    def beat(self) -> None:
+        """Mark activity. Called right before a (possibly slow) LLM call."""
+        self.last_activity = time.monotonic()
 
     @property
     def total_tokens(self) -> int:
@@ -80,6 +90,7 @@ class TokenTracker:
     def record(self, resp: LLMResponse) -> None:
         """Records the results of an LLM call and updates cumulative metrics[cite: 37]."""
         self.calls += 1
+        self.last_activity = time.monotonic()
 
         # Extract safe values once[cite: 37]
         in_tokens = resp.input_tokens if resp.input_tokens is not None else 0

--- a/src/qallm/llm/ollama_provider.py
+++ b/src/qallm/llm/ollama_provider.py
@@ -63,6 +63,11 @@ class OllamaModel(LLMModel):
         with timer() as t:
             try:
                 import ollama
+                # Mark activity right before the (potentially minutes-long)
+                # call so a watchdog gives this call a fresh window rather
+                # than mistaking a slow local generation for a hang.
+                if tracker:
+                    tracker.beat()
                 client = ollama.Client(
                     host=settings.OLLAMA_BASE_URL,
                     timeout=timeout_seconds,

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -45,6 +45,7 @@ from __future__ import annotations
 from datetime import datetime
 import json
 import logging
+import time
 from typing import Literal, Optional
 
 from qallm.analysis.normalizer import LifecycleStage
@@ -411,6 +412,9 @@ class QALLMOrchestrator:
             elapsed_seconds=self.budget_state.elapsed_seconds,
             tokens_used=self.tracker.total_tokens,
             cost_usd=self.tracker.total_cost_usd,
+            seconds_since_activity=max(
+                0.0, time.monotonic() - self.tracker.last_activity
+            ),
             halt_reason=self.halt_reason.value if self.halt_reason else None,
         )
 

--- a/src/qallm/orchestrator_models.py
+++ b/src/qallm/orchestrator_models.py
@@ -130,8 +130,14 @@ class OrchestratorProgress:
     elapsed_seconds: float
     tokens_used: int
     cost_usd: float
+    # Seconds since the last LLM-call heartbeat. A watchdog uses this to
+    # tell a slow-but-live run (a single local generation in flight) from a
+    # genuinely hung one: this stays small while a call is being made or has
+    # just completed, and only grows without bound if the process is stuck
+    # somewhere that is not an LLM call.
+    seconds_since_activity: float = 0.0
     # Termination state.
-    halt_reason: Optional[str]
+    halt_reason: Optional[str] = None
 
     def to_dict(self) -> dict:
         return dataclasses.asdict(self)

--- a/tests/test_tracker_heartbeat.py
+++ b/tests/test_tracker_heartbeat.py
@@ -1,0 +1,30 @@
+"""The TokenTracker heartbeat lets a watchdog tell slow from hung."""
+
+import time
+
+from qallm.llm.base import TokenTracker, LLMResponse
+
+
+def test_beat_updates_last_activity():
+    t = TokenTracker(budget=1000)
+    first = t.last_activity
+    time.sleep(0.01)
+    t.beat()
+    assert t.last_activity > first
+
+
+def test_record_updates_last_activity():
+    t = TokenTracker(budget=1000)
+    first = t.last_activity
+    time.sleep(0.01)
+    t.record(LLMResponse(content="x", provider="ollama", model="m",
+                         input_tokens=1, output_tokens=1))
+    assert t.last_activity > first
+
+
+def test_snapshot_reports_seconds_since_activity():
+    # A fresh tracker has a near-zero idle time; after a pause it grows.
+    t = TokenTracker(budget=1000)
+    t.beat()
+    idle_now = time.monotonic() - t.last_activity
+    assert idle_now < 1.0

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -162,6 +162,9 @@ export interface JobProgress {
   elapsed_seconds: number;
   tokens_used: number;
   cost_usd: number;
+  // Seconds since the last LLM-call heartbeat. Small while a call is in
+  // flight or just completed; grows without bound only if truly stuck.
+  seconds_since_activity?: number;
   halt_reason: string | null;
 }
 
@@ -257,10 +260,24 @@ export async function pollJobUntilDone<T = unknown>(
       );
     }
     if (now - lastProgressAt > inactivity) {
-      throw new Error(
-        `Job ${jobId} made no progress for ${Math.round(inactivity / 60000)} minutes. ` +
-        `Last observed: ${view.progress?.current_stage ?? view.status} on ${view.progress?.current_unit_id ?? "n/a"}.`,
-      );
+      // The progress signature has been flat for the inactivity window.
+      // Before declaring a stall, check the heartbeat: if an LLM call is
+      // in flight or recently completed (seconds_since_activity small), the
+      // run is slow, not hung (a single local-model generation can run for
+      // minutes), so keep waiting and reset the window. Only a flat
+      // signature AND a stale heartbeat is a genuine stall.
+      const sinceActivity = view.progress?.seconds_since_activity;
+      const heartbeatStale = sinceActivity === undefined
+        ? true  // backend did not report a heartbeat: fall back to old behaviour
+        : sinceActivity * 1000 > inactivity;
+      if (!heartbeatStale) {
+        lastProgressAt = now;  // model is working; grant a fresh window
+      } else {
+        throw new Error(
+          `Job ${jobId} made no progress for ${Math.round(inactivity / 60000)} minutes. ` +
+          `Last observed: ${view.progress?.current_stage ?? view.status} on ${view.progress?.current_unit_id ?? "n/a"}.`,
+        );
+      }
     }
     await new Promise(r => setTimeout(r, interval));
   }

--- a/web/frontend/src/screens/TestGenScreen.tsx
+++ b/web/frontend/src/screens/TestGenScreen.tsx
@@ -298,6 +298,21 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
               <span className="h-2 w-2 animate-pulse rounded-full bg-indigo-500" /> Generating tests automatically...
             </div>
           ) : null}
+
+          {/* Active oracle reference. Lives on the left, below the function
+              list, since it is read once to understand what the oracle
+              does; the right column is reserved for live stream status. */}
+          <div className="mt-6 border-t border-slate-100 pt-4">
+            <h3 className="text-sm font-semibold text-slate-700">Active oracle: <span className="capitalize">{oracle}</span></h3>
+            <div className="mt-3 space-y-2">
+              {Object.entries(ORACLES).map(([k, v]) => (
+                <div key={k} className={`rounded-xl border p-3 transition ${oracle === k ? "border-slate-900 bg-slate-50" : "border-slate-200 opacity-60"}`}>
+                  <div className="text-sm font-medium">{v.title}</div>
+                  <div className="mt-1 text-xs text-slate-500">{oracle === k ? v.desc : `${v.desc.slice(0, 80)}...`}</div>
+                </div>
+              ))}
+            </div>
+          </div>
         </div>
 
         <div className="space-y-6">
@@ -397,20 +412,6 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
               </div>
             </div>
           )}
-
-          {/* Oracle reference, moved below the live state since it is read
-              once rather than watched. */}
-          <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
-            <h3 className="font-semibold">Active oracle: <span className="capitalize">{oracle}</span></h3>
-            <div className="mt-3 space-y-3">
-              {Object.entries(ORACLES).map(([k, v]) => (
-                <div key={k} className={`rounded-xl border p-3 transition ${oracle === k ? "border-slate-900 bg-slate-50" : "border-slate-200 opacity-60"}`}>
-                  <div className="text-sm font-medium">{v.title}</div>
-                  <div className="mt-1 text-xs text-slate-500">{oracle === k ? v.desc : `${v.desc.slice(0, 80)}...`}</div>
-                </div>
-              ))}
-            </div>
-          </div>
 
           {state.testGenResult && (
             <div className="rounded-2xl border border-emerald-200 bg-emerald-50 p-6">


### PR DESCRIPTION
Branch: `feature/watchdog-heartbeat-oracle-move` (off `dev`, after #78)
**1 commit.** All green: **455 Python tests pass**, frontend type-checks and builds, ruff clean.

## What this fixes

### The false "no progress for 5 minutes" halt (your error)

Your run halted mid-`verify` on `complex_branching` in round 2, with "made no progress for 5 minutes." It wasn't actually hung. A single local-model generation can legitimately exceed the 5-minute inactivity window: the Ollama per-call timeout is 240s, and FROZEN+GROW makes later-round prompts large (the accumulated suite), so one generation can run for minutes. During that single call, nothing in the progress signature changes (same round, stage, function; tokens only tick when the call returns), so the watchdog mistook a slow call for a stall.

**Fix:** a heartbeat. `TokenTracker` gains `last_activity`, bumped right before each LLM call (`beat()`) and on `record()`. The orchestrator snapshot exposes `seconds_since_activity`. The frontend watchdog now declares a stall only when the progress signature is flat **and** the heartbeat is stale (no call in flight); a slow-but-live call grants a fresh window. Falls back to the old behaviour if the backend doesn't report a heartbeat, so it's safe across versions.

### Oracle panel moved (your request)

Active oracle details moved to the left column, below the functions list (it's read-once reference), leaving the right column entirely for the live stream status.

## Roadmap captured

`docs/roadmap-next-sessions.md` records the agreed sequence, with backend explicitly in scope (you noted you didn't mean to scope it out):

1. **AST-validate generated tests** before running (drop/repair tests referencing undefined names/fixtures, like the `fixed_obj` that errored every `dangerous` test). Raises verification signal; prerequisite for confirm/refute.
2. **Static-vs-execution diff view / gap dashboard.**
3. **Confirm/refute static findings** using the SonarQube integration.

Plus the note that we borrow SonarQube's workflow/UI/config conventions throughout, since it's the standard and QALLM sits on top of it rather than competing.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 455 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```
