### PR TITLE
Review: headline quality metrics card (stacked on verified-fix)

### DIFF
--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -98,6 +98,84 @@ async def confirm_findings(session_id: str):
     }
 
 
+@router.post("/api/session/{session_id}/verify-fixes")
+async def verify_fixes_endpoint(session_id: str, req: dict):
+    """Prove that confirmed findings are fixed by the repair, via execution.
+
+    Takes the confirmed findings (verdict dicts carrying a reproducing_test,
+    as returned by /confirm-findings), re-runs each one's reproducing test
+    against the repaired source for its file, and reports whether the defect
+    is provably gone (verified_fixed), still present (not_fixed), or could
+    not be re-tested (inconclusive).
+
+    The confirmed findings are passed in from the client (which already has
+    them from the confirm step) so no LLM calls are repeated; this endpoint
+    is pure execution.
+    """
+    from qallm.verification.verified_fix import verify_fixes
+
+    state = get_state(session_id)
+    repaired_units = state.get("repaired_units", {})
+    if not repaired_units:
+        return {"available": False, "results": [],
+                "reason": "No repaired code yet. Run repair first."}
+
+    findings = req.get("findings") or []
+    if not findings:
+        return {"available": False, "results": [],
+                "reason": "No confirmed findings provided to verify."}
+
+    # Group the confirmed findings by file so each is re-run against the
+    # repaired source for its own unit.
+    by_file: dict[str, list[dict]] = {}
+    for f in findings:
+        by_file.setdefault(f.get("file") or "", []).append(f)
+
+    all_results: list[dict] = []
+    verified_fixed = not_fixed = inconclusive = 0
+    for name, file_findings in by_file.items():
+        repaired = repaired_units.get(name)
+        if not repaired:
+            # No repair for this file: its findings cannot be verified fixed.
+            for f in file_findings:
+                all_results.append({
+                    **{k: f.get(k) for k in (
+                        "finding_index", "tool", "type", "severity", "line",
+                        "message", "rule_id", "function")},
+                    "file": name,
+                    "fix_verdict": "inconclusive",
+                    "reason": "No repaired version of this file to test against.",
+                })
+                inconclusive += 1
+            continue
+        repaired_unit = repaired.repaired_code_unit
+        report = verify_fixes(
+            confirmed_findings=file_findings,
+            repaired_source=repaired_unit.source_code,
+            source_filename=name,
+            source_origin=repaired_unit.original_path,
+        )
+        verified_fixed += report.verified_fixed
+        not_fixed += report.not_fixed
+        inconclusive += report.inconclusive
+        for r in report.results:
+            d = r.to_dict()
+            d["file"] = name
+            all_results.append(d)
+
+    denom = verified_fixed + not_fixed
+    return {
+        "available": True,
+        "results": all_results,
+        "summary": {
+            "verified_fixed": verified_fixed,
+            "not_fixed": not_fixed,
+            "inconclusive": inconclusive,
+            "verified_fix_rate": (verified_fixed / denom) if denom else None,
+        },
+    }
+
+
 @router.post("/api/analyse")
 async def run_analysis(req: dict):
     """Run static analysis on the session's code units.

--- a/src/qallm/verification/verified_fix.py
+++ b/src/qallm/verification/verified_fix.py
@@ -1,0 +1,187 @@
+"""Verify that a repair actually fixed a confirmed finding, by execution.
+
+The strategy doc's principle is "prove the fix, do not assert it". Static
+tools and even LLM repairers typically *claim* a fix is correct. QALLM can
+do better: when a finding was confirmed by a reproducing test (the test
+demonstrated the defect against the original code), re-run that same test
+against the repaired code and see whether the defect is gone.
+
+This is the verified-fix loop. For a confirmed finding it yields:
+
+* verified_fixed: the reproducing test demonstrated the defect on the
+  original code and shows it is gone on the repaired code. A proven fix.
+* not_fixed: the test still demonstrates the defect on the repaired code;
+  the repair did not address it.
+* inconclusive: the test errored on the repaired code, or the finding was
+  not actually confirmed on the original (no reproducing test to re-run),
+  so there is no clean before/after to compare.
+
+The "is the defect gone" check is type-aware, mirroring confirm/refute but
+inverted for the repaired code:
+
+* RELIABILITY: the reproducing test asserts CORRECT behaviour, so on the
+  original it FAILED (bug present). Fixed means it now PASSES on repaired.
+* SECURITY: the reproducing test asserts the unsafe effect OCCURS, so on
+  the original it PASSED (exploitable). Fixed means it now FAILS on
+  repaired (the unsafe effect no longer occurs).
+
+The verified-fix rate is verified_fixed over the confirmed findings we were
+able to re-test (verified_fixed + not_fixed), so it is not deflated by
+findings that could not be re-run.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from qallm.verification.confirm_refute import _RELIABILITY_TYPES
+from qallm.verification.executor import run_tests
+
+logger = logging.getLogger(__name__)
+
+FixVerdict = Literal["verified_fixed", "not_fixed", "inconclusive"]
+
+
+@dataclass
+class FixResult:
+    finding_index: int
+    tool: str
+    type: str
+    severity: str
+    line: int
+    message: str
+    rule_id: str
+    function: str | None
+    fix_verdict: FixVerdict
+    reason: str
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "finding_index": self.finding_index,
+            "tool": self.tool, "type": self.type, "severity": self.severity,
+            "line": self.line, "message": self.message,
+            "rule_id": self.rule_id, "function": self.function,
+            "fix_verdict": self.fix_verdict, "reason": self.reason,
+        }
+
+
+@dataclass
+class VerifiedFixReport:
+    results: list[FixResult] = field(default_factory=list)
+
+    @property
+    def verified_fixed(self) -> int:
+        return sum(1 for r in self.results if r.fix_verdict == "verified_fixed")
+
+    @property
+    def not_fixed(self) -> int:
+        return sum(1 for r in self.results if r.fix_verdict == "not_fixed")
+
+    @property
+    def inconclusive(self) -> int:
+        return sum(1 for r in self.results if r.fix_verdict == "inconclusive")
+
+    @property
+    def verified_fix_rate(self) -> float | None:
+        """verified_fixed over the findings we could re-test (verified_fixed
+        + not_fixed). None when nothing was re-testable."""
+        denom = self.verified_fixed + self.not_fixed
+        return (self.verified_fixed / denom) if denom else None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "results": [r.to_dict() for r in self.results],
+            "summary": {
+                "verified_fixed": self.verified_fixed,
+                "not_fixed": self.not_fixed,
+                "inconclusive": self.inconclusive,
+                "verified_fix_rate": self.verified_fix_rate,
+            },
+        }
+
+
+def _defect_gone(ftype: str, passed: int, failed: int, errors: int) -> tuple[FixVerdict, str]:
+    """Did the reproducing test show the defect is gone on repaired code?"""
+    if errors > 0 and passed == 0 and failed == 0:
+        return "inconclusive", (
+            "The reproducing test errored against the repaired code, so the "
+            "fix could not be verified by execution."
+        )
+    if ftype in _RELIABILITY_TYPES:
+        # Reproducing test asserts correct behaviour: passing on repaired
+        # means the bug is gone.
+        if passed > 0 and failed == 0:
+            return "verified_fixed", (
+                "The reproducing test, which failed against the original "
+                "code, now passes against the repaired code: the bug is "
+                "provably gone."
+            )
+        if failed > 0:
+            return "not_fixed", (
+                "The reproducing test still fails against the repaired code; "
+                "the repair did not fix the defect."
+            )
+        return "inconclusive", "No clear result against the repaired code."
+    # SECURITY: reproducing test asserts the unsafe effect occurs. Fixed
+    # means it no longer can, i.e. the test now fails.
+    if failed > 0 and passed == 0:
+        return "verified_fixed", (
+            "The exploit test, which passed against the original code, now "
+            "fails against the repaired code: the unsafe behaviour is no "
+            "longer reachable."
+        )
+    if passed > 0:
+        return "not_fixed", (
+            "The exploit test still passes against the repaired code; the "
+            "vulnerability is still reachable."
+        )
+    return "inconclusive", "No clear result against the repaired code."
+
+
+def verify_fixes(
+    confirmed_findings: list[dict],
+    repaired_source: str,
+    source_filename: str = "source_module.py",
+    source_origin=None,
+) -> VerifiedFixReport:
+    """Re-run each confirmed finding's reproducing test against repaired code.
+
+    ``confirmed_findings`` are verdict dicts from confirm/refute with
+    ``verdict == "confirmed"`` and a ``reproducing_test``. Findings without a
+    reproducing test are skipped (nothing to re-run).
+    """
+    report = VerifiedFixReport()
+    for finding in confirmed_findings:
+        if finding.get("verdict") != "confirmed":
+            continue
+        test_code = finding.get("reproducing_test")
+        base = dict(
+            finding_index=finding.get("finding_index", -1),
+            tool=finding.get("tool", "?"),
+            type=(finding.get("type") or "?").upper(),
+            severity=finding.get("severity", "?"),
+            line=int(finding.get("line", 0) or 0),
+            message=finding.get("message", ""),
+            rule_id=finding.get("rule_id", ""),
+            function=finding.get("function"),
+        )
+        if not test_code:
+            report.results.append(FixResult(
+                **base, fix_verdict="inconclusive",
+                reason="No reproducing test was recorded for this finding.",
+            ))
+            continue
+
+        result = run_tests(
+            source_code=repaired_source,
+            test_code=test_code,
+            source_filename=source_filename,
+            source_origin=source_origin,
+        )
+        verdict, reason = _defect_gone(
+            base["type"], result.passed, result.failed, result.errors,
+        )
+        report.results.append(FixResult(**base, fix_verdict=verdict, reason=reason))
+    return report

