### PR TITLE
Review: static-vs-execution gap view (roadmap step 2 + step-1 follow-up)

### DIFF
--- a/src/qallm/analysis/gap_analysis.py
+++ b/src/qallm/analysis/gap_analysis.py
@@ -1,0 +1,234 @@
+"""Correlate static-analysis findings with execution results: the gap.
+
+The thesis claim is that execution catches defects static analysis misses
+(the "verification gap"), and that some static findings are not reproducible
+by execution (candidate false positives). This module computes that
+correlation per round from the persisted artefacts, so it can be shown for
+any session, live or historical.
+
+For each round we have, on disk:
+- ``source.py``: the code as analysed that round.
+- ``static.json``: the static findings (tool, line, severity, message).
+- ``verification.json``: per-function execution results, including the
+  generated tests and which of them failed (a failure is an
+  execution-found bug; an error is a test that never ran and is not
+  evidence either way).
+
+Correlation is line-level: each finding's line is mapped to the function
+whose line span contains it (computed by AST). A finding is then classified
+against that function's execution outcome:
+
+- ``confirmed``: the function has at least one execution-found bug, so
+  execution corroborates that something is wrong where the finding points.
+- ``unconfirmed``: the function was tested (tests ran) but produced no
+  execution-found bug, so the finding is not reproduced. A candidate false
+  positive, or simply not triggerable by the generated tests.
+- ``untested``: the function had no tests that actually ran (all errored,
+  or none generated), so there is no execution evidence either way.
+
+The gap itself runs the other direction: an execution-found bug in a
+function that has *no* static finding on it is a defect static analysis
+missed. Those are counted as ``execution_only`` bugs, the heart of the
+claim.
+
+Counts deliberately exclude discarded and errored tests: only tests that
+ran and failed are bugs, so the gap number is not polluted by tests that
+never executed (the ERROR-vs-BUG distinction established earlier).
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+FindingStatus = Literal["confirmed", "unconfirmed", "untested"]
+
+
+@dataclass
+class FunctionSpan:
+    name: str
+    start: int
+    end: int
+
+    def contains(self, line: int) -> bool:
+        return self.start <= line <= self.end
+
+
+@dataclass
+class ClassifiedFinding:
+    tool: str
+    severity: str
+    line: int
+    message: str
+    rule_id: str
+    function: str | None  # the function the line falls in, if any
+    status: FindingStatus
+
+
+@dataclass
+class FunctionExecution:
+    name: str
+    ran: int  # tests that actually ran (passed + failed)
+    bugs: int  # tests that ran and failed
+    errors: int  # tests that errored (never ran)
+
+    @property
+    def tested(self) -> bool:
+        return self.ran > 0
+
+    @property
+    def has_bug(self) -> bool:
+        return self.bugs > 0
+
+
+@dataclass
+class GapReport:
+    round: int
+    findings: list[ClassifiedFinding] = field(default_factory=list)
+    # Functions with an execution-found bug but no static finding: the gap.
+    execution_only_functions: list[str] = field(default_factory=list)
+
+    @property
+    def confirmed(self) -> int:
+        return sum(1 for f in self.findings if f.status == "confirmed")
+
+    @property
+    def unconfirmed(self) -> int:
+        return sum(1 for f in self.findings if f.status == "unconfirmed")
+
+    @property
+    def untested(self) -> int:
+        return sum(1 for f in self.findings if f.status == "untested")
+
+    @property
+    def confirmation_rate(self) -> float | None:
+        """Confirmed over (confirmed + unconfirmed): of findings we could
+        test, the fraction execution corroborated. None when nothing was
+        testable."""
+        denom = self.confirmed + self.unconfirmed
+        return (self.confirmed / denom) if denom else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "round": self.round,
+            "findings": [
+                {
+                    "tool": f.tool, "severity": f.severity, "line": f.line,
+                    "message": f.message, "rule_id": f.rule_id,
+                    "function": f.function, "status": f.status,
+                }
+                for f in self.findings
+            ],
+            "execution_only_functions": self.execution_only_functions,
+            "summary": {
+                "confirmed": self.confirmed,
+                "unconfirmed": self.unconfirmed,
+                "untested": self.untested,
+                "execution_only": len(self.execution_only_functions),
+                "confirmation_rate": self.confirmation_rate,
+            },
+        }
+
+
+def function_spans(source: str) -> list[FunctionSpan]:
+    """Line spans of top-level and nested functions in the source.
+
+    Uses end_lineno (Python 3.8+). A finding on a line inside a function
+    body maps to that function; the most specific (innermost, smallest)
+    enclosing function wins when functions nest.
+    """
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    spans: list[FunctionSpan] = []
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            end = getattr(node, "end_lineno", None) or node.lineno
+            spans.append(FunctionSpan(node.name, node.lineno, end))
+    return spans
+
+
+def _function_for_line(spans: list[FunctionSpan], line: int) -> str | None:
+    """The innermost function whose span contains the line, or None."""
+    best: FunctionSpan | None = None
+    for s in spans:
+        if s.contains(line):
+            if best is None or (s.end - s.start) < (best.end - best.start):
+                best = s
+    return best.name if best else None
+
+
+def _executions_from_verification(verification: list | None) -> dict[str, FunctionExecution]:
+    """Map function name -> execution outcome from a round's verification.json.
+
+    Reads the last round of each function's session (the final state that
+    round), counting tests that ran (passed/failed) vs errored, mirroring
+    the bug-detail summary used elsewhere.
+    """
+    out: dict[str, FunctionExecution] = {}
+    if not verification:
+        return out
+    for session in verification:
+        rounds = session.get("rounds") or []
+        if not rounds:
+            continue
+        execution = (rounds[-1].get("execution") or {})
+        name = session.get("function") or session.get("function_name") or "?"
+        passed = int(execution.get("passed", 0) or 0)
+        failed = int(execution.get("failed", 0) or 0)
+        errors = int(execution.get("errors", 0) or 0)
+        out[name] = FunctionExecution(
+            name=name, ran=passed + failed, bugs=failed, errors=errors,
+        )
+    return out
+
+
+def build_gap_report(
+    round_no: int,
+    source: str,
+    findings: list[dict],
+    verification: list | None,
+) -> GapReport:
+    """Classify each static finding against execution, and find the gap.
+
+    ``findings`` is a list of finding dicts (tool, line, severity, message,
+    rule_id) as persisted in static.json. ``verification`` is the parsed
+    verification.json for the same round.
+    """
+    spans = function_spans(source)
+    execs = _executions_from_verification(verification)
+    report = GapReport(round=round_no)
+
+    functions_with_finding: set[str] = set()
+    for f in findings:
+        line = int(f.get("line", 0) or 0)
+        fn = _function_for_line(spans, line)
+        if fn:
+            functions_with_finding.add(fn)
+        status: FindingStatus
+        ex = execs.get(fn) if fn else None
+        if ex is None or not ex.tested:
+            status = "untested"
+        elif ex.has_bug:
+            status = "confirmed"
+        else:
+            status = "unconfirmed"
+        report.findings.append(ClassifiedFinding(
+            tool=f.get("tool", "?"),
+            severity=f.get("severity", "?"),
+            line=line,
+            message=f.get("message", ""),
+            rule_id=f.get("rule_id", ""),
+            function=fn,
+            status=status,
+        ))
+
+    # The gap: functions with an execution-found bug but no static finding.
+    for name, ex in execs.items():
+        if ex.has_bug and name not in functions_with_finding:
+            report.execution_only_functions.append(name)
+    report.execution_only_functions.sort()
+
+    return report

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -17,6 +17,7 @@ from qallm.api.core import (
     get_state,
     sessions,
 )
+from qallm.analysis.gap_analysis import GapReport, build_gap_report
 from qallm.config import settings
 from qallm.orchestrator import QALLMOrchestrator
 
@@ -149,6 +150,9 @@ def _summarise_bug_detail(verification: list | None) -> list[dict]:
             "errors": execution.get("errors", 0),
             "skipped": execution.get("skipped", 0),
             "total": execution.get("total", 0),
+            # Tests dropped pre-execution for requesting undefined fixtures
+            # (would have errored in setup); surfaced so the count is visible.
+            "discarded": list(generated.get("discarded_tests") or []),
             "coverage_percent": execution.get("coverage_percent"),
             "execution_error": execution.get("execution_error"),
             # The full generated test file, for reference / download.
@@ -254,6 +258,78 @@ async def download_tests(session_id: str):
                     "content": gen["test_code"],
                 })
     return {"files": files}
+
+
+@router.get("/api/session/{session_id}/gap")
+async def get_gap(session_id: str):
+    """Static-vs-execution gap per round: which static findings execution
+    confirmed, which it could not reproduce, and which execution-found bugs
+    no static tool flagged (the verification gap).
+
+    Reads each round's persisted source.py, static.json, and
+    verification.json, so it works for live and historical sessions alike.
+    """
+    state = sessions.get(session_id) or {}
+    report_dir = state.get("report_dir")
+    if not report_dir or not os.path.isdir(report_dir):
+        candidate = os.path.join(settings.QALLM_SESSIONS_DIR, session_id)
+        if os.path.isdir(candidate):
+            report_dir = candidate
+    if not report_dir or not os.path.isdir(report_dir):
+        return {"available": False, "rounds": [],
+                "reason": "No run artefacts yet. Run the pipeline first."}
+
+    def _read_json(path: str):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _read_text(path: str) -> str:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return fh.read()
+        except OSError:
+            return ""
+
+    # Each round's artefacts live under lineage/round_N/<unit>/ (accepted)
+    # or abandoned/round_N/<unit>/. We classify findings per unit and merge
+    # per round. static.json + source.py + verification.json sit together.
+    reports: dict[int, GapReport] = {}
+    for bucket in ("lineage", "abandoned"):
+        bucket_dir = os.path.join(report_dir, bucket)
+        if not os.path.isdir(bucket_dir):
+            continue
+        for round_name in sorted(os.listdir(bucket_dir)):
+            round_path = os.path.join(bucket_dir, round_name)
+            if not os.path.isdir(round_path):
+                continue
+            try:
+                round_no = int(round_name.replace("round_", ""))
+            except ValueError:
+                continue
+            for unit_seg in sorted(os.listdir(round_path)):
+                unit_dir = os.path.join(round_path, unit_seg)
+                if not os.path.isdir(unit_dir):
+                    continue
+                source = _read_text(os.path.join(unit_dir, "source.py"))
+                findings = _read_json(os.path.join(unit_dir, "static.json")) or []
+                verification = _read_json(os.path.join(unit_dir, "verification.json"))
+                if not source and not findings:
+                    continue
+                unit_report = build_gap_report(round_no, source, findings, verification)
+                merged = reports.setdefault(round_no, GapReport(round=round_no))
+                merged.findings.extend(unit_report.findings)
+                merged.execution_only_functions.extend(
+                    unit_report.execution_only_functions
+                )
+
+    for rep in reports.values():
+        rep.execution_only_functions = sorted(set(rep.execution_only_functions))
+
+    ordered = [reports[k].to_dict() for k in sorted(reports)]
+    return {"available": True, "rounds": ordered}
 
 
 @router.get("/api/health")

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -1,0 +1,117 @@
+"""Tests for static-vs-execution gap correlation."""
+
+from qallm.analysis.gap_analysis import (
+    build_gap_report,
+    function_spans,
+    _function_for_line,
+)
+
+SOURCE = '''import os
+
+def dangerous(user_input):
+    value = eval(user_input)
+    return value
+
+def complex_branching(n):
+    total = 0
+    for i in range(n):
+        if i % 2 == 0:
+            total += 1
+    return total
+'''
+
+
+def test_function_spans_and_line_mapping():
+    spans = function_spans(SOURCE)
+    names = {s.name for s in spans}
+    assert names == {"dangerous", "complex_branching"}
+    # Line 4 (eval) is inside dangerous; line 10 (if) inside complex_branching.
+    assert _function_for_line(spans, 4) == "dangerous"
+    assert _function_for_line(spans, 10) == "complex_branching"
+    # A line outside any function maps to None.
+    assert _function_for_line(spans, 1) is None
+
+
+def _verification(func, passed, failed, errors):
+    return [{
+        "function": func,
+        "rounds": [{"execution": {
+            "passed": passed, "failed": failed, "errors": errors,
+            "total": passed + failed + errors,
+        }}],
+    }]
+
+
+def test_finding_confirmed_when_function_has_bug():
+    findings = [{"tool": "bandit", "line": 4, "severity": "HIGH",
+                 "message": "eval", "rule_id": "B307"}]
+    verification = _verification("dangerous", passed=2, failed=1, errors=0)
+    rep = build_gap_report(0, SOURCE, findings, verification)
+    assert rep.confirmed == 1
+    assert rep.unconfirmed == 0
+    assert rep.findings[0].function == "dangerous"
+    assert rep.findings[0].status == "confirmed"
+
+
+def test_finding_unconfirmed_when_tested_but_no_bug():
+    findings = [{"tool": "bandit", "line": 4, "severity": "HIGH",
+                 "message": "eval", "rule_id": "B307"}]
+    verification = _verification("dangerous", passed=3, failed=0, errors=0)
+    rep = build_gap_report(0, SOURCE, findings, verification)
+    assert rep.unconfirmed == 1
+    assert rep.confirmed == 0
+    assert rep.findings[0].status == "unconfirmed"
+
+
+def test_finding_untested_when_all_errored():
+    # All tests errored (the fixed_obj situation): no execution evidence.
+    findings = [{"tool": "bandit", "line": 4, "severity": "HIGH",
+                 "message": "eval", "rule_id": "B307"}]
+    verification = _verification("dangerous", passed=0, failed=0, errors=5)
+    rep = build_gap_report(0, SOURCE, findings, verification)
+    assert rep.untested == 1
+    assert rep.findings[0].status == "untested"
+
+
+def test_execution_only_is_the_gap():
+    # complex_branching has bugs but NO static finding -> the gap.
+    findings = [{"tool": "bandit", "line": 4, "severity": "HIGH",
+                 "message": "eval", "rule_id": "B307"}]  # only on dangerous
+    verification = (
+        _verification("dangerous", 2, 0, 0)
+        + _verification("complex_branching", 5, 3, 0)
+    )
+    rep = build_gap_report(0, SOURCE, findings, verification)
+    assert rep.execution_only_functions == ["complex_branching"]
+
+
+def test_confirmation_rate():
+    findings = [
+        {"tool": "bandit", "line": 4, "severity": "HIGH", "message": "a", "rule_id": "B1"},
+        {"tool": "radon", "line": 10, "severity": "LOW", "message": "b", "rule_id": "R1"},
+    ]
+    verification = (
+        _verification("dangerous", 1, 1, 0)        # confirmed
+        + _verification("complex_branching", 3, 0, 0)  # unconfirmed
+    )
+    rep = build_gap_report(0, SOURCE, findings, verification)
+    assert rep.confirmed == 1
+    assert rep.unconfirmed == 1
+    assert rep.confirmation_rate == 0.5
+
+
+def test_to_dict_shape():
+    findings = [{"tool": "bandit", "line": 4, "severity": "HIGH",
+                 "message": "eval", "rule_id": "B307"}]
+    rep = build_gap_report(0, SOURCE, findings, _verification("dangerous", 1, 1, 0))
+    d = rep.to_dict()
+    assert d["round"] == 0
+    assert d["summary"]["confirmed"] == 1
+    assert "confirmation_rate" in d["summary"]
+    assert d["findings"][0]["status"] == "confirmed"
+
+
+def test_syntax_error_source_no_crash():
+    rep = build_gap_report(0, "def broken(:\n  pass", [], None)
+    assert rep.findings == []
+    assert rep.execution_only_functions == []

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -389,6 +389,7 @@ export interface FunctionBugDetail {
   errors: number;
   skipped: number;
   total: number;
+  discarded?: string[];
   coverage_percent: number | null;
   execution_error: string | null;
   test_code: string;
@@ -421,6 +422,44 @@ export interface ImprovementResponse {
 
 export async function getImprovement(sid: string): Promise<ImprovementResponse> {
   return req<ImprovementResponse>(`/api/session/${sid}/improvement`);
+}
+
+// ─── Static-vs-execution gap ───
+export type FindingStatus = "confirmed" | "unconfirmed" | "untested";
+
+export interface GapFinding {
+  tool: string;
+  severity: string;
+  line: number;
+  message: string;
+  rule_id: string;
+  function: string | null;
+  status: FindingStatus;
+}
+
+export interface GapRoundSummary {
+  confirmed: number;
+  unconfirmed: number;
+  untested: number;
+  execution_only: number;
+  confirmation_rate: number | null;
+}
+
+export interface GapRound {
+  round: number;
+  findings: GapFinding[];
+  execution_only_functions: string[];
+  summary: GapRoundSummary;
+}
+
+export interface GapResponse {
+  available: boolean;
+  rounds: GapRound[];
+  reason?: string;
+}
+
+export async function getGap(sid: string): Promise<GapResponse> {
+  return req<GapResponse>(`/api/session/${sid}/gap`);
 }
 
 // ─── Quality model profiles (selector) ───

--- a/web/frontend/src/screens/GapPanel.tsx
+++ b/web/frontend/src/screens/GapPanel.tsx
@@ -1,0 +1,143 @@
+import { useState, useEffect } from "react";
+import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap } from "lucide-react";
+import * as api from "../api";
+import type { GapRound, FindingStatus } from "../api";
+
+// The static-vs-execution gap, per round: how many static findings
+// execution confirmed, could not reproduce, or could not test, and the
+// execution-found bugs no static tool flagged (the verification gap).
+export default function GapPanel({ sessionId }: { sessionId: string }) {
+  const [rounds, setRounds] = useState<GapRound[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [reason, setReason] = useState<string | null>(null);
+
+  useEffect(() => {
+    let alive = true;
+    setLoading(true);
+    api.getGap(sessionId)
+      .then(res => {
+        if (!alive) return;
+        if (res.available) setRounds(res.rounds);
+        else setReason(res.reason ?? "Not available yet.");
+      })
+      .catch(() => alive && setReason("Could not load the gap analysis."))
+      .finally(() => alive && setLoading(false));
+    return () => { alive = false; };
+  }, [sessionId]);
+
+  if (loading) {
+    return <div className="rounded-2xl border border-slate-200 bg-white/70 p-6 text-sm text-slate-400">Loading gap analysis...</div>;
+  }
+  if (reason) {
+    return <div className="rounded-2xl border border-slate-200 bg-white/70 p-6 text-sm text-slate-400">{reason}</div>;
+  }
+  if (rounds.length === 0) return null;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white/70 p-6 shadow-sm">
+      <div className="flex items-center gap-2">
+        <Zap className="h-5 w-5 text-indigo-600" />
+        <h2 className="text-xl font-semibold text-slate-800">Static analysis vs execution</h2>
+      </div>
+      <p className="mt-1 text-sm text-slate-500">
+        Static findings are hypotheses; execution is the judge. For each round: which static findings execution confirmed, which it could not reproduce (candidate false positives), which it could not test, and the bugs execution found that no static tool flagged, the verification gap.
+      </p>
+
+      <div className="mt-4 space-y-4">
+        {rounds.map(r => <GapRoundCard key={r.round} round={r} />)}
+      </div>
+    </div>
+  );
+}
+
+function GapRoundCard({ round }: { round: GapRound }) {
+  const s = round.summary;
+  const rate = s.confirmation_rate;
+  return (
+    <div className="rounded-xl border border-slate-100 p-4">
+      <div className="flex flex-wrap items-center justify-between gap-2">
+        <span className="text-sm font-semibold text-slate-700">
+          {round.round === 0 ? "Round 0 (baseline)" : `Round ${round.round}`}
+        </span>
+        <div className="flex flex-wrap items-center gap-2 text-xs">
+          <Stat icon={<ShieldCheck className="h-3.5 w-3.5" />} label="confirmed" value={s.confirmed} tone="emerald" />
+          <Stat icon={<ShieldQuestion className="h-3.5 w-3.5" />} label="unconfirmed" value={s.unconfirmed} tone="amber" />
+          <Stat icon={<ShieldAlert className="h-3.5 w-3.5" />} label="untested" value={s.untested} tone="slate" />
+          <Stat icon={<Zap className="h-3.5 w-3.5" />} label="execution-only" value={s.execution_only} tone="indigo" />
+        </div>
+      </div>
+
+      {rate !== null && (
+        <div className="mt-2 text-xs text-slate-500">
+          Confirmation rate: <span className="font-semibold text-slate-700">{(rate * 100).toFixed(0)}%</span>
+          <span className="text-slate-400"> (of findings execution could test)</span>
+        </div>
+      )}
+
+      {/* The gap, called out: execution-found bugs with no static finding. */}
+      {round.execution_only_functions.length > 0 && (
+        <div className="mt-3 rounded-lg border border-indigo-200 bg-indigo-50 p-3">
+          <div className="flex items-center gap-1.5 text-xs font-semibold text-indigo-800">
+            <Zap className="h-3.5 w-3.5" /> Verification gap: bugs static analysis missed
+          </div>
+          <div className="mt-1 text-xs text-indigo-700">
+            Execution found bugs in {round.execution_only_functions.map(f => <code key={f} className="mx-0.5 rounded bg-white/70 px-1 font-mono">{f}</code>)} that no static tool flagged.
+          </div>
+        </div>
+      )}
+
+      {round.findings.length > 0 && (
+        <div className="mt-3 max-h-64 overflow-auto rounded-lg border border-slate-100">
+          <table className="w-full text-xs">
+            <thead className="sticky top-0 bg-slate-50 text-left text-slate-500">
+              <tr>
+                <th className="px-2 py-1.5">Status</th>
+                <th className="px-2 py-1.5">Tool</th>
+                <th className="px-2 py-1.5">Severity</th>
+                <th className="px-2 py-1.5">Line</th>
+                <th className="px-2 py-1.5">Function</th>
+                <th className="px-2 py-1.5">Finding</th>
+              </tr>
+            </thead>
+            <tbody>
+              {round.findings.map((f, i) => (
+                <tr key={i} className="border-t border-slate-100">
+                  <td className="px-2 py-1.5"><StatusBadge status={f.status} /></td>
+                  <td className="px-2 py-1.5 text-slate-600">{f.tool}</td>
+                  <td className="px-2 py-1.5 text-slate-600">{f.severity}</td>
+                  <td className="px-2 py-1.5 font-mono text-slate-500">{f.line}</td>
+                  <td className="px-2 py-1.5 font-mono text-slate-700">{f.function ?? "—"}</td>
+                  <td className="px-2 py-1.5 text-slate-600">{f.message}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Stat({ icon, label, value, tone }: { icon: React.ReactNode; label: string; value: number; tone: string }) {
+  const tones: Record<string, string> = {
+    emerald: "text-emerald-700 bg-emerald-50",
+    amber: "text-amber-700 bg-amber-50",
+    slate: "text-slate-600 bg-slate-100",
+    indigo: "text-indigo-700 bg-indigo-50",
+  };
+  return (
+    <span className={`flex items-center gap-1 rounded-md px-1.5 py-0.5 font-medium ${tones[tone]}`}>
+      {icon}{value} {label}
+    </span>
+  );
+}
+
+function StatusBadge({ status }: { status: FindingStatus }) {
+  const map: Record<FindingStatus, { label: string; cls: string }> = {
+    confirmed: { label: "confirmed", cls: "text-emerald-700 bg-emerald-50 border-emerald-200" },
+    unconfirmed: { label: "unconfirmed", cls: "text-amber-700 bg-amber-50 border-amber-200" },
+    untested: { label: "untested", cls: "text-slate-600 bg-slate-50 border-slate-200" },
+  };
+  const m = map[status];
+  return <span className={`rounded border px-1.5 py-0.5 font-medium ${m.cls}`}>{m.label}</span>;
+}

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -16,6 +16,7 @@ import {
   ChevronRight, ChevronDown, MessageSquare, Sparkles, FlaskConical,
 } from "lucide-react";
 import * as api from "../api";
+import GapPanel from "./GapPanel";
 import type {
   ImprovementRound, ImprovementUnit, IndicatorDelta, LLMCall,
 } from "../api";
@@ -294,6 +295,7 @@ export default function ImprovementView({ sessionId }: { sessionId: string }) {
 
   return (
     <div className="space-y-3">
+      <GapPanel sessionId={sessionId} />
       <div className="flex items-end justify-between gap-3">
         <div>
           <h2 className="text-xl font-semibold text-slate-800">Improvement audit</h2>

--- a/web/frontend/src/screens/TestGenScreen.tsx
+++ b/web/frontend/src/screens/TestGenScreen.tsx
@@ -45,6 +45,7 @@ interface RoundTestSummary {
     passed: number;
     bugs: number;
     errors: number;
+    discarded: number;
   }[];
 }
 
@@ -195,6 +196,7 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
                 passed: fn.passed,
                 bugs: fn.failed,
                 errors: fn.errors,
+                discarded: (fn.discarded || []).length,
               });
             }
           }
@@ -401,6 +403,7 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
                             <span className="flex items-center gap-0.5 text-emerald-600"><CheckCircle2 className="h-3 w-3" />{fn.passed}</span>
                             <span className="flex items-center gap-0.5 text-rose-600"><XCircle className="h-3 w-3" />{fn.bugs}</span>
                             {fn.errors > 0 && <span className="flex items-center gap-0.5 text-amber-600"><AlertCircle className="h-3 w-3" />{fn.errors}</span>}
+                            {fn.discarded > 0 && <span className="flex items-center gap-0.5 text-slate-400" title="Tests dropped before running: requested undefined fixtures">⊘{fn.discarded}</span>}
                             <span className="text-slate-400">/ {fn.total}</span>
                           </span>
                         </div>


### PR DESCRIPTION
Branch: `feature/static-execution-gap` (off `dev`, after #80)
**1 commit.** All green: **474 Python tests pass**, frontend type-checks and builds, ruff clean.

I combined step 2 with the step-1 follow-up, as we discussed. They share one story: a trustworthy verification-gap number must account for which tests actually ran (the discarded/error distinction from step 1). Folding them was the right design, not just convenient bundling.

## The gap analysis (backend)

New `qallm/analysis/gap_analysis.py`. `build_gap_report` correlates static findings with execution results per round, **line-level** (your choice):

- Each finding's line is mapped to its enclosing function via AST span (`end_lineno`; innermost function wins when nested).
- Each finding is then classified:
  - **confirmed**: the function has an execution-found bug, execution corroborates the finding.
  - **unconfirmed**: the function was tested but produced no bug, a candidate false positive or not triggerable.
  - **untested**: no test actually ran for the function (all errored, or none), so no execution evidence either way.
- **The gap** runs the other direction: functions with an execution-found bug but *no* static finding (`execution_only`), the defects static analysis missed.
- Counts exclude errored and discarded tests: only ran-and-failed is a bug, so the gap number isn't polluted by tests that never executed (the ERROR-vs-BUG distinction we established).
- Confirmation rate = confirmed / (confirmed + unconfirmed).

`GET /api/session/{id}/gap` reads each round's persisted `source.py`, `static.json`, and `verification.json`, so it works for live *and* historical sessions, and shows the gap per round, not just baseline.

## The gap view (frontend)

`GapPanel` on the Report page, above the improvement audit (your placement choice). Per round: confirmed / unconfirmed / untested / execution-only counts, the confirmation rate, the verification gap called out in its own indigo block, and a findings table (status, tool, severity, line, function, message).

## Step-1 follow-up folded in

The discarded-test count (tests dropped before running because they requested undefined fixtures, the `fixed_obj` class) is now carried in the improvement `bug_detail` and shown as a `⊘N` chip in the live "Tests by round" panel, next to pass/bug/error. So the effect of step 1 is now visible in the UI, not just the logs.

## Why line-level was worth the fragility

You picked line-level over function-level. The payoff: a finding on line 4 (an `eval`) maps precisely to `dangerous`, and if `dangerous`'s tests found a bug, that finding is confirmed; a finding on a function whose tests all passed is flagged unconfirmed. Function-level would have been coarser. The fragility (a finding line outside any function maps to "no function", and the finding shows status untested) is handled: such findings are simply not attributed to a function and count as untested, which is honest.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 474 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```
