### PR TITLE
Review: AST-validate generated tests (roadmap step 1)

### DIFF
--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -20,6 +20,7 @@ from qallm.verification.prompts import (
     build_feedback_prompt
 )
 from qallm.verification.sandbox import CodeExtractor
+from qallm.verification.test_validator import strip_unsatisfied_fixture_tests
 
 logger = logging.getLogger(__name__)
 
@@ -113,6 +114,28 @@ class TestGenerator:
         test_code = _fix_source_import(extracted_code, module_name)
         is_valid, validation_error = _validate_test_code(test_code)
 
+        # Drop tests that request fixtures nothing provides: they would
+        # error during pytest setup and never run, contributing no signal
+        # while inflating the error count. Keep the valid tests.
+        discarded: list[str] = []
+        if is_valid:
+            stripped_code, discarded = strip_unsatisfied_fixture_tests(test_code)
+            if discarded:
+                logger.warning(
+                    "Discarded %d test(s) for %s requesting undefined "
+                    "fixtures: %s",
+                    len(discarded), func.name, ", ".join(discarded),
+                )
+                test_code = stripped_code
+                # Re-validate: if stripping removed every test, the result
+                # is no longer a usable suite.
+                is_valid, validation_error = _validate_test_code(test_code)
+                if not is_valid:
+                    validation_error = (
+                        "All generated tests requested undefined fixtures "
+                        f"({', '.join(discarded)}); nothing left to run."
+                    )
+
         if not is_valid:
             logger.warning("Generated tests for %s are invalid: %s", func.name, validation_error)
 
@@ -126,4 +149,5 @@ class TestGenerator:
             provider=resp.provider,
             input_tokens=resp.input_tokens,
             output_tokens=resp.output_tokens,
+            discarded_tests=discarded,
         )

--- a/src/qallm/verification/models.py
+++ b/src/qallm/verification/models.py
@@ -58,6 +58,9 @@ class GeneratedTest:
     provider: str = ""
     input_tokens: int = 0
     output_tokens: int = 0
+    # Names of test functions removed before execution because they
+    # requested fixtures nothing provides (would error in setup, never run).
+    discarded_tests: list[str] = field(default_factory=list)
 
 
 @dataclass

