### PR TITLE
Review: thesis metrics export, cross-session aggregation, draft scaffold

### DIFF
--- a/docs/thesis-draft-scaffold.md
+++ b/docs/thesis-draft-scaffold.md
@@ -1,0 +1,222 @@
+# Execution-Based Quality Assessment of AI-Generated Code in Jupyter Notebooks
+
+**A thesis draft scaffold.** This is a structural starting point, not finished
+prose. Each section states its purpose, the claim or content it must carry,
+and where the supporting evidence comes from in the QALLM system. Placeholders
+in [brackets] mark numbers to be filled from real runs. The point is a
+foundation that is honest about what has been shown and what has not.
+
+Throughout, dashes are avoided as punctuation per the author's convention;
+commas, semicolons, and colons are used instead.
+
+---
+
+## Abstract
+
+[To be written last.] One paragraph: research software is increasingly written
+or assisted by large language models, often in Jupyter notebooks; static
+analysis is the standard quality gate but cannot observe runtime behaviour;
+this thesis presents QALLM, an execution-based, quality-model-guided
+improvement pipeline that treats static findings as hypotheses and execution
+as the judge; across [N] notebooks it found that [X]% of code passing static
+analysis still contained execution-reproducible defects (the verification
+gap), confirmed [Y]% of static findings by execution, and provably fixed
+[Z]% of confirmed findings; the contribution is the method, the open
+implementation, and the empirical characterisation of the gap.
+
+## 1. Introduction
+
+Purpose: motivate the problem and state the contribution.
+
+- Research software quality matters and is under-served; notebooks especially
+  (exploratory, rarely tested, increasingly LLM-authored).
+- Static analysers (Bandit, Radon, SonarQube) are the de facto quality gate.
+  They are valuable and necessary, and this work builds on them rather than
+  competing with them. Their structural limit: they reason about source text,
+  not runtime behaviour, so they miss defects that only manifest on execution
+  and they raise findings that may not be reproducible.
+- The gap this leaves: code can pass static analysis and still be wrong. This
+  is the "verification gap".
+- Contribution, stated plainly:
+  1. A method that treats each static finding as a hypothesis and uses
+     execution to confirm, refute, or supplement it, then to verify fixes.
+  2. An open implementation (QALLM) realising the method end to end.
+  3. An empirical characterisation of the verification gap on AI-generated
+     notebook code, with three reproducible metrics.
+- Research questions (carried from the proposal, refined):
+  - RQ1: To what extent does execution-based assessment reveal defects that
+    static analysis of AI-generated notebook code misses?
+  - RQ2: How reliably can individual static findings be confirmed or refuted
+    by automatically generated, executed tests?
+  - RQ3: When a repair is applied, can the fix be verified by execution, and
+    how often does a repair that satisfies static analysis fail to fix the
+    underlying defect?
+
+## 2. Background and related work
+
+Purpose: situate the work; show the gap in the literature is real.
+
+- Static analysis for Python and for research software; what each tool sees.
+- Quality models: ISO/IEC 25010, and the role and lifecycle-aware framing of
+  Volentir et al. (QRS 2025), on which QALLM's quality profiles build
+  (EVERSE, FAIR4RS, ISO 25010). [Cite and summarise.]
+- LLMs for code generation and for test generation; the reliability problem.
+- Execution-based / dynamic approaches and search-based test generation;
+  position QALLM relative to them.
+- The under-addressed point: using execution specifically to adjudicate
+  static findings and to verify repairs, on notebook code. [This is the gap.]
+
+## 3. Method
+
+Purpose: describe the QALLM method precisely enough to reproduce.
+
+### 3.1 Overview
+
+The pipeline: select a quality model, establish a baseline (Round 0: analyse
+and verify the original code, no repair), then N improvement rounds (repair,
+re-analyse, verify, judge accept or abandon), then a final report. The LLM
+acts as test generator and code repairer via an API with quantitative
+feedback; it is not trained. [Frame as iterative prompting with feedback, not
+model training.]
+
+### 3.2 Static analysis as hypotheses
+
+Findings from Bandit, Radon, and SonarQube are normalised into a common
+finding model (tool, type, severity, line, message, rule). Each finding is a
+hypothesis to be adjudicated by execution, not an end state.
+
+### 3.3 Execution-based verification
+
+Test generation oracles (crash, property, metamorphic), the sandboxed
+executor, and the FROZEN+GROW test-accumulation policy that gives a stable,
+growing oracle and enforces no-regression across rounds. The ERROR vs BUG
+distinction: only a test that ran and failed is evidence of a defect; a test
+that errored never ran and is excluded from all defect counts. Generated
+tests are AST-validated before running (undefined fixtures are dropped), so
+the signal is not polluted by tests that could never execute.
+
+### 3.4 The verification gap
+
+Per round, each static finding's line is mapped to its enclosing function;
+the finding is classified as confirmed (the function has an execution-found
+bug), unconfirmed (tested, no bug), or untested (no test ran). The gap is the
+set of execution-found bugs in functions with no static finding: defects
+static analysis missed entirely. [Define the verification-gap rate formally.]
+
+### 3.5 Confirm and refute individual findings
+
+For a finding whose type execution can judge (reliability, security), a
+targeted test is generated to reproduce that specific finding. Type-aware:
+for reliability, a failing test confirms the bug; for security, a passing
+exploit test confirms reachability. Complexity and maintainability findings
+are properties of the source, not runtime behaviour, and are explicitly not
+execution-testable. [Define the confirmation rate; state its honest limit:
+confirmation is corroboration at the targeted level, refutation is evidence
+of a candidate false positive, not proof.]
+
+### 3.6 Verified fixes
+
+When a finding was confirmed by a reproducing test, the same test is re-run
+against the repaired code. The fix is verified when the test that
+demonstrated the defect now shows it gone (a reliability test that now passes,
+a security exploit test that now fails). A repair that removes the static
+finding without fixing the underlying defect is detected as "not fixed".
+[Define the verified-fix rate.]
+
+### 3.7 Research method (TAR)
+
+Technical Action Research: the artifact (QALLM) is built and then exercised
+across iterations from controlled to realistic conditions. [Tie to Wieringa
+and Moralı; mirror the proposal's framing.]
+
+## 4. Implementation
+
+Purpose: enough detail that the system is credible and reproducible.
+
+- Architecture: ingestion, analysis, verification (loop, executor, reward,
+  generator, sandbox), reporting. [Map to the package structure.]
+- Models: local (Ollama, gemma family) and hosted (OpenAI) via one interface.
+- Static tools integrated: Bandit, Radon, Ruff, TruffleHog, SonarQube.
+- Reproducibility: every run persists per-round source, static findings, and
+  verification results; the three metrics are exported per session (JSON and
+  CSV) and aggregated across sessions, count-weighted. [This is the evidence
+  pipeline for Chapter 5.]
+- Open source; commit history; the web interface for inspection.
+
+## 5. Evaluation
+
+Purpose: answer the research questions with the metrics, honestly.
+
+### 5.1 Setup
+
+Dataset: [Li's 2,796 notebooks from 277 projects, or the subset used.]
+Models: [which, and why]. Quality profile(s): [which]. Budget caps: [values].
+Procedure: for each unit, run the pipeline; record the per-session metrics;
+aggregate. [State exactly what was run, so it is reproducible.]
+
+### 5.2 RQ1: the verification gap
+
+Report the verification-gap rate across the dataset: of all
+execution-found defects, the share that no static tool flagged.
+[Verification-gap rate = X%, N = ...]. This is the headline empirical result.
+Break down by finding type and by oracle. Discuss what kinds of defects
+execution catches that static analysis does not.
+
+### 5.3 RQ2: confirming and refuting findings
+
+Report the confirmation rate: of static findings execution could test, the
+share it reproduced. [Confirmation rate = Y%.] Report how many findings were
+not execution-testable (complexity, maintainability) and why excluding them
+from the rate is correct. Discuss refuted findings as candidate false
+positives, with the caveat that refutation is not proof.
+
+### 5.4 RQ3: verifying fixes
+
+Report the verified-fix rate: of confirmed findings re-tested after repair,
+the share provably fixed. [Verified-fix rate = Z%.] Report the "not fixed"
+cases: repairs that satisfied the static tool but did not fix the defect.
+[This is a distinct, citable finding: static-only pipelines would mark these
+resolved.]
+
+### 5.5 Threats to validity
+
+- Construct: confirmation is corroboration, not per-line causation; test
+  generation quality bounds what can be confirmed; refutation depends on the
+  generator finding a triggering input.
+- Internal: model nondeterminism; budget caps truncating rounds; the
+  ERROR/discarded exclusions (argue these strengthen, not bias, the gap rate).
+- External: notebook dataset representativeness; model choice; Python only.
+- Conclusion: count-weighted aggregation choices; sample size.
+
+## 6. Discussion
+
+What the gap rate means for how research software should be quality-gated;
+where QALLM complements rather than replaces static analysis; cost and
+practicality; the role of local vs hosted models.
+
+## 7. Conclusion and future work
+
+Restate the contribution and the headline numbers. Future work: per-round
+verified-fix tracking, larger and multi-language datasets, tighter
+per-finding causal linking, integration into CI.
+
+---
+
+## Appendix: metric definitions (authoritative)
+
+Stated here once, precisely, and referenced from the text.
+
+- **Verification-gap rate** = execution_only / (confirmed_findings +
+  execution_only), where execution_only is the count of execution-found bugs
+  in functions with no static finding, and confirmed_findings is static
+  findings whose function had an execution-found bug. Excludes errored and
+  discarded tests.
+- **Confirmation rate** = confirmed / (confirmed + refuted), over findings
+  whose type execution can test. Not_execution_testable findings are excluded
+  from the denominator.
+- **Verified-fix rate** = verified_fixed / (verified_fixed + not_fixed), over
+  confirmed findings re-tested after repair. Inconclusive results excluded.
+
+All three are produced per session and aggregated count-weighted across
+sessions by the QALLM metrics export, so every number in Chapter 5 is
+reproducible from the persisted run artefacts.

--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -85,16 +85,19 @@ async def confirm_findings(session_id: str):
                 all_verdicts.append(d)
 
     denom = confirmed + refuted
+    summary = {
+        "confirmed": confirmed,
+        "refuted": refuted,
+        "inconclusive": inconclusive,
+        "not_execution_testable": not_testable,
+        "confirmation_rate": (confirmed / denom) if denom else None,
+    }
+    # Record on session state so the metrics export can include it.
+    state["confirm_summary"] = summary
     return {
         "available": True,
         "verdicts": all_verdicts,
-        "summary": {
-            "confirmed": confirmed,
-            "refuted": refuted,
-            "inconclusive": inconclusive,
-            "not_execution_testable": not_testable,
-            "confirmation_rate": (confirmed / denom) if denom else None,
-        },
+        "summary": summary,
     }
 
 
@@ -164,15 +167,17 @@ async def verify_fixes_endpoint(session_id: str, req: dict):
             all_results.append(d)
 
     denom = verified_fixed + not_fixed
+    summary = {
+        "verified_fixed": verified_fixed,
+        "not_fixed": not_fixed,
+        "inconclusive": inconclusive,
+        "verified_fix_rate": (verified_fixed / denom) if denom else None,
+    }
+    state["verify_summary"] = summary
     return {
         "available": True,
         "results": all_results,
-        "summary": {
-            "verified_fixed": verified_fixed,
-            "not_fixed": not_fixed,
-            "inconclusive": inconclusive,
-            "verified_fix_rate": (verified_fixed / denom) if denom else None,
-        },
+        "summary": summary,
     }
 
 

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -12,12 +12,18 @@ import logging
 import os
 
 from fastapi import APIRouter
+from fastapi.responses import PlainTextResponse
 
 from qallm.api.core import (
     get_state,
     sessions,
 )
 from qallm.analysis.gap_analysis import GapReport, build_gap_report
+from qallm.metrics_export import (
+    aggregate_sessions,
+    build_session_metrics,
+    to_csv,
+)
 from qallm.config import settings
 from qallm.orchestrator import QALLMOrchestrator
 
@@ -261,24 +267,18 @@ async def download_tests(session_id: str):
 
 
 @router.get("/api/session/{session_id}/gap")
-async def get_gap(session_id: str):
-    """Static-vs-execution gap per round: which static findings execution
-    confirmed, which it could not reproduce, and which execution-found bugs
-    no static tool flagged (the verification gap).
-
-    Reads each round's persisted source.py, static.json, and
-    verification.json, so it works for live and historical sessions alike.
-    """
+def _resolve_report_dir(session_id: str) -> str | None:
+    """The on-disk report dir for a session, from live state or the library."""
     state = sessions.get(session_id) or {}
     report_dir = state.get("report_dir")
-    if not report_dir or not os.path.isdir(report_dir):
-        candidate = os.path.join(settings.QALLM_SESSIONS_DIR, session_id)
-        if os.path.isdir(candidate):
-            report_dir = candidate
-    if not report_dir or not os.path.isdir(report_dir):
-        return {"available": False, "rounds": [],
-                "reason": "No run artefacts yet. Run the pipeline first."}
+    if report_dir and os.path.isdir(report_dir):
+        return report_dir
+    candidate = os.path.join(settings.QALLM_SESSIONS_DIR, session_id)
+    return candidate if os.path.isdir(candidate) else None
 
+
+def _compute_gap_rounds(report_dir: str) -> list[dict]:
+    """Per-round gap dicts from a session's persisted round artefacts."""
     def _read_json(path: str):
         try:
             with open(path, encoding="utf-8") as fh:
@@ -293,9 +293,6 @@ async def get_gap(session_id: str):
         except OSError:
             return ""
 
-    # Each round's artefacts live under lineage/round_N/<unit>/ (accepted)
-    # or abandoned/round_N/<unit>/. We classify findings per unit and merge
-    # per round. static.json + source.py + verification.json sit together.
     reports: dict[int, GapReport] = {}
     for bucket in ("lineage", "abandoned"):
         bucket_dir = os.path.join(report_dir, bucket)
@@ -327,9 +324,123 @@ async def get_gap(session_id: str):
 
     for rep in reports.values():
         rep.execution_only_functions = sorted(set(rep.execution_only_functions))
+    return [reports[k].to_dict() for k in sorted(reports)]
 
-    ordered = [reports[k].to_dict() for k in sorted(reports)]
-    return {"available": True, "rounds": ordered}
+
+@router.get("/api/session/{session_id}/gap")
+async def get_gap(session_id: str):
+    """Static-vs-execution gap per round: which static findings execution
+    confirmed, which it could not reproduce, and which execution-found bugs
+    no static tool flagged (the verification gap).
+
+    Reads each round's persisted source.py, static.json, and
+    verification.json, so it works for live and historical sessions alike.
+    """
+    report_dir = _resolve_report_dir(session_id)
+    if not report_dir:
+        return {"available": False, "rounds": [],
+                "reason": "No run artefacts yet. Run the pipeline first."}
+    return {"available": True, "rounds": _compute_gap_rounds(report_dir)}
+
+
+@router.get("/api/session/{session_id}/metrics")
+async def get_session_metrics(session_id: str):
+    """Thesis-ready metrics for one session: run metadata plus the
+    verification-gap figures (always available), and the confirmation /
+    verified-fix figures if those actions were run and recorded on the
+    session state. Returns JSON; see /metrics.csv for the flat form.
+    """
+    report_dir = _resolve_report_dir(session_id)
+    if not report_dir:
+        return {"available": False,
+                "reason": "No run artefacts yet. Run the pipeline first."}
+
+    summary_path = os.path.join(report_dir, "summary.json")
+    summary = None
+    if os.path.isfile(summary_path):
+        try:
+            with open(summary_path, encoding="utf-8") as fh:
+                summary = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            summary = None
+
+    gap_rounds = _compute_gap_rounds(report_dir)
+    # Confirmation / verified-fix summaries are recorded on the live session
+    # state when those actions run; absent for historical sessions.
+    state = sessions.get(session_id) or {}
+    metrics = build_session_metrics(
+        session_id=session_id,
+        summary=summary,
+        gap_rounds=gap_rounds,
+        confirm_summary=state.get("confirm_summary"),
+        verify_summary=state.get("verify_summary"),
+    )
+    return {"available": True, "metrics": metrics.to_dict()}
+
+
+@router.get("/api/session/{session_id}/metrics.csv")
+async def get_session_metrics_csv(session_id: str):
+    """The single session's metrics as a one-row CSV (with header)."""
+    report_dir = _resolve_report_dir(session_id)
+    if not report_dir:
+        return PlainTextResponse("", status_code=404)
+    summary = None
+    summary_path = os.path.join(report_dir, "summary.json")
+    if os.path.isfile(summary_path):
+        try:
+            with open(summary_path, encoding="utf-8") as fh:
+                summary = json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            summary = None
+    state = sessions.get(session_id) or {}
+    metrics = build_session_metrics(
+        session_id, summary, _compute_gap_rounds(report_dir),
+        confirm_summary=state.get("confirm_summary"),
+        verify_summary=state.get("verify_summary"),
+    )
+    csv_text = to_csv([metrics])
+    return PlainTextResponse(csv_text, media_type="text/csv", headers={
+        "Content-Disposition": f'attachment; filename="qallm_metrics_{session_id}.csv"',
+    })
+
+
+@router.get("/api/metrics/aggregate")
+async def get_aggregate_metrics():
+    """Cross-session roll-up over every persisted session in the library.
+
+    Rates are recomputed from summed counts (count-weighted), not averaged,
+    so larger sessions weigh proportionally. Confirmation / verified-fix
+    counts come from live state when present.
+    """
+    base = settings.QALLM_SESSIONS_DIR
+    if not os.path.isdir(base):
+        return {"available": False, "reason": "No sessions directory yet."}
+
+    metrics_list = []
+    for sid in sorted(os.listdir(base)):
+        sdir = os.path.join(base, sid)
+        if not os.path.isdir(sdir):
+            continue
+        summary = None
+        summary_path = os.path.join(sdir, "summary.json")
+        if os.path.isfile(summary_path):
+            try:
+                with open(summary_path, encoding="utf-8") as fh:
+                    summary = json.load(fh)
+            except (OSError, json.JSONDecodeError):
+                summary = None
+        gap_rounds = _compute_gap_rounds(sdir)
+        if not gap_rounds and summary is None:
+            continue
+        state = sessions.get(sid) or {}
+        metrics_list.append(build_session_metrics(
+            sid, summary, gap_rounds,
+            confirm_summary=state.get("confirm_summary"),
+            verify_summary=state.get("verify_summary"),
+        ))
+
+    agg = aggregate_sessions(metrics_list)
+    return {"available": True, "aggregate": agg.to_dict()}
 
 
 @router.get("/api/health")

--- a/src/qallm/metrics_export.py
+++ b/src/qallm/metrics_export.py
@@ -1,0 +1,220 @@
+"""Export QALLM's execution-based metrics in a citable, reproducible form.
+
+The three headline metrics (verification gap, confirmation rate, verified-fix
+rate) live in the UI, computed on demand. For the thesis they need to exist
+as durable, machine-readable records: one per session, and aggregated across
+many sessions. This module produces both, as plain dicts that the API
+serialises to JSON and flattens to CSV.
+
+A per-session export carries:
+* run metadata (model, oracle, rounds, cost, profile), from summary.json.
+* the verification-gap figures, derived from the per-round gap reports
+  (always available, computed from persisted artefacts).
+* the confirmation and verified-fix figures, IF those on-demand actions were
+  run and recorded; otherwise null, never a misleading zero.
+
+Honesty rules, carried over from the UI:
+* rates are null when their denominator is zero (nothing was testable), not
+  0.0, so an absent measurement is never read as a measured absence.
+* the verification-gap rate counts only execution-found defects; errored and
+  discarded tests are already excluded upstream.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class SessionMetrics:
+    session_id: str
+    model: str = ""
+    testgen_model: str = ""
+    oracle: str = ""
+    rounds: int = 0
+    units_analyzed: int = 0
+    functions_verified: int = 0
+    cost_usd: float = 0.0
+    tokens: int = 0
+    # Verification gap (from gap reports, always available post-run).
+    static_findings: int = 0
+    confirmed_findings: int = 0  # findings execution corroborated (function-level)
+    execution_only_bugs: int = 0
+    verification_gap_rate: float | None = None
+    # Confirmation (only if confirm/refute was run and recorded).
+    confirmed: int | None = None
+    refuted: int | None = None
+    confirmation_rate: float | None = None
+    # Verified-fix (only if verify-fixes was run and recorded).
+    verified_fixed: int | None = None
+    not_fixed: int | None = None
+    verified_fix_rate: float | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session_id": self.session_id,
+            "model": self.model,
+            "testgen_model": self.testgen_model,
+            "oracle": self.oracle,
+            "rounds": self.rounds,
+            "units_analyzed": self.units_analyzed,
+            "functions_verified": self.functions_verified,
+            "cost_usd": round(self.cost_usd, 6),
+            "tokens": self.tokens,
+            "static_findings": self.static_findings,
+            "execution_only_bugs": self.execution_only_bugs,
+            "verification_gap_rate": self.verification_gap_rate,
+            "confirmed": self.confirmed,
+            "refuted": self.refuted,
+            "confirmation_rate": self.confirmation_rate,
+            "verified_fixed": self.verified_fixed,
+            "not_fixed": self.not_fixed,
+            "verified_fix_rate": self.verified_fix_rate,
+        }
+
+
+# Stable column order for CSV; mirrors to_dict so the two never drift.
+CSV_COLUMNS: list[str] = [
+    "session_id", "model", "testgen_model", "oracle", "rounds",
+    "units_analyzed", "functions_verified", "cost_usd", "tokens",
+    "static_findings", "execution_only_bugs", "verification_gap_rate",
+    "confirmed", "refuted", "confirmation_rate",
+    "verified_fixed", "not_fixed", "verified_fix_rate",
+]
+
+
+def _rate(numerator: int, denominator: int) -> float | None:
+    return (numerator / denominator) if denominator > 0 else None
+
+
+def build_session_metrics(
+    session_id: str,
+    summary: dict | None,
+    gap_rounds: list[dict],
+    confirm_summary: dict | None = None,
+    verify_summary: dict | None = None,
+) -> SessionMetrics:
+    """Assemble one session's metrics from its summary and gap data.
+
+    ``gap_rounds`` is the list of per-round gap dicts (each with a "summary").
+    ``confirm_summary`` / ``verify_summary`` are the summary dicts from the
+    confirm-findings / verify-fixes endpoints, when those were run.
+    """
+    summary = summary or {}
+    cost = summary.get("cost") or {}
+
+    m = SessionMetrics(
+        session_id=session_id,
+        model=summary.get("model", ""),
+        testgen_model=summary.get("testgen_model", ""),
+        oracle=summary.get("oracle", ""),
+        rounds=int(summary.get("rounds_per_function", 0) or 0),
+        units_analyzed=int(summary.get("units_analyzed", 0) or 0),
+        functions_verified=int(summary.get("functions_verified", 0) or 0),
+        cost_usd=float(cost.get("total_cost_usd", 0.0) or 0.0),
+        tokens=int(cost.get("total_tokens", 0) or 0),
+    )
+
+    # Verification gap, aggregated across rounds (matches the UI card).
+    exec_only = sum(int(r.get("summary", {}).get("execution_only", 0) or 0)
+                    for r in gap_rounds)
+    confirmed_findings = sum(
+        int(r.get("summary", {}).get("confirmed", 0) or 0) for r in gap_rounds
+    )
+    findings = sum(len(r.get("findings", []) or []) for r in gap_rounds)
+    m.static_findings = findings
+    m.confirmed_findings = confirmed_findings
+    m.execution_only_bugs = exec_only
+    m.verification_gap_rate = _rate(exec_only, confirmed_findings + exec_only)
+
+    if confirm_summary:
+        m.confirmed = int(confirm_summary.get("confirmed", 0) or 0)
+        m.refuted = int(confirm_summary.get("refuted", 0) or 0)
+        m.confirmation_rate = confirm_summary.get("confirmation_rate")
+
+    if verify_summary:
+        m.verified_fixed = int(verify_summary.get("verified_fixed", 0) or 0)
+        m.not_fixed = int(verify_summary.get("not_fixed", 0) or 0)
+        m.verified_fix_rate = verify_summary.get("verified_fix_rate")
+
+    return m
+
+
+@dataclass
+class AggregateMetrics:
+    """Cross-session roll-up. Rates are recomputed from summed counts, not
+    averaged, so a session with one finding does not weigh the same as a
+    session with fifty (count-weighted, the correct aggregation for rates)."""
+    n_sessions: int = 0
+    total_static_findings: int = 0
+    total_confirmed_findings: int = 0
+    total_execution_only_bugs: int = 0
+    total_confirmed: int = 0
+    total_refuted: int = 0
+    total_verified_fixed: int = 0
+    total_not_fixed: int = 0
+    total_cost_usd: float = 0.0
+    per_session: list[dict] = field(default_factory=list)
+
+    @property
+    def verification_gap_rate(self) -> float | None:
+        # execution-only over all execution-found defects at the function
+        # level (confirmed findings + execution-only).
+        return _rate(self.total_execution_only_bugs,
+                     self.total_confirmed_findings + self.total_execution_only_bugs)
+
+    @property
+    def confirmation_rate(self) -> float | None:
+        return _rate(self.total_confirmed,
+                     self.total_confirmed + self.total_refuted)
+
+    @property
+    def verified_fix_rate(self) -> float | None:
+        return _rate(self.total_verified_fixed,
+                     self.total_verified_fixed + self.total_not_fixed)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "n_sessions": self.n_sessions,
+            "total_static_findings": self.total_static_findings,
+            "total_execution_only_bugs": self.total_execution_only_bugs,
+            "verification_gap_rate": self.verification_gap_rate,
+            "total_confirmed": self.total_confirmed,
+            "total_refuted": self.total_refuted,
+            "confirmation_rate": self.confirmation_rate,
+            "total_verified_fixed": self.total_verified_fixed,
+            "total_not_fixed": self.total_not_fixed,
+            "verified_fix_rate": self.verified_fix_rate,
+            "total_cost_usd": round(self.total_cost_usd, 6),
+            "per_session": self.per_session,
+        }
+
+
+def aggregate_sessions(sessions: list[SessionMetrics]) -> AggregateMetrics:
+    """Roll up many sessions, recomputing rates from summed counts."""
+    agg = AggregateMetrics(n_sessions=len(sessions))
+    for s in sessions:
+        agg.total_static_findings += s.static_findings
+        agg.total_confirmed_findings += s.confirmed_findings
+        agg.total_execution_only_bugs += s.execution_only_bugs
+        agg.total_confirmed += (s.confirmed or 0)
+        agg.total_refuted += (s.refuted or 0)
+        agg.total_verified_fixed += (s.verified_fixed or 0)
+        agg.total_not_fixed += (s.not_fixed or 0)
+        agg.total_cost_usd += s.cost_usd
+        agg.per_session.append(s.to_dict())
+    return agg
+
+
+def to_csv(sessions: list[SessionMetrics]) -> str:
+    """Flatten per-session metrics to CSV text with a stable header."""
+    import csv
+    import io
+
+    buf = io.StringIO()
+    writer = csv.DictWriter(buf, fieldnames=CSV_COLUMNS)
+    writer.writeheader()
+    for s in sessions:
+        writer.writerow(s.to_dict())
+    return buf.getvalue()

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -1,0 +1,105 @@
+"""Tests for thesis metrics export and cross-session aggregation."""
+
+from qallm.metrics_export import (
+    build_session_metrics,
+    aggregate_sessions,
+    to_csv,
+    CSV_COLUMNS,
+    SessionMetrics,
+)
+
+
+def _gap_rounds():
+    # One round: 2 findings, 1 confirmed at function level, 1 execution-only.
+    return [{
+        "round": 0,
+        "findings": [
+            {"status": "confirmed"}, {"status": "unconfirmed"},
+        ],
+        "summary": {"confirmed": 1, "unconfirmed": 1, "untested": 0,
+                    "execution_only": 1, "confirmation_rate": 0.5},
+    }]
+
+
+def _summary():
+    return {
+        "model": "gemma3:4b", "testgen_model": "gemma3:4b", "oracle": "crash",
+        "rounds_per_function": 3, "units_analyzed": 1, "functions_verified": 2,
+        "cost": {"total_cost_usd": 0.0123, "total_tokens": 4567},
+    }
+
+
+def test_gap_rate_from_rounds():
+    m = build_session_metrics("s1", _summary(), _gap_rounds())
+    # execution_only / (confirmed_findings + execution_only) = 1 / (1 + 1)
+    assert m.verification_gap_rate == 0.5
+    assert m.execution_only_bugs == 1
+    assert m.confirmed_findings == 1
+    assert m.static_findings == 2
+    # confirm/verify not run -> null, not zero.
+    assert m.confirmation_rate is None
+    assert m.verified_fix_rate is None
+    assert m.confirmed is None
+
+
+def test_metadata_carried():
+    m = build_session_metrics("s1", _summary(), _gap_rounds())
+    assert m.model == "gemma3:4b"
+    assert m.oracle == "crash"
+    assert m.rounds == 3
+    assert m.cost_usd == 0.0123
+    assert m.tokens == 4567
+
+
+def test_confirm_and_verify_summaries_included():
+    m = build_session_metrics(
+        "s1", _summary(), _gap_rounds(),
+        confirm_summary={"confirmed": 3, "refuted": 1, "confirmation_rate": 0.75},
+        verify_summary={"verified_fixed": 2, "not_fixed": 1, "verified_fix_rate": 2/3},
+    )
+    assert m.confirmation_rate == 0.75
+    assert m.confirmed == 3
+    assert m.verified_fixed == 2
+    assert round(m.verified_fix_rate, 3) == 0.667
+
+
+def test_null_rate_when_no_denominator():
+    # No findings, no execution-only -> gap rate is None, not 0.
+    m = build_session_metrics("s1", _summary(), [])
+    assert m.verification_gap_rate is None
+
+
+def test_aggregate_recomputes_rates_count_weighted():
+    s1 = SessionMetrics("s1", confirmed_findings=1, execution_only_bugs=1,
+                        confirmed=1, refuted=1, verified_fixed=1, not_fixed=0)
+    s2 = SessionMetrics("s2", confirmed_findings=3, execution_only_bugs=1,
+                        confirmed=3, refuted=0, verified_fixed=2, not_fixed=2)
+    agg = aggregate_sessions([s1, s2])
+    assert agg.n_sessions == 2
+    # gap: total_exec_only / (total_confirmed_findings + total_exec_only)
+    #    = 2 / (4 + 2) = 1/3
+    assert round(agg.verification_gap_rate, 3) == 0.333
+    # confirmation: 4 / (4 + 1) = 0.8
+    assert agg.confirmation_rate == 0.8
+    # verified-fix: 3 / (3 + 2) = 0.6
+    assert agg.verified_fix_rate == 0.6
+
+
+def test_aggregate_empty():
+    agg = aggregate_sessions([])
+    assert agg.n_sessions == 0
+    assert agg.verification_gap_rate is None
+    assert agg.confirmation_rate is None
+
+
+def test_csv_has_stable_header_and_rows():
+    s1 = SessionMetrics("s1", model="m", execution_only_bugs=2)
+    csv_text = to_csv([s1])
+    lines = csv_text.strip().splitlines()
+    assert lines[0] == ",".join(CSV_COLUMNS)
+    assert "s1" in lines[1]
+
+
+def test_to_dict_keys_match_csv_columns():
+    s1 = SessionMetrics("s1")
+    assert set(s1.to_dict().keys()) == set(CSV_COLUMNS)

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -540,6 +540,65 @@ export async function verifyFixes(
   });
 }
 
+// ─── Metrics export (thesis evidence) ───
+export interface SessionMetricsResponse {
+  available: boolean;
+  reason?: string;
+  metrics?: Record<string, unknown>;
+}
+
+export async function getSessionMetrics(sid: string): Promise<SessionMetricsResponse> {
+  return req<SessionMetricsResponse>(`/api/session/${sid}/metrics`);
+}
+
+export interface AggregateMetricsResponse {
+  available: boolean;
+  reason?: string;
+  aggregate?: {
+    n_sessions: number;
+    verification_gap_rate: number | null;
+    confirmation_rate: number | null;
+    verified_fix_rate: number | null;
+    total_static_findings: number;
+    total_execution_only_bugs: number;
+    total_confirmed: number;
+    total_refuted: number;
+    total_verified_fixed: number;
+    total_not_fixed: number;
+    total_cost_usd: number;
+    per_session: Record<string, unknown>[];
+  };
+}
+
+export async function getAggregateMetrics(): Promise<AggregateMetricsResponse> {
+  return req<AggregateMetricsResponse>(`/api/metrics/aggregate`);
+}
+
+// Trigger a browser download of a session's metrics in the given format.
+export async function downloadSessionMetrics(sid: string, format: "json" | "csv") {
+  if (format === "csv") {
+    const a = document.createElement("a");
+    a.href = `/api/session/${sid}/metrics.csv`;
+    a.download = `qallm_metrics_${sid}.csv`;
+    document.body.appendChild(a);
+    a.click();
+    a.remove();
+    return;
+  }
+  // JSON: fetch the metrics object and save the inner `metrics` as a file.
+  const res = await getSessionMetrics(sid);
+  const payload = res.metrics ?? res;
+  const blob = new Blob([JSON.stringify(payload, null, 2)], { type: "application/json" });
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = `qallm_metrics_${sid}.json`;
+  document.body.appendChild(a);
+  a.click();
+  a.remove();
+  URL.revokeObjectURL(url);
+}
+
 // ─── Quality model profiles (selector) ───
 export interface QualityProfileInfo {
   id: string;

--- a/web/frontend/src/screens/GapPanel.tsx
+++ b/web/frontend/src/screens/GapPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap, Microscope, Loader2, BadgeCheck } from "lucide-react";
+import { ShieldCheck, ShieldAlert, ShieldQuestion, Zap, Microscope, Loader2, BadgeCheck, Download } from "lucide-react";
 import * as api from "../api";
 import type { GapRound, FindingStatus, FindingVerdictRow, FindingVerdict, FixResultRow, FixVerdict } from "../api";
 
@@ -126,6 +126,24 @@ export default function GapPanel({ sessionId }: { sessionId: string }) {
           detail={fixSummary ? `${fixSummary.verified_fixed} fixed / ${fixSummary.not_fixed} not` : "not run yet"}
           tone="sky"
         />
+      </div>
+
+      {/* Export the metrics for the thesis. The numbers shown above are what
+          gets written; confirm/verify rates are included once run. */}
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        <button
+          onClick={() => api.downloadSessionMetrics(sessionId, "json")}
+          className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
+        >
+          <Download className="h-3.5 w-3.5" /> Metrics JSON
+        </button>
+        <button
+          onClick={() => api.downloadSessionMetrics(sessionId, "csv")}
+          className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1 text-xs font-medium text-slate-600 hover:bg-slate-50"
+        >
+          <Download className="h-3.5 w-3.5" /> Metrics CSV
+        </button>
+        <span className="text-xs text-slate-400">Run confirm/refute and verify fixes first to include those rates.</span>
       </div>
 
       <div className="mt-4 space-y-4">


### PR DESCRIPTION
Branch: `feature/metrics-export` (off `dev`, after #83)
**1 commit.** All green: **502 Python tests pass**, frontend type-checks and builds, ruff clean.

## Done: metrics export + aggregation (the citable evidence)

`qallm/metrics_export.py`:
- `build_session_metrics`: per-session record with run metadata + the three metrics. Rates are **null when their denominator is zero**, never a misleading zero.
- `aggregate_sessions`: cross-session roll-up that **recomputes rates from summed counts** (count-weighted), not by averaging per-session rates, the correct way to aggregate rates.
- `to_csv`: stable-column CSV; `to_dict` and `CSV_COLUMNS` are kept in sync (tested).

API (results router):
- Refactored gap loading into `_resolve_report_dir` / `_compute_gap_rounds` helpers (reused, no duplication).
- `GET /api/session/{id}/metrics` (JSON), `/metrics.csv` (one-row download), `/api/metrics/aggregate` (roll-up over the whole library).
- `confirm-findings` and `verify-fixes` now record their summaries on session state, so the export includes those rates once you've run them.

UI (GapPanel): "Metrics JSON" and "Metrics CSV" buttons under the headline card, with a note that confirm/verify must be run first to include those rates.

## Done: thesis draft scaffold

`docs/thesis-draft-scaffold.md` (also surfaced as `THESIS_draft-scaffold.md`). A structural foundation, not filler:
- The claim and three refined RQs (gap, confirm/refute, verified-fix).
- A method chapter mapping each step (static-as-hypotheses, verification, the gap, confirm/refute, verified fixes, TAR) to the implementation.
- An evaluation chapter wired to the exact three metrics, with bracketed placeholders for the numbers your runs will produce.
- Threats to validity stated honestly (confirmation is corroboration not causation; refutation is not proof; why the ERROR/discarded exclusions strengthen rather than bias the gap rate).
- An authoritative metric-definitions appendix, so every number in Chapter 5 traces to a precise formula and to the export.


## Verify locally

```
pip install -e . --break-system-packages
pip install pytest pytest-asyncio httpx radon bandit ruff --break-system-packages
python -m pytest -q                       # 502 passed
ruff check src/qallm
cd web/frontend && npm install && npx tsc --noEmit && npx vite build
```
(If `vite build` errors with ERR_MODULE_NOT_FOUND on first try, it's a stale temp file; `npm install` then rebuild. The `tsconfig baseUrl` deprecation warning is pre-existing and harmless.)