--- a/tests/test_verified_fix.py
+++ b/tests/test_verified_fix.py
@@ -1,0 +1,112 @@
+"""Tests for the verified-fix loop: proving a confirmed finding is fixed."""
+
+from qallm.verification.verified_fix import (
+    verify_fixes,
+    VerifiedFixReport,
+    FixResult,
+    _defect_gone,
+)
+
+
+# ── type-aware before/after classification (no execution) ──
+
+def test_reliability_now_passing_is_verified_fixed():
+    v, _ = _defect_gone("RELIABILITY", passed=2, failed=0, errors=0)
+    assert v == "verified_fixed"
+
+
+def test_reliability_still_failing_is_not_fixed():
+    v, _ = _defect_gone("RELIABILITY", passed=0, failed=1, errors=0)
+    assert v == "not_fixed"
+
+
+def test_security_now_failing_is_verified_fixed():
+    # Exploit test no longer demonstrates the unsafe effect -> fixed.
+    v, _ = _defect_gone("SECURITY", passed=0, failed=1, errors=0)
+    assert v == "verified_fixed"
+
+
+def test_security_still_passing_is_not_fixed():
+    v, _ = _defect_gone("SECURITY", passed=1, failed=0, errors=0)
+    assert v == "not_fixed"
+
+
+def test_errored_on_repaired_is_inconclusive():
+    v, _ = _defect_gone("RELIABILITY", passed=0, failed=0, errors=2)
+    assert v == "inconclusive"
+
+
+# ── end-to-end against real repaired code ──
+
+ORIGINAL_BUG = "def add_one(x):\n    return x - 1\n"   # wrong: subtracts
+REPAIRED = "def add_one(x):\n    return x + 1\n"        # correct
+
+REPRO_TEST = (
+    "def test_add_one():\n"
+    "    assert add_one(3) == 4\n"   # fails on original, passes on repaired
+)
+
+
+def test_verified_fixed_against_repaired_source():
+    confirmed = [{
+        "verdict": "confirmed", "finding_index": 0, "tool": "sonar",
+        "type": "RELIABILITY", "severity": "HIGH", "line": 2,
+        "message": "off-by-one", "rule_id": "S1", "function": "add_one",
+        "reproducing_test": REPRO_TEST,
+    }]
+    report = verify_fixes(confirmed, repaired_source=REPAIRED,
+                          source_filename="m.py")
+    assert report.verified_fixed == 1
+    assert report.results[0].fix_verdict == "verified_fixed"
+
+
+def test_not_fixed_when_repair_did_not_help():
+    confirmed = [{
+        "verdict": "confirmed", "finding_index": 0, "tool": "sonar",
+        "type": "RELIABILITY", "severity": "HIGH", "line": 2,
+        "message": "off-by-one", "rule_id": "S1", "function": "add_one",
+        "reproducing_test": REPRO_TEST,
+    }]
+    # "Repaired" is still the buggy version.
+    report = verify_fixes(confirmed, repaired_source=ORIGINAL_BUG,
+                          source_filename="m.py")
+    assert report.not_fixed == 1
+    assert report.results[0].fix_verdict == "not_fixed"
+
+
+def test_non_confirmed_findings_skipped():
+    findings = [
+        {"verdict": "refuted", "reproducing_test": None, "type": "RELIABILITY"},
+        {"verdict": "not_execution_testable", "type": "COMPLEXITY"},
+    ]
+    report = verify_fixes(findings, repaired_source=REPAIRED)
+    assert report.results == []
+
+
+def test_confirmed_without_test_is_inconclusive():
+    confirmed = [{
+        "verdict": "confirmed", "finding_index": 0, "tool": "t",
+        "type": "RELIABILITY", "severity": "HIGH", "line": 1, "message": "m",
+        "rule_id": "r", "function": "f", "reproducing_test": None,
+    }]
+    report = verify_fixes(confirmed, repaired_source=REPAIRED)
+    assert report.inconclusive == 1
+
+
+def test_verified_fix_rate_excludes_inconclusive():
+    report = VerifiedFixReport(results=[
+        FixResult(0, "t", "RELIABILITY", "H", 1, "m", "r", "f", "verified_fixed", "x"),
+        FixResult(1, "t", "RELIABILITY", "H", 2, "m", "r", "f", "not_fixed", "x"),
+        FixResult(2, "t", "RELIABILITY", "H", 3, "m", "r", "f", "inconclusive", "x"),
+    ])
+    assert report.verified_fix_rate == 0.5  # 1 / (1 + 1)
+
+
+def test_to_dict_shape():
+    report = VerifiedFixReport(results=[
+        FixResult(0, "sonar", "RELIABILITY", "HIGH", 2, "m", "S1", "f",
+                  "verified_fixed", "proven"),
+    ])
+    d = report.to_dict()
+    assert d["summary"]["verified_fixed"] == 1
+    assert d["results"][0]["fix_verdict"] == "verified_fixed"

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -500,6 +500,46 @@ export async function confirmFindings(sid: string): Promise<ConfirmFindingsRespo
   });
 }
 
