### PR TITLE
Review: confirm/refute individual static findings (roadmap step 3)

### DIFF
--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -22,6 +22,82 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+@router.post("/api/session/{session_id}/confirm-findings")
+async def confirm_findings(session_id: str):
+    """Confirm or refute each static finding individually by execution.
+
+    For each finding on a unit, a targeted test is generated and run to
+    decide whether the finding reproduces (confirmed), does not (refuted),
+    could not be tested (inconclusive), or is a finding type execution
+    cannot judge such as complexity (not_execution_testable). Reuses the
+    session's test-generation model and token tracker.
+
+    This makes LLM calls, so it is an explicit POST action rather than
+    something computed on every page load.
+    """
+    from qallm.verification.confirm_refute import FindingConfirmer
+    from qallm.verification.extractor import extract_functions_from_source
+    from qallm.analysis.gap_analysis import function_spans, _function_for_line
+
+    state = get_state(session_id)
+    orch: QALLMOrchestrator = state["orchestrator"]
+    confirmer = FindingConfirmer(orch.testgen_llm, orch.tracker)
+
+    analysed_units = state.get("analysed_units", {})
+    if not analysed_units:
+        return {"available": False, "verdicts": [],
+                "reason": "Run analysis first so there are findings to confirm."}
+
+    all_verdicts: list[dict] = []
+    confirmed = refuted = inconclusive = not_testable = 0
+
+    for name, analysed in analysed_units.items():
+        findings = [asdict(f) for f in analysed.findings]
+        if not findings:
+            continue
+        source = analysed.code_unit.source_code
+        spans = function_spans(source)
+        funcs = {f.name: f for f in extract_functions_from_source(source, name)}
+
+        # Group findings by the function their line falls in, so each
+        # function's findings are confirmed against that function's code.
+        for fname, func in funcs.items():
+            fn_findings = [
+                f for f in findings
+                if _function_for_line(spans, int(f.get("line", 0) or 0)) == fname
+            ]
+            if not fn_findings:
+                continue
+            report = confirmer.confirm_findings(
+                func=func,
+                findings=fn_findings,
+                source_code=source,
+                source_filename=name,
+                source_origin=analysed.code_unit.original_path,
+            )
+            confirmed += report.confirmed
+            refuted += report.refuted
+            inconclusive += report.inconclusive
+            not_testable += report.not_testable
+            for v in report.verdicts:
+                d = v.to_dict()
+                d["file"] = name
+                all_verdicts.append(d)
+
+    denom = confirmed + refuted
+    return {
+        "available": True,
+        "verdicts": all_verdicts,
+        "summary": {
+            "confirmed": confirmed,
+            "refuted": refuted,
+            "inconclusive": inconclusive,
+            "not_execution_testable": not_testable,
+            "confirmation_rate": (confirmed / denom) if denom else None,
+        },
+    }
+
+
 @router.post("/api/analyse")
 async def run_analysis(req: dict):
     """Run static analysis on the session's code units.

--- a/src/qallm/verification/confirm_refute.py
+++ b/src/qallm/verification/confirm_refute.py
@@ -1,0 +1,246 @@
+"""Confirm or refute individual static findings by execution.
+
+Roadmap step 3. The gap view (step 2) correlates findings to functions:
+useful, but only at function granularity. This module sharpens the claim to
+the level of a single finding: take one static finding, generate a test
+whose explicit job is to demonstrate that finding's defect, run it, and
+record whether the finding reproduced.
+
+Crucially this is *type-aware*, because not every static finding is
+something execution can speak to:
+
+* RELIABILITY (a correctness bug): a test can reproduce it by making the
+  function return a wrong result or raise. Confirmable.
+* SECURITY (a vulnerability such as eval / shell=True): a test can
+  demonstrate the unsafe behaviour is reachable. Confirmable as
+  exploitability.
+* COMPLEXITY / MAINTAINABILITY: a property of the source text (e.g. high
+  cyclomatic complexity), not a runtime behaviour. No test can "reproduce"
+  it, so we never attempt one and label it not_execution_testable. Pretending
+  otherwise would be dishonest and waste an LLM call.
+
+A finding's verdict is therefore one of:
+  - confirmed: the targeted test demonstrated the defect.
+  - refuted: the targeted test ran cleanly, the finding was not reproducible
+    by the generated test (a candidate false positive, stated cautiously).
+  - inconclusive: the test could not be generated or errored (no evidence).
+  - not_execution_testable: the finding type is not something execution can
+    judge.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from qallm.verification.executor import run_tests
+from qallm.verification.generator import _fix_source_import, _validate_test_code
+from qallm.verification.models import FunctionInfo
+from qallm.verification.prompts import (
+    SYSTEM_PROMPT,
+    build_finding_targeted_prompt,
+)
+from qallm.verification.sandbox import CodeExtractor
+from qallm.verification.test_validator import strip_unsatisfied_fixture_tests
+
+logger = logging.getLogger(__name__)
+
+Verdict = Literal[
+    "confirmed", "refuted", "inconclusive", "not_execution_testable",
+]
+
+# Finding types execution can speak to, and how the targeted test's outcome
+# maps to a verdict.
+#   RELIABILITY: the test asserts CORRECT behaviour, so a FAILURE means the
+#     bug reproduced (confirmed); a pass means not reproduced (refuted).
+#   SECURITY: the test asserts the unsafe effect OCCURS, so a PASS means the
+#     vulnerability is demonstrated (confirmed); a failure means it did not
+#     trigger (refuted).
+_RELIABILITY_TYPES = {"RELIABILITY"}
+_SECURITY_TYPES = {"SECURITY"}
+_TESTABLE_TYPES = _RELIABILITY_TYPES | _SECURITY_TYPES
+
+
+@dataclass
+class FindingVerdict:
+    finding_index: int
+    tool: str
+    type: str
+    severity: str
+    line: int
+    message: str
+    rule_id: str
+    function: str | None
+    verdict: Verdict
+    reason: str
+    reproducing_test: str | None = None  # the test body, when confirmed
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_index": self.finding_index,
+            "tool": self.tool, "type": self.type, "severity": self.severity,
+            "line": self.line, "message": self.message,
+            "rule_id": self.rule_id, "function": self.function,
+            "verdict": self.verdict, "reason": self.reason,
+            "reproducing_test": self.reproducing_test,
+        }
+
+
+@dataclass
+class ConfirmRefuteReport:
+    verdicts: list[FindingVerdict] = field(default_factory=list)
+
+    @property
+    def confirmed(self) -> int:
+        return sum(1 for v in self.verdicts if v.verdict == "confirmed")
+
+    @property
+    def refuted(self) -> int:
+        return sum(1 for v in self.verdicts if v.verdict == "refuted")
+
+    @property
+    def inconclusive(self) -> int:
+        return sum(1 for v in self.verdicts if v.verdict == "inconclusive")
+
+    @property
+    def not_testable(self) -> int:
+        return sum(1 for v in self.verdicts
+                   if v.verdict == "not_execution_testable")
+
+    @property
+    def confirmation_rate(self) -> float | None:
+        """Confirmed over the findings we actually tested (confirmed +
+        refuted). None when nothing was testable/attempted."""
+        denom = self.confirmed + self.refuted
+        return (self.confirmed / denom) if denom else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "verdicts": [v.to_dict() for v in self.verdicts],
+            "summary": {
+                "confirmed": self.confirmed,
+                "refuted": self.refuted,
+                "inconclusive": self.inconclusive,
+                "not_execution_testable": self.not_testable,
+                "confirmation_rate": self.confirmation_rate,
+            },
+        }
+
+
+def _classify_outcome(ftype: str, passed: int, failed: int, errors: int) -> tuple[Verdict, str]:
+    """Map a targeted test's run outcome to a verdict, by finding type."""
+    if errors > 0 and passed == 0 and failed == 0:
+        return "inconclusive", "The targeted test errored before running."
+    if ftype in _RELIABILITY_TYPES:
+        if failed > 0:
+            return "confirmed", (
+                "A targeted test asserting correct behaviour failed against "
+                "the current code, reproducing the defect."
+            )
+        if passed > 0:
+            return "refuted", (
+                "Targeted tests asserting correct behaviour passed; the "
+                "finding was not reproducible by the generated test."
+            )
+        return "inconclusive", "No targeted test produced a clear result."
+    # SECURITY: a passing test demonstrates the unsafe effect occurs.
+    if passed > 0:
+        return "confirmed", (
+            "A targeted test demonstrated the flagged unsafe behaviour is "
+            "reachable."
+        )
+    if failed > 0:
+        return "refuted", (
+            "The targeted test could not demonstrate the unsafe behaviour; "
+            "the finding was not reproduced."
+        )
+    return "inconclusive", "No targeted test produced a clear result."
+
+
+class FindingConfirmer:
+    """Generates and runs a targeted test per finding to reach a verdict."""
+
+    def __init__(self, llm, tracker=None) -> None:
+        self.llm = llm
+        self.tracker = tracker
+
+    def confirm_findings(
+        self,
+        func: FunctionInfo,
+        findings: list[dict],
+        source_code: str,
+        source_filename: str = "source_module.py",
+        source_origin=None,
+    ) -> ConfirmRefuteReport:
+        """Reach a verdict for each finding that maps to ``func``.
+
+        Findings whose type execution cannot judge are recorded as
+        not_execution_testable without an LLM call. The rest get a targeted
+        test, executed in the sandbox.
+        """
+        report = ConfirmRefuteReport()
+        module_name = source_filename.removesuffix(".py")
+        for idx, finding in enumerate(findings):
+            ftype = (finding.get("type") or "").upper()
+            base = dict(
+                finding_index=idx,
+                tool=finding.get("tool", "?"),
+                type=ftype or "?",
+                severity=finding.get("severity", "?"),
+                line=int(finding.get("line", 0) or 0),
+                message=finding.get("message", ""),
+                rule_id=finding.get("rule_id", ""),
+                function=func.name,
+            )
+            if ftype not in _TESTABLE_TYPES:
+                report.verdicts.append(FindingVerdict(
+                    **base,
+                    verdict="not_execution_testable",
+                    reason=(
+                        f"A {ftype or 'non-runtime'} finding is a property of "
+                        "the source, not a runtime behaviour; execution "
+                        "cannot confirm or refute it."
+                    ),
+                ))
+                continue
+
+            verdict, reason, test_body = self._attempt(
+                func, finding, module_name, source_code,
+                source_filename, source_origin,
+            )
+            report.verdicts.append(FindingVerdict(
+                **base, verdict=verdict, reason=reason,
+                reproducing_test=test_body if verdict == "confirmed" else None,
+            ))
+        return report
+
+    def _attempt(
+        self, func, finding, module_name, source_code,
+        source_filename, source_origin,
+    ) -> tuple[Verdict, str, str | None]:
+        ftype = (finding.get("type") or "").upper()
+        prompt = build_finding_targeted_prompt(func, finding)
+        resp = self.llm.chat(SYSTEM_PROMPT, prompt, self.tracker)
+        if resp.error:
+            return "inconclusive", f"Test generation failed: {resp.error}", None
+
+        code, _ = CodeExtractor.extract(resp.content)
+        code = _fix_source_import(code, module_name)
+        is_valid, err = _validate_test_code(code)
+        if is_valid:
+            code, _discarded = strip_unsatisfied_fixture_tests(code)
+            is_valid, err = _validate_test_code(code)
+        if not is_valid:
+            return "inconclusive", f"Generated test was invalid: {err}", None
+
+        result = run_tests(
+            source_code=source_code,
+            test_code=code,
+            source_filename=source_filename,
+            source_origin=source_origin,
+        )
+        verdict, reason = _classify_outcome(
+            ftype, result.passed, result.failed, result.errors,
+        )
+        return verdict, reason, code