--- a/src/qallm/verification/test_validator.py
+++ b/src/qallm/verification/test_validator.py
@@ -1,0 +1,176 @@
+"""AST validation of generated test code before it is executed.
+
+A language model sometimes writes a test that takes a parameter it never
+provides a fixture for, e.g.::
+
+    def test_complex_dictionary_input(fixed_obj):   # <- no such fixture
+        ...
+
+pytest treats every test-function parameter as a fixture request. With no
+matching fixture, the test errors during *setup* and never runs, producing
+no verification signal (this is the ``fixed_obj`` case seen on the
+``domain.py`` sample, where every ``dangerous`` test errored). Catching this
+before execution lets the pipeline drop or repair the offending tests and
+report how many were invalid, so the verification signal is not silently
+polluted by tests that never ran.
+
+The check is deliberately conservative. It flags exactly one thing: a test
+function whose parameter is neither a fixture defined in the same module nor
+a known pytest builtin fixture. It does not try to flag undefined names in
+test bodies, because the executor injects the source module via
+``from <module> import *`` at run time, so a free name may well be a valid
+source export that is simply not visible in the test text alone. Flagging
+those would risk discarding good tests; flagging unsatisfied fixtures does
+not.
+"""
+
+from __future__ import annotations
+
+import ast
+
+# Fixtures pytest (and common plugins) provide without any definition in
+# the test module. A parameter with one of these names is always
+# satisfiable, so it must never be flagged.
+PYTEST_BUILTIN_FIXTURES: frozenset[str] = frozenset({
+    # pytest core
+    "request", "tmp_path", "tmp_path_factory", "tmpdir", "tmpdir_factory",
+    "capsys", "capsysbinary", "capfd", "capfdbinary", "caplog",
+    "monkeypatch", "recwarn", "pytestconfig", "record_property",
+    "record_testsuite_property", "cache", "doctest_namespace",
+    "testdir", "pytester",
+    # pytest-asyncio
+    "event_loop", "event_loop_policy",
+    # pytest-mock
+    "mocker",
+})
+
+# A parameter named ``self`` or ``cls`` is a method receiver, not a fixture.
+_RECEIVER_PARAMS: frozenset[str] = frozenset({"self", "cls"})
+
+
+def _collect_defined_fixtures(tree: ast.Module) -> set[str]:
+    """Return names of functions decorated as pytest fixtures in the module.
+
+    Recognises ``@pytest.fixture``, ``@pytest.fixture(...)``, ``@fixture``
+    and ``@fixture(...)`` (the latter from ``from pytest import fixture``).
+    """
+    fixtures: set[str] = set()
+    for node in ast.walk(tree):
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            target = dec.func if isinstance(dec, ast.Call) else dec
+            # @pytest.fixture / @<anything>.fixture
+            if isinstance(target, ast.Attribute) and target.attr == "fixture":
+                fixtures.add(node.name)
+                break
+            # @fixture
+            if isinstance(target, ast.Name) and target.id == "fixture":
+                fixtures.add(node.name)
+                break
+    return fixtures
+
+
+def _test_functions(tree: ast.Module) -> list[ast.FunctionDef | ast.AsyncFunctionDef]:
+    """Top-level functions whose names start with ``test``."""
+    out: list[ast.FunctionDef | ast.AsyncFunctionDef] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                and node.name.startswith("test"):
+            out.append(node)
+    return out
+
+
+def _params_with_parametrize(node: ast.FunctionDef | ast.AsyncFunctionDef) -> set[str]:
+    """Parameter names supplied by ``@pytest.mark.parametrize`` decorators.
+
+    Those are provided by the decorator, not by a fixture, so they must not
+    be flagged. The first argument of parametrize is a names string (or a
+    sequence of names); we parse both forms.
+    """
+    supplied: set[str] = set()
+    for dec in node.decorator_list:
+        if not isinstance(dec, ast.Call):
+            continue
+        func = dec.func
+        is_parametrize = (
+            isinstance(func, ast.Attribute) and func.attr == "parametrize"
+        )
+        if not is_parametrize or not dec.args:
+            continue
+        first = dec.args[0]
+        if isinstance(first, ast.Constant) and isinstance(first.value, str):
+            for piece in first.value.replace(",", " ").split():
+                supplied.add(piece)
+        elif isinstance(first, (ast.List, ast.Tuple)):
+            for elt in first.elts:
+                if isinstance(elt, ast.Constant) and isinstance(elt.value, str):
+                    supplied.add(elt.value)
+    return supplied
+
+
+def find_unsatisfied_fixtures(code: str) -> dict[str, list[str]]:
+    """Map each test function to the parameter names it requests but that no
+    fixture (defined or builtin) and no parametrize decorator provides.
+
+    Returns an empty dict when everything is satisfiable. Raises nothing on
+    a syntax error: it returns an empty dict, leaving syntax checks to the
+    caller's existing ``compile`` step.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return {}
+
+    defined = _collect_defined_fixtures(tree)
+    available = defined | PYTEST_BUILTIN_FIXTURES
+
+    problems: dict[str, list[str]] = {}
+    for fn in _test_functions(tree):
+        parametrized = _params_with_parametrize(fn)
+        args = fn.args
+        # positional-or-keyword and positional-only parameters can be
+        # fixture requests; *args/**kwargs and keyword-only are not how
+        # fixtures are injected, so we ignore them.
+        candidate_params = [a.arg for a in (args.posonlyargs + args.args)]
+        unsatisfied = [
+            p for p in candidate_params
+            if p not in available
+            and p not in parametrized
+            and p not in _RECEIVER_PARAMS
+        ]
+        if unsatisfied:
+            problems[fn.name] = unsatisfied
+    return problems
+
+
+def strip_unsatisfied_fixture_tests(code: str) -> tuple[str, list[str]]:
+    """Remove test functions that request unsatisfiable fixtures.
+
+    Returns the rewritten code and the list of removed test names. Keeps
+    every other top-level statement (imports, fixtures, helpers, valid
+    tests) intact. If parsing fails or nothing needs removing, returns the
+    code unchanged with an empty list.
+    """
+    problems = find_unsatisfied_fixtures(code)
+    if not problems:
+        return code, []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return code, []
+
+    to_remove = set(problems.keys())
+    kept_body = [
+        node for node in tree.body
+        if not (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in to_remove
+        )
+    ]
+    tree.body = kept_body
+    try:
+        rewritten = ast.unparse(tree)
+    except Exception:  # noqa: BLE001 - unparse should not fail, but be safe
+        return code, []
+    return rewritten, sorted(to_remove)

--- a/src/qallm/verification/verification_manager.py
+++ b/src/qallm/verification/verification_manager.py
@@ -210,13 +210,14 @@ class VerificationManager:
                 )
                 gen_elapsed = time.perf_counter() - gen_start
                 logger.info(
-                    "  [%s] test-gen: %.2fs (provider=%s, model=%s, tokens=in:%d/out:%d, valid=%s%s)",
+                    "  [%s] test-gen: %.2fs (provider=%s, model=%s, tokens=in:%d/out:%d, valid=%s%s%s)",
                     func.name, gen_elapsed,
                     generated.provider or "unknown",
                     generated.model or "unknown",
                     generated.input_tokens or 0,
                     generated.output_tokens or 0,
                     generated.is_valid,
+                    f", discarded={len(generated.discarded_tests)}" if generated.discarded_tests else "",
                     f", error={generated.generation_error}" if generated.generation_error else "",
                 )
                 # Record only valid tests in the store under FROZEN modes;

--- a/tests/test_test_validator.py
+++ b/tests/test_test_validator.py
@@ -1,0 +1,134 @@
+"""Tests for AST validation of generated tests (undefined fixtures)."""
+
+from qallm.verification.test_validator import (
+    find_unsatisfied_fixtures,
+    strip_unsatisfied_fixture_tests,
+)
+
+
+def test_flags_undefined_fixture():
+    code = '''
+def test_uses_missing(fixed_obj):
+    assert fixed_obj == 1
+'''
+    problems = find_unsatisfied_fixtures(code)
+    assert problems == {"test_uses_missing": ["fixed_obj"]}
+
+
+def test_defined_fixture_is_ok():
+    code = '''
+import pytest
+
+@pytest.fixture
+def fixed_obj():
+    return 1
+
+def test_uses_defined(fixed_obj):
+    assert fixed_obj == 1
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_bare_fixture_decorator_is_ok():
+    code = '''
+from pytest import fixture
+
+@fixture
+def thing():
+    return 7
+
+def test_thing(thing):
+    assert thing == 7
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_pytest_builtin_fixtures_are_ok():
+    code = '''
+def test_with_tmp(tmp_path, monkeypatch, capsys):
+    assert tmp_path is not None
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_parametrize_params_are_ok():
+    code = '''
+import pytest
+
+@pytest.mark.parametrize("value,expected", [(1, 2), (2, 3)])
+def test_param(value, expected):
+    assert value + 1 == expected
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_no_arg_tests_are_ok():
+    code = '''
+def test_simple():
+    assert 1 + 1 == 2
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_free_names_in_body_not_flagged():
+    # `dangerous` would arrive via `from <module> import *` at runtime; the
+    # validator must not flag body names, only unsatisfied parameters.
+    code = '''
+def test_calls_source():
+    result = dangerous("1 + 1")
+    assert result is not None
+'''
+    assert find_unsatisfied_fixtures(code) == {}
+
+
+def test_strip_removes_only_offending_tests():
+    code = '''
+import pytest
+
+@pytest.fixture
+def good():
+    return 1
+
+def test_ok(good):
+    assert good == 1
+
+def test_bad(fixed_obj):
+    assert fixed_obj == 2
+
+def test_also_ok():
+    assert True
+'''
+    rewritten, removed = strip_unsatisfied_fixture_tests(code)
+    assert removed == ["test_bad"]
+    assert "test_ok" in rewritten
+    assert "test_also_ok" in rewritten
+    assert "test_bad" not in rewritten
+    # The kept code still parses and the good fixture survived.
+    assert "def good" in rewritten
+    compile(rewritten, "<rewritten>", "exec")
+
+
+def test_strip_noop_when_all_valid():
+    code = '''
+def test_a():
+    assert True
+'''
+    rewritten, removed = strip_unsatisfied_fixture_tests(code)
+    assert removed == []
+    assert rewritten == code
+
+
+def test_syntax_error_returns_empty():
+    code = "def test_broken(:\n    pass"
+    assert find_unsatisfied_fixtures(code) == {}
+    rewritten, removed = strip_unsatisfied_fixture_tests(code)
+    assert removed == []
+
+
+def test_multiple_unsatisfied_params():
+    code = '''
+def test_two(foo, bar):
+    assert foo == bar
+'''
+    problems = find_unsatisfied_fixtures(code)
+    assert set(problems["test_two"]) == {"foo", "bar"}


### PR DESCRIPTION
Branch: `feature/ast-validate-tests` (off `dev`, after #79)
**1 commit.** All green: **466 Python tests pass**, ruff clean.

This is step 1 of the agreed roadmap: catch generated tests that would error in setup and never run, before they run.

## The problem it solves

On the `domain.py` sample, every `dangerous` test took a `fixed_obj` parameter with no matching fixture. pytest treats each test parameter as a fixture request, so those tests errored during setup and never executed: zero verification signal, but they inflated the error count and hid whether the code was actually exercised. This is also why `dangerous` looked unrepaired across rounds.

## What changed

New module `qallm/verification/test_validator.py`:

- `find_unsatisfied_fixtures(code)`: an AST pass mapping each test function to parameters that nothing provides, no `@pytest.fixture`/`@fixture` defined in the module, no pytest builtin (`tmp_path`, `monkeypatch`, `capsys`, `request`, ...), and no `@pytest.mark.parametrize` name.
- `strip_unsatisfied_fixture_tests(code)`: removes exactly those test functions, keeping all other statements (imports, fixtures, helpers, valid tests) intact.

**Conservative by design, to avoid discarding good tests.** It flags only unsatisfied *fixtures* (parameters), never free names in test bodies. That's deliberate: the executor injects the source module via `from <module> import *` at run time, so a name like `dangerous` in a test body is a valid source export even though it's not visible in the test text. Flagging body names would risk dropping good tests; flagging unsatisfied fixture parameters does not. `self`/`cls` receivers and parametrize names are excluded too.

Generator integration: after the existing compile/test-presence check, strip unsatisfied-fixture tests, keep the valid ones, re-validate. If stripping removes *every* test, the result is marked invalid with a clear reason. `GeneratedTest` gains `discarded_tests`; the verification manager logs the discarded count on the test-gen line, so the effect is measurable in the logs.

## Why this first

It's the prerequisite for roadmap step 3 (confirm/refute static findings): you cannot claim a static finding is confirmed-by-execution with a test that never ran. It also immediately raises verification signal on local models, which is where the `fixed_obj` problem showed up.

## Verified behaviour

Fed the exact `fixed_obj` pattern through: the two `fixed_obj` tests are removed, a valid test that calls `dangerous(...)` via the wildcard import is kept. The 11 unit tests cover the no-false-positive cases explicitly (parametrize, builtins, defined fixtures, bare `@fixture`, source-export body names, syntax errors).

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 466 passed
ruff check src/qallm
```