+// ─── Verified-fix loop ───
+export type FixVerdict = "verified_fixed" | "not_fixed" | "inconclusive";
+
+export interface FixResultRow {
+  finding_index: number;
+  file?: string;
+  tool: string;
+  type: string;
+  severity: string;
+  line: number;
+  message: string;
+  rule_id: string;
+  function: string | null;
+  fix_verdict: FixVerdict;
+  reason: string;
+}
+
+export interface VerifyFixesResponse {
+  available: boolean;
+  results: FixResultRow[];
+  reason?: string;
+  summary?: {
+    verified_fixed: number;
+    not_fixed: number;
+    inconclusive: number;
+    verified_fix_rate: number | null;
+  };
+}
+
+export async function verifyFixes(
+  sid: string,
+  findings: FindingVerdictRow[],
+): Promise<VerifyFixesResponse> {
+  return req<VerifyFixesResponse>(`/api/session/${sid}/verify-fixes`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ findings }),
+  });
+}
+
 // ─── Quality model profiles (selector) ───
 export interface QualityProfileInfo {
   id: string;

--- a/web/frontend/src/screens/GapPanel.tsx
+++ b/web/frontend/src/screens/GapPanel.tsx
@@ -81,6 +81,17 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
   }
   if (rounds.length === 0) return null;
 