--- a/src/qallm/verification/prompts.py
+++ b/src/qallm/verification/prompts.py
@@ -272,3 +272,69 @@ def build_feedback_prompt(
     parts.append("Return ONLY the complete test file. Start with imports.\n")
 
     return "\n".join(parts)
+
+
+def build_finding_targeted_prompt(func: FunctionInfo, finding: dict) -> str:
+    """Build a prompt to write a test that demonstrates one specific static
+    finding's defect.
+
+    Unlike the oracle prompts (which explore broadly), this is surgical: the
+    model is told exactly what a static analyser flagged and asked to write a
+    test whose failure (or demonstration) confirms the finding is a real,
+    triggerable problem. The framing differs by finding type:
+
+    * RELIABILITY: a correctness bug, the test should make the function
+      return a wrong result or raise an unexpected exception.
+    * SECURITY: a vulnerability, the test should demonstrate the unsafe
+      behaviour is reachable (e.g. injected input being executed), not just
+      that the function runs.
+
+    The caller is responsible for only invoking this on finding types that
+    execution can speak to; complexity/maintainability findings are not
+    reproducible by a test and must not reach here.
+    """
+    ftype = (finding.get("type") or "").upper()
+    line = finding.get("line")
+    message = finding.get("message", "")
+    rule = finding.get("rule_id", "")
+    tool = finding.get("tool", "a static analyser")
+
+    parts = [
+        "## Function under test\n",
+        f"```python\n{func.source}\n```\n",
+    ]
+    if func.docstring:
+        parts.append(f"## Docstring\n{func.docstring}\n")
+
+    parts.append(
+        "## Static finding to investigate\n"
+        f"{tool} reported, on line {line} (rule {rule}):\n"
+        f"> {message}\n"
+    )
+
+    if ftype == "SECURITY":
+        goal = (
+            "Write a pytest test that DEMONSTRATES this security problem is "
+            "real and reachable: construct an input that causes the flagged "
+            "unsafe operation to do something it should not (for example, "
+            "input that gets executed, or that escapes its intended scope). "
+            "The test should assert that the unsafe effect occurs, so a "
+            "passing test is evidence the vulnerability is exploitable."
+        )
+    else:  # RELIABILITY / correctness
+        goal = (
+            "Write a pytest test that REPRODUCES this as a concrete defect: "
+            "find an input for which the function returns a wrong result or "
+            "raises an exception it should handle. The test should assert the "
+            "CORRECT expected behaviour, so that it FAILS against the current "
+            "code, demonstrating the finding is a real bug."
+        )
+
+    parts.append(
+        "## Task\n"
+        f"{goal}\n\n"
+        "Focus only on this one finding. Generate 1 to 3 focused tests that "
+        "target it specifically; do not test unrelated behaviour.\n\n"
+        "Return ONLY the complete test file. Start with imports."
+    )
+    return "\n".join(parts)

--- a/tests/test_confirm_refute.py
+++ b/tests/test_confirm_refute.py
@@ -1,0 +1,108 @@
+"""Tests for type-aware confirm/refute of individual findings."""
+
+from qallm.verification.confirm_refute import (
+    FindingConfirmer,
+    ConfirmRefuteReport,
+    FindingVerdict,
+    _classify_outcome,
+)
+from qallm.verification.models import FunctionInfo
+
+
+def _func():
+    return FunctionInfo(
+        name="dangerous", source="def dangerous(x):\n    return eval(x)",
+        docstring=None, args=[("x", None)], lineno=1, filepath="m.py",
+    )
+
+
+# ── classification logic (no LLM, no execution) ──
+
+def test_reliability_failure_is_confirmed():
+    v, _ = _classify_outcome("RELIABILITY", passed=0, failed=1, errors=0)
+    assert v == "confirmed"
+
+
+def test_reliability_pass_is_refuted():
+    v, _ = _classify_outcome("RELIABILITY", passed=2, failed=0, errors=0)
+    assert v == "refuted"
+
+
+def test_security_pass_is_confirmed():
+    # A security test asserts the unsafe effect occurs; passing = exploitable.
+    v, _ = _classify_outcome("SECURITY", passed=1, failed=0, errors=0)
+    assert v == "confirmed"
+
+
+def test_security_failure_is_refuted():
+    v, _ = _classify_outcome("SECURITY", passed=0, failed=1, errors=0)
+    assert v == "refuted"
+
+
+def test_all_errored_is_inconclusive():
+    v, _ = _classify_outcome("RELIABILITY", passed=0, failed=0, errors=3)
+    assert v == "inconclusive"
+
+
+# ── type-awareness: complexity/maintainability never run ──
+
+class _FakeLLM:
+    def __init__(self):
+        self.calls = 0
+    def chat(self, system, user, tracker=None):
+        self.calls += 1
+        raise AssertionError("should not be called for non-testable findings")
+
+
+def test_complexity_finding_not_execution_testable_no_llm_call():
+    llm = _FakeLLM()
+    confirmer = FindingConfirmer(llm)
+    findings = [{"tool": "Radon", "type": "COMPLEXITY", "severity": "MEDIUM",
+                 "line": 1, "message": "cyclomatic complexity is high",
+                 "rule_id": "CC"}]
+    report = confirmer.confirm_findings(
+        _func(), findings, source_code="def dangerous(x):\n    return x",
+    )
+    assert llm.calls == 0
+    assert report.not_testable == 1
+    assert report.verdicts[0].verdict == "not_execution_testable"
+
+
+def test_maintainability_also_not_testable():
+    confirmer = FindingConfirmer(_FakeLLM())
+    findings = [{"tool": "Radon", "type": "MAINTAINABILITY", "severity": "LOW",
+                 "line": 1, "message": "low MI", "rule_id": "MI"}]
+    report = confirmer.confirm_findings(
+        _func(), findings, source_code="def dangerous(x):\n    return x",
+    )
+    assert report.verdicts[0].verdict == "not_execution_testable"
+
+
+# ── report summary maths ──
+
+def test_confirmation_rate_excludes_inconclusive_and_nontestable():
+    report = ConfirmRefuteReport(verdicts=[
+        FindingVerdict(0, "t", "RELIABILITY", "HIGH", 1, "m", "r", "f",
+                       "confirmed", "x"),
+        FindingVerdict(1, "t", "RELIABILITY", "HIGH", 2, "m", "r", "f",
+                       "refuted", "x"),
+        FindingVerdict(2, "t", "COMPLEXITY", "LOW", 3, "m", "r", "f",
+                       "not_execution_testable", "x"),
+        FindingVerdict(3, "t", "RELIABILITY", "HIGH", 4, "m", "r", "f",
+                       "inconclusive", "x"),
+    ])
+    # rate = confirmed / (confirmed + refuted) = 1 / 2
+    assert report.confirmation_rate == 0.5
+    assert report.not_testable == 1
+    assert report.inconclusive == 1
+
+
+def test_to_dict_shape():
+    report = ConfirmRefuteReport(verdicts=[
+        FindingVerdict(0, "bandit", "SECURITY", "HIGH", 2, "eval", "B307",
+                       "dangerous", "confirmed", "demo", reproducing_test="def test(): ..."),
+    ])
+    d = report.to_dict()
+    assert d["summary"]["confirmed"] == 1
+    assert d["verdicts"][0]["verdict"] == "confirmed"
+    assert d["verdicts"][0]["reproducing_test"] is not None

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -462,6 +462,44 @@ export async function getGap(sid: string): Promise<GapResponse> {
   return req<GapResponse>(`/api/session/${sid}/gap`);
 }
 
+// ─── Confirm/refute individual findings ───
+export type FindingVerdict =
+  | "confirmed" | "refuted" | "inconclusive" | "not_execution_testable";
+
+export interface FindingVerdictRow {
+  finding_index: number;
+  file?: string;
+  tool: string;
+  type: string;
+  severity: string;
+  line: number;
+  message: string;
+  rule_id: string;
+  function: string | null;
+  verdict: FindingVerdict;
+  reason: string;
+  reproducing_test: string | null;
+}
+
+export interface ConfirmFindingsResponse {
+  available: boolean;
+  verdicts: FindingVerdictRow[];
+  reason?: string;
+  summary?: {
+    confirmed: number;
+    refuted: number;
+    inconclusive: number;
+    not_execution_testable: number;
+    confirmation_rate: number | null;
+  };
+}
+
+export async function confirmFindings(sid: string): Promise<ConfirmFindingsResponse> {
+  return req<ConfirmFindingsResponse>(`/api/session/${sid}/confirm-findings`, {
+    method: "POST",
+  });
+}
+
 // ─── Quality model profiles (selector) ───
 export interface QualityProfileInfo {
   id: string;

--- a/web/frontend/src/screens/GapPanel.tsx
+++ b/web/frontend/src/screens/GapPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap } from "lucide-react";
+import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap, Microscope, Loader2 } from "lucide-react";
 import * as api from "../api";