+  // Headline metrics, aggregated across rounds. The verification-gap rate
+  // is the share of all execution-found defects that no static tool
+  // flagged: execution_only / (findings_with_a_function_bug + execution_only).
+  // It is the clearest single expression of what execution adds over static
+  // analysis. Confirmation and verified-fix rates come from the on-demand
+  // actions below and are null until those are run.
+  const totalExecOnly = rounds.reduce((a, r) => a + r.summary.execution_only, 0);
+  const totalConfirmedFindings = rounds.reduce((a, r) => a + r.summary.confirmed, 0);
+  const gapDenom = totalConfirmedFindings + totalExecOnly;
+  const gapRate = gapDenom > 0 ? totalExecOnly / gapDenom : null;
+
   return (
     <div className="rounded-2xl border border-slate-200 bg-white/70 p-6 shadow-sm">
       <div className="flex items-center gap-2">
@@ -90,6 +101,32 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
       <p className="mt-1 text-sm text-slate-500">
         Static findings are hypotheses; execution is the judge. For each round: which static findings execution confirmed, which it could not reproduce (candidate false positives), which it could not test, and the bugs execution found that no static tool flagged, the verification gap.
       </p>
+
+      {/* Headline: the three metrics that express QALLM's value over static
+          analysis, in one place. */}
+      <div className="mt-4 grid grid-cols-1 gap-3 sm:grid-cols-3">
+        <MetricCard
+          label="Verification gap"
+          help="Execution-found bugs no static tool flagged, as a share of all execution-found defects."
+          value={gapRate}
+          detail={`${totalExecOnly} execution-only`}
+          tone="indigo"
+        />
+        <MetricCard
+          label="Confirmation rate"
+          help="Of static findings execution could test, the share it reproduced. Run confirm/refute below."
+          value={confirmSummary ? confirmSummary.confirmation_rate : null}
+          detail={confirmSummary ? `${confirmSummary.confirmed} confirmed / ${confirmSummary.refuted} refuted` : "not run yet"}
+          tone="emerald"
+        />
+        <MetricCard
+          label="Verified-fix rate"
+          help="Of confirmed findings re-tested after repair, the share provably fixed. Run verify fixes below."
+          value={fixSummary ? fixSummary.verified_fix_rate : null}
+          detail={fixSummary ? `${fixSummary.verified_fixed} fixed / ${fixSummary.not_fixed} not` : "not run yet"}
+          tone="sky"
+        />
+      </div>
 
       <div className="mt-4 space-y-4">
         {rounds.map(r => <GapRoundCard key={r.round} round={r} />)}
@@ -316,6 +353,29 @@ function GapRoundCard({ round }: { round: GapRound }) {
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+function MetricCard({ label, help, value, detail, tone }: {
+  label: string;
+  help: string;
+  value: number | null;
+  detail: string;
+  tone: string;
+}) {
+  const tones: Record<string, string> = {
+    indigo: "border-indigo-200 bg-indigo-50",
+    emerald: "border-emerald-200 bg-emerald-50",
+    sky: "border-sky-200 bg-sky-50",
+  };
+  return (
+    <div className={`rounded-xl border p-4 ${tones[tone]}`} title={help}>
+      <div className="text-xs font-medium text-slate-600">{label}</div>
+      <div className="mt-1 text-2xl font-bold text-slate-900">
+        {value === null ? <span className="text-slate-300">—</span> : `${(value * 100).toFixed(0)}%`}
+      </div>
+      <div className="mt-0.5 text-xs text-slate-500">{detail}</div>
     </div>
   );
 }

--- a/web/frontend/src/screens/GapPanel.tsx
+++ b/web/frontend/src/screens/GapPanel.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from "react";
-import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap, Microscope, Loader2 } from "lucide-react";
+import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap, Microscope, Loader2, BadgeCheck } from "lucide-react";
 import * as api from "../api";