-import type { GapRound, FindingStatus } from "../api";
+import type { GapRound, FindingStatus, FindingVerdictRow, FindingVerdict } from "../api";
 
 // The static-vs-execution gap, per round: how many static findings
 // execution confirmed, could not reproduce, or could not test, and the
@@ -10,6 +10,29 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
   const [rounds, setRounds] = useState<GapRound[]>([]);
   const [loading, setLoading] = useState(true);
   const [reason, setReason] = useState<string | null>(null);
+
+  // Confirm/refute: an explicit action (it makes LLM calls), so it runs on
+  // demand rather than on load.
+  const [confirming, setConfirming] = useState(false);
+  const [verdicts, setVerdicts] = useState<FindingVerdictRow[] | null>(null);
+  const [confirmSummary, setConfirmSummary] = useState<api.ConfirmFindingsResponse["summary"] | null>(null);
+  const [confirmError, setConfirmError] = useState<string | null>(null);
+
+  const runConfirm = () => {
+    setConfirming(true);
+    setConfirmError(null);
+    api.confirmFindings(sessionId)
+      .then(res => {
+        if (res.available) {
+          setVerdicts(res.verdicts);
+          setConfirmSummary(res.summary ?? null);
+        } else {
+          setConfirmError(res.reason ?? "Not available.");
+        }
+      })
+      .catch(() => setConfirmError("Confirm/refute failed."))
+      .finally(() => setConfirming(false));
+  };
 
   useEffect(() => {
     let alive = true;
@@ -46,8 +69,90 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
       <div className="mt-4 space-y-4">
         {rounds.map(r => <GapRoundCard key={r.round} round={r} />)}
       </div>
+
+      {/* Per-finding confirm/refute: sharpens the function-level gap above to
+          individual findings by generating a targeted test for each. */}
+      <div className="mt-6 border-t border-slate-100 pt-4">
+        <div className="flex flex-wrap items-center justify-between gap-3">
+          <div>
+            <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+              <Microscope className="h-4 w-4 text-indigo-600" /> Confirm or refute each finding
+            </h3>
+            <p className="mt-1 text-xs text-slate-500">
+              Generates a targeted test per finding to reproduce its defect. Reliability findings are confirmed when a correctness test fails; security findings when an exploit test passes. Complexity and maintainability findings are not execution-testable.
+            </p>
+          </div>
+          <button
+            onClick={runConfirm}
+            disabled={confirming}
+            className="flex shrink-0 items-center gap-2 rounded-xl bg-slate-900 px-4 py-2 text-sm font-medium text-white disabled:opacity-50"
+          >
+            {confirming ? <><Loader2 className="h-4 w-4 animate-spin" /> Running...</> : <>Run confirm/refute</>}
+          </button>
+        </div>
+
+        {confirmError && <div className="mt-3 text-xs text-rose-600">{confirmError}</div>}
+
+        {confirmSummary && (
+          <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+            <Stat icon={<ShieldCheck className="h-3.5 w-3.5" />} label="confirmed" value={confirmSummary.confirmed} tone="emerald" />
+            <Stat icon={<ShieldQuestion className="h-3.5 w-3.5" />} label="refuted" value={confirmSummary.refuted} tone="amber" />
+            <Stat icon={<ShieldAlert className="h-3.5 w-3.5" />} label="inconclusive" value={confirmSummary.inconclusive} tone="slate" />
+            <Stat icon={<ShieldAlert className="h-3.5 w-3.5" />} label="not testable" value={confirmSummary.not_execution_testable} tone="slate" />
+            {confirmSummary.confirmation_rate !== null && (
+              <span className="text-slate-500">rate: <span className="font-semibold text-slate-700">{(confirmSummary.confirmation_rate * 100).toFixed(0)}%</span></span>
+            )}
+          </div>
+        )}
+
+        {verdicts && verdicts.length > 0 && (
+          <div className="mt-3 space-y-2">
+            {verdicts.map((v, i) => <VerdictCard key={i} v={v} />)}
+          </div>
+        )}
+      </div>
     </div>
   );
+}
+
+function VerdictCard({ v }: { v: FindingVerdictRow }) {
+  const [showTest, setShowTest] = useState(false);
+  return (
+    <div className="rounded-lg border border-slate-100 p-3 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <VerdictBadge verdict={v.verdict} />
+        <span className="text-slate-600">{v.tool}</span>
+        <span className="text-slate-400">·</span>
+        <span className="text-slate-500">{v.type}</span>
+        <span className="text-slate-400">·</span>
+        <span className="font-mono text-slate-500">L{v.line}</span>
+        {v.function && <><span className="text-slate-400">·</span><span className="font-mono text-slate-700">{v.function}</span></>}
+      </div>
+      <div className="mt-1 text-slate-600">{v.message}</div>
+      <div className="mt-1 text-slate-500 italic">{v.reason}</div>
+      {v.reproducing_test && (
+        <div className="mt-2">
+          <button onClick={() => setShowTest(s => !s)} className="text-indigo-600 hover:underline">
+            {showTest ? "Hide" : "Show"} reproducing test
+          </button>
+          {showTest && (
+            <pre className="mt-1 overflow-auto rounded bg-slate-900 p-2 text-[11px] text-slate-100">{v.reproducing_test}</pre>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VerdictBadge({ verdict }: { verdict: FindingVerdict }) {
+  const map: Record<FindingVerdict, { label: string; cls: string }> = {
+    confirmed: { label: "confirmed", cls: "text-emerald-700 bg-emerald-50 border-emerald-200" },
+    refuted: { label: "refuted", cls: "text-amber-700 bg-amber-50 border-amber-200" },
+    inconclusive: { label: "inconclusive", cls: "text-slate-600 bg-slate-50 border-slate-200" },
+    not_execution_testable: { label: "not testable", cls: "text-slate-500 bg-slate-50 border-slate-200" },
+  };
+  const m = map[verdict];
+  return <span className={`rounded border px-1.5 py-0.5 font-medium ${m.cls}`}>{m.label}</span>;
 }
 
 function GapRoundCard({ round }: { round: GapRound }) {


### PR DESCRIPTION
Branch: `feature/confirm-refute-findings` (off `dev`, after #81)
**1 commit.** All green: **483 Python tests pass**, frontend type-checks and builds, ruff clean.

This is roadmap step 3, and it sharpens the claim from step 2's function-level correlation to per-finding reproduction.

## What it does

For each static finding, generate a test whose explicit job is to demonstrate *that finding's* defect, run it, and record a verdict. Backend engine + full UI, as you scoped.

## Type-aware (your choice), and why it matters

Not every finding is something execution can judge, so the engine branches on finding type:

- **RELIABILITY** (a correctness bug): the targeted test asserts *correct* behaviour, so a **failure** means the bug reproduced → **confirmed**; a pass → **refuted**.
- **SECURITY** (eval, shell=True, ...): the targeted test asserts the *unsafe effect occurs*, so a **pass** demonstrates exploitability → **confirmed**; a failure → **refuted**.
- **COMPLEXITY / MAINTAINABILITY**: a property of the source text, not a runtime behaviour. Marked **not_execution_testable** with **no LLM call**. Pretending a test can "reproduce" cyclomatic complexity would be dishonest and waste tokens.

Verdicts: `confirmed`, `refuted`, `inconclusive` (test couldn't be generated or errored), `not_execution_testable`.

## Pieces

- `qallm/verification/confirm_refute.py`: `FindingConfirmer` generates a targeted test per testable finding (reusing the existing extractor, validator, AST fixture-stripper from step 1, and `run_tests`), classifies by type, keeps the reproducing test for confirmed findings.
- `build_finding_targeted_prompt` in `prompts.py`: type-specific framing (reproduce-the-bug vs demonstrate-the-exploit).
- `POST /api/session/{id}/confirm-findings`: groups each unit's findings by the function their line falls in (reusing step 2's `function_spans`/`_function_for_line`), runs the confirmer per function with the session's testgen LLM and tracker, returns per-finding verdicts + a summary with confirmation rate.
- `GapPanel`: a "Run confirm/refute" button, per-finding verdict cards (status, type, line, function, reason), an expandable reproducing test for confirmed findings, and the summary counts + rate.

## Framing (important for the thesis)

- The confirmation rate counts only findings execution could actually test (`confirmed / (confirmed + refuted)`). Complexity/maintainability are excluded from the denominator, not counted as refuted, so the rate isn't deflated by findings execution was never going to reach.
- A confirmed **reliability** finding has a *failing* test as evidence (the bug is real). A confirmed **security** finding has a *passing* exploit test (the unsafe behaviour is reachable). These are different kinds of evidence, and the UI states the reason per verdict so it's never ambiguous.
- "Refuted" is stated cautiously: it means the generated test did not reproduce the finding, which is evidence of a candidate false positive, not proof. The model may simply have failed to find the triggering input.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 483 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```