-import type { GapRound, FindingStatus, FindingVerdictRow, FindingVerdict } from "../api";
+import type { GapRound, FindingStatus, FindingVerdictRow, FindingVerdict, FixResultRow, FixVerdict } from "../api";
 
 // The static-vs-execution gap, per round: how many static findings
 // execution confirmed, could not reproduce, or could not test, and the
@@ -32,6 +32,31 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
       })
       .catch(() => setConfirmError("Confirm/refute failed."))
       .finally(() => setConfirming(false));
+  };
+
+  // Verified-fix loop: re-run confirmed findings' reproducing tests against
+  // the repaired code to prove the defect is gone. Pure execution, no LLM.
+  const [verifying, setVerifying] = useState(false);
+  const [fixResults, setFixResults] = useState<FixResultRow[] | null>(null);
+  const [fixSummary, setFixSummary] = useState<api.VerifyFixesResponse["summary"] | null>(null);
+  const [fixError, setFixError] = useState<string | null>(null);
+
+  const confirmedFindings = (verdicts ?? []).filter(v => v.verdict === "confirmed");
+
+  const runVerifyFixes = () => {
+    setVerifying(true);
+    setFixError(null);
+    api.verifyFixes(sessionId, confirmedFindings)
+      .then(res => {
+        if (res.available) {
+          setFixResults(res.results);
+          setFixSummary(res.summary ?? null);
+        } else {
+          setFixError(res.reason ?? "Not available.");
+        }
+      })
+      .catch(() => setFixError("Verify-fixes failed."))
+      .finally(() => setVerifying(false));
   };
 
   useEffect(() => {
@@ -110,9 +135,81 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
             {verdicts.map((v, i) => <VerdictCard key={i} v={v} />)}
           </div>
         )}
+
+        {/* Verified-fix loop: once findings are confirmed, prove the repair
+            actually fixed them by re-running the reproducing tests against
+            the repaired code. */}
+        {confirmedFindings.length > 0 && (
+          <div className="mt-5 border-t border-slate-100 pt-4">
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <div>
+                <h3 className="flex items-center gap-2 text-sm font-semibold text-slate-700">
+                  <BadgeCheck className="h-4 w-4 text-emerald-600" /> Prove the fixes
+                </h3>
+                <p className="mt-1 text-xs text-slate-500">
+                  Re-runs each confirmed finding's reproducing test against the repaired code. A fix is verified when the test that demonstrated the defect now shows it is gone. Pure execution, no model calls.
+                </p>
+              </div>
+              <button
+                onClick={runVerifyFixes}
+                disabled={verifying}
+                className="flex shrink-0 items-center gap-2 rounded-xl border border-slate-300 bg-white px-4 py-2 text-sm font-medium text-slate-800 disabled:opacity-50"
+              >
+                {verifying ? <><Loader2 className="h-4 w-4 animate-spin" /> Verifying...</> : <>Verify fixes ({confirmedFindings.length})</>}
+              </button>
+            </div>
+
+            {fixError && <div className="mt-3 text-xs text-rose-600">{fixError}</div>}
+
+            {fixSummary && (
+              <div className="mt-3 flex flex-wrap items-center gap-2 text-xs">
+                <Stat icon={<BadgeCheck className="h-3.5 w-3.5" />} label="verified fixed" value={fixSummary.verified_fixed} tone="emerald" />
+                <Stat icon={<ShieldAlert className="h-3.5 w-3.5" />} label="not fixed" value={fixSummary.not_fixed} tone="amber" />
+                <Stat icon={<ShieldAlert className="h-3.5 w-3.5" />} label="inconclusive" value={fixSummary.inconclusive} tone="slate" />
+                {fixSummary.verified_fix_rate !== null && (
+                  <span className="text-slate-500">verified-fix rate: <span className="font-semibold text-slate-700">{(fixSummary.verified_fix_rate * 100).toFixed(0)}%</span></span>
+                )}
+              </div>
+            )}
+
+            {fixResults && fixResults.length > 0 && (
+              <div className="mt-3 space-y-2">
+                {fixResults.map((r, i) => <FixCard key={i} r={r} />)}
+              </div>
+            )}
+          </div>
+        )}
       </div>
     </div>
   );
+}
+
+function FixCard({ r }: { r: FixResultRow }) {
+  return (
+    <div className="rounded-lg border border-slate-100 p-3 text-xs">
+      <div className="flex flex-wrap items-center gap-2">
+        <FixBadge verdict={r.fix_verdict} />
+        <span className="text-slate-600">{r.tool}</span>
+        <span className="text-slate-400">·</span>
+        <span className="text-slate-500">{r.type}</span>
+        <span className="text-slate-400">·</span>
+        <span className="font-mono text-slate-500">L{r.line}</span>
+        {r.function && <><span className="text-slate-400">·</span><span className="font-mono text-slate-700">{r.function}</span></>}
+      </div>
+      <div className="mt-1 text-slate-600">{r.message}</div>
+      <div className="mt-1 italic text-slate-500">{r.reason}</div>
+    </div>
+  );
+}
+
+function FixBadge({ verdict }: { verdict: FixVerdict }) {
+  const map: Record<FixVerdict, { label: string; cls: string }> = {
+    verified_fixed: { label: "verified fixed", cls: "text-emerald-700 bg-emerald-50 border-emerald-200" },
+    not_fixed: { label: "not fixed", cls: "text-amber-700 bg-amber-50 border-amber-200" },
+    inconclusive: { label: "inconclusive", cls: "text-slate-600 bg-slate-50 border-slate-200" },
+  };
+  const m = map[verdict];
+  return <span className={`rounded border px-1.5 py-0.5 font-medium ${m.cls}`}>{m.label}</span>;
 }
 
 function VerdictCard({ v }: { v: FindingVerdictRow }) {


### PR DESCRIPTION
Branch: `feature/verified-fix-loop` (off `dev`, after #82), now **2 commits**.
All green: **494 Python tests pass**, frontend type-checks and builds, ruff clean.

## Important: this stacks on the not-yet-merged verified-fix work

You hadn't merged the verified-fix loop yet, so I built this on top of that branch. There are **two commits** here:

1. `5ea61b6` feat(verified-fix): the verified-fix loop (from last session)
2. `3458100` feat(ui): the headline metrics card (this session)

The bundle's main patch (`verified-fix-and-metrics.patch`) contains **both**. If you want to merge them as one PR, use that. If you'd rather keep them separate, `metrics-card-only.patch` is just the second commit (apply it after the verified-fix commit is in). The `commits/` folder has both as individual `git am` patches in order.

## What the metrics card does (commit 2)

Collects the three execution-based metrics into one headline at the top of the gap panel, so a researcher sees the whole story at a glance:

- **Verification gap**: execution-found bugs no static tool flagged, as a share of all execution-found defects. Aggregated across rounds from the gap data, always shown (it's disk-based and free).
- **Confirmation rate**: of static findings execution could test, the share it reproduced. From the confirm/refute action; shows "not run yet" until you run it.
- **Verified-fix rate**: of confirmed findings re-tested after repair, the share provably fixed. From the verify-fixes action; shows "not run yet" until you run it.

Frontend only; all three values come from endpoints that already exist. The card is honest about what hasn't been computed (em dash for an unavailable rate, "not run yet" detail) rather than showing a misleading zero.

## Why this is the researcher payoff

The three metrics form a chain a researcher can cite directly: static analysis flagged X, execution confirmed Y of those as real (not false positives), and the repair provably fixed Z of those, plus the gap (bugs execution found that static analysis entirely missed). That chain, in one card, is the thesis claim made measurable.

## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 494 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```
