### PR TITLE
Documentation audit + presentation artifact

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,14 @@ flowchart TD
     subgraph S2["Stage 2: Static Quality Analysis"]
         Units --> Radon[Radon: MI, CC]
         Units --> Bandit[Bandit: security]
-        Radon --> Norm[LifecycleNormalizer<br/>per EVERSE dimension]
+        Units --> Ruff[Ruff: lint]
+        Units --> Sonar[SonarQube: optional<br/>reliability, security]
+        Units --> Truffle[TruffleHog: secrets]
+        Radon --> Norm[Normalizer<br/>per EVERSE dimension]
         Bandit --> Norm
+        Ruff --> Norm
+        Sonar --> Norm
+        Truffle --> Norm
         Norm --> Report1[Static findings]
     end
 
@@ -115,6 +121,41 @@ A design question sits inside this stage: is the iterative-feedback test generat
 * **`feedback`** (default): LLM, N rounds with execution feedback (default N = 5). The proposed verifier.
 
 This is an ablation *within* the verification stage, not three rival products. The thesis contribution is the improvement loop; the strategy flag exists to justify which verifier the loop should use. Selectable as a single flag (`--strategy hypothesis|oneshot|feedback`). The legacy value `rl` is accepted as an alias for `feedback` for back-compat.
+
+## Static findings as hypotheses: confirm, refute, and verify fixes
+
+QALLM does not stop at listing static findings. It treats each finding as a *hypothesis* and uses execution to adjudicate it, then to prove that a repair actually worked. This is the layer that turns "the linter complained" into "the bug was real and is now provably gone", and it produces three reproducible metrics that are the empirical core of the thesis.
+
+```mermaid
+flowchart TD
+    Finding[Static finding<br/>tool, type, line] --> Type{Execution-testable type?}
+    Type -->|Complexity, Maintainability| NT[not_execution_testable<br/>a property of the source]
+    Type -->|Reliability, Security| Target[Generate a targeted test<br/>for this specific finding]
+    Target --> Run[Run in sandbox]
+    Run --> Verdict{Verdict}
+    Verdict -->|reliability test fails<br/>security exploit passes| Confirmed[confirmed:<br/>finding reproduced]
+    Verdict -->|clean run| Refuted[refuted:<br/>candidate false positive]
+
+    Confirmed --> Repair[Repair applied]
+    Repair --> Rerun[Re-run the same test<br/>against repaired code]
+    Rerun --> Fix{Defect gone?}
+    Fix -->|yes| Fixed[verified_fixed:<br/>proven fix]
+    Fix -->|no| NotFixed[not_fixed:<br/>repair satisfied the tool<br/>but not the defect]
+
+    Exec[Execution-found bugs in<br/>functions with no static finding] --> Gap[Verification gap:<br/>defects static analysis missed]
+```
+
+The classification is deliberately type-aware: complexity and maintainability are properties of the source text, not runtime behaviour, so they are marked `not_execution_testable` rather than pretending a test can reproduce them. Reliability findings are confirmed when a correctness test fails; security findings when an exploit test passes.
+
+Three metrics fall out of this, each produced per session and aggregated count-weighted across sessions by [`qallm.metrics_export`](src/qallm/metrics_export.py):
+
+| Metric | Question it answers | Definition |
+| --- | --- | --- |
+| **Verification gap rate** | What share of execution-found defects did static analysis miss entirely? | execution-only bugs / (confirmed findings + execution-only bugs) |
+| **Confirmation rate** | Of static findings execution could test, how many did it reproduce? | confirmed / (confirmed + refuted) |
+| **Verified-fix rate** | Of confirmed findings re-tested after repair, how many were provably fixed? | verified_fixed / (verified_fixed + not_fixed) |
+
+Rates are null (not zero) when their denominator is empty, so an absent measurement is never read as a measured absence. Errored and discarded tests are excluded from all defect counts: only a test that ran and failed is evidence of a defect. These metrics are exported per session as JSON and CSV, and rolled up across the session library, the evidence pipeline behind the thesis evaluation. The on-demand confirm/refute and verify-fixes actions, the gap dashboard, and the metric exports are all surfaced in the web UI. The reasoning behind this layer is in [`docs/surpassing-static-analysers.md`](docs/surpassing-static-analysers.md).
 
 ## Quality profiles
 
@@ -200,7 +241,7 @@ docker compose up --build
 Open <http://localhost:8000> in a browser. The CLI is also available inside the container:
 
 ```bash
-docker compose exec api qallm --source /home/qallm/app/uploads/your_notebook.ipynb --strategy feedback
+docker compose exec api qallm /home/qallm/app/uploads/your_notebook.ipynb --strategy feedback
 ```
 
 Outputs land in `./outputs` on the host (mounted into the container).
@@ -229,13 +270,13 @@ pip install -e .
 export OPENAI_API_KEY=sk-...   # or ANTHROPIC_API_KEY
 
 # Static analysis only, on a notebook
-qallm --source notebooks/analysis.ipynb --strategy hypothesis
+qallm notebooks/analysis.ipynb --strategy hypothesis
 
 # One-shot LLM verification
-qallm --source notebooks/analysis.ipynb --strategy oneshot --llm openai
+qallm notebooks/analysis.ipynb --strategy oneshot --llm openai
 
 # Full iterative-feedback verification, 5 rounds
-qallm --source notebooks/analysis.ipynb --strategy feedback --rounds 5 --llm openai
+qallm notebooks/analysis.ipynb --strategy feedback --rounds 5 --llm openai
 ```
 
 Inputs may be a single `.py` or `.ipynb` file, a directory, a `.zip` archive, or a GitHub URL.
@@ -266,22 +307,33 @@ The Docker Compose stack above is the unit of deployment, and serving the fronte
 ```
 src/qallm/
   ingestion/          Stage 1: notebook, script, ZIP, git
-  analysis/           Stage 2: Radon, Bandit, Ruff, normalisation
-  verification/       Stage 3: iterative-feedback loop, sandbox, executor, prompts
+  analysis/           Stage 2: Radon, Bandit, Ruff, SonarQube, TruffleHog,
+                      normalisation, and gap_analysis (static vs execution)
+  verification/       Stage 3: iterative-feedback loop, sandbox, executor,
+                      prompts, test_validator, confirm_refute, verified_fix
   repair/             LLM code repair between rounds
   judge/              Accept/abandon verdict per round
   utils/              Reporters, signatures
+  common/             Shared types used across stages
   llm/                OpenAI, Anthropic, Ollama adapters
   api/                FastAPI app (serves the React UI from web/dist)
   experiments/        HumanEval validation harness
+  sample_data/        Example inputs
   profiles.py         EVERSE quality profiles
   evaluation.py       Indicator registry and verdicts
   fairness.py         FAIRness indicators
+  improvement.py      Improvement-lineage model
+  metrics_export.py   Per-session and cross-session metric export (JSON/CSV)
+  config.py           Settings (env-driven)
+  cost.py             Token/cost tracking and budget caps
   jobs.py             Background job store for the web UI
+  jupyter.py          %%qallm notebook magic
   orchestrator.py     The conductor
+  orchestrator_models.py  Progress/snapshot dataclasses
+  cli_observability.py    CLI run telemetry
   experiment.py       Batch experiment runner
   stats.py            Wilcoxon + Cliff's delta
-  run_qallm.py        CLI entry point
+  run_qallm.py        CLI entry point (`qallm <source> ...`)
 web/frontend/         React + Vite web UI
 tests/                Unit and integration tests
 docs/                 Design notes, thesis materials
@@ -296,6 +348,12 @@ To keep one source of truth, each document owns a domain. When they overlap, the
 | What QALLM is, quickstart, CLI | This README | full |
 | What QALLM *does* (the loop, judge, budget, outputs, methodology) | [`docs/workflow-design.md`](docs/workflow-design.md) | one-paragraph summary, links out |
 | Quality frameworks (EVERSE, ISO/IEC 25010, FAIR4RS, SonarQube) | [`docs/workflow-design.md`](docs/workflow-design.md) section 13 | summary table, links out |
+| Static-vs-execution strategy (gap, confirm/refute, verified fixes) | [`docs/surpassing-static-analysers.md`](docs/surpassing-static-analysers.md) | summary section, links out |
+| Run mechanics (rounds, FROZEN+GROW, ERROR vs BUG) | [`docs/run-mechanics-and-diagnostics.md`](docs/run-mechanics-and-diagnostics.md) | none |
+| SonarQube integration and setup | [`docs/sonarqube-integration.md`](docs/sonarqube-integration.md) | none |
+| Verification oracles | [`docs/oracles.md`](docs/oracles.md) | none |
+| Methodology decisions | [`docs/methodology-decisions.md`](docs/methodology-decisions.md) | none |
+| Thesis structure and metric definitions | [`docs/thesis-draft-scaffold.md`](docs/thesis-draft-scaffold.md) | none |
 | Production deployment (split FE/API, CORS, TLS, ops) | [`docs/deployment.md`](docs/deployment.md) | quickstart only, links out |
 | Auto-mode web UI behaviour | [`docs/web-ui-automode.md`](docs/web-ui-automode.md) | none |
 | Issue backlog state | [`docs/backlog-audit-2026-05.md`](docs/backlog-audit-2026-05.md) | none |
@@ -305,16 +363,19 @@ To keep one source of truth, each document owns a domain. When they overlap, the
 Working in `dev`:
 
 * All four pipeline stages, three strategies, three LLM providers.
+* Static analysis via Radon, Bandit, Ruff, TruffleHog, and optional SonarQube.
+* The static-vs-execution layer: gap analysis, per-finding confirm/refute, and verified-fix checking, with per-session and cross-session metric export (JSON/CSV).
 * Sandbox with timeout enforcement and pytest-cov telemetry.
-* Code extractor with AST-validated multi-strategy extraction.
-* Dependency mapper for sibling-module imports.
+* AST validation of generated tests (drops tests that request undefined fixtures before they run).
+* Code extractor with AST-validated multi-strategy extraction; dependency mapper for sibling-module imports.
+* EVERSE quality profiles integrated into the orchestrator.
+* React web UI served from the API process, with live verification timeline, gap dashboard, and the confirm/verify/export actions.
 * Experiment runner and statistical analysis (Wilcoxon, Cliff's delta).
 * Pilot results across 31 functions on three models.
 
 In development:
 
-* React SPA frontend on a feature branch (Option B architecture: Vite build, FastAPI static mount).
-* `qallm.profiles` module landing in `dev`; orchestrator integration to follow incrementally.
+* Wiring the batch experiment runner to emit the three execution-based metrics across a whole dataset.
 * Full-scale experiments on the Yutong Li dataset (2,796 notebooks, 277 projects).
 
 Out of scope for v1:

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -86,38 +86,31 @@ The output is in `web/frontend/dist/`. Upload this directory to your static host
 
 ### 2. Configure the API to NOT serve the frontend
 
-When the frontend lives elsewhere, the API should not also try to serve it. Make this conditional on an environment variable.
-
-In `src/qallm/api/main.py`, find the static-files mount near the bottom of the file:
+When the frontend lives elsewhere, the API should not also try to serve it. This is already handled by presence: the API mounts the frontend only when a built dist directory is found. The mount logic in `src/qallm/api/main.py` resolves the dist path from the `QALLM_FRONTEND_DIST` environment variable (used by the Docker image) and otherwise falls back to the source-tree location for editable installs:
 
 ```python
-# Mount the built frontend at /
-_FRONTEND_DIST = Path(__file__).parents[2] / "web" / "frontend" / "dist"
-if _FRONTEND_DIST.exists():
-    app.mount("/", StaticFiles(directory=str(_FRONTEND_DIST), html=True), name="frontend")
-```
+_env_dist = os.getenv("QALLM_FRONTEND_DIST")
+if _env_dist:
+    _FRONTEND_DIST = Path(_env_dist)
+else:
+    _FRONTEND_DIST = Path(__file__).resolve().parents[2].parent / "web" / "dist"
 
-Replace with:
-
-```python
-import os
-_SERVE_FRONTEND = os.getenv("QALLM_SERVE_FRONTEND", "true").lower() != "false"
-_FRONTEND_DIST = Path(__file__).parents[2] / "web" / "frontend" / "dist"
-if _SERVE_FRONTEND and _FRONTEND_DIST.exists():
+if _FRONTEND_DIST.is_dir():
     app.mount("/", StaticFiles(directory=str(_FRONTEND_DIST), html=True), name="frontend")
 else:
-    logger.info("Frontend serving disabled (QALLM_SERVE_FRONTEND=false or dist missing)")
+    logger.info("Frontend dist not found at %s; running API only", _FRONTEND_DIST)
 ```
 
-When deploying the API standalone:
+So to run the API standalone, build an API-only image (do not run the frontend build stage) or point `QALLM_FRONTEND_DIST` at a path that does not exist. There is no separate on/off boolean; the presence of a dist directory is the switch.
 
 ```
-docker run -e QALLM_SERVE_FRONTEND=false -p 8000:8000 qallm-api
+# API-only: no dist present, so nothing is mounted at /
+docker run -p 8000:8000 qallm-api
 ```
 
 ### 3. Configure CORS on the API
 
-The API needs to accept cross-origin requests from your frontend's domain.
+The API needs to accept cross-origin requests from your frontend's domain. CORS middleware is *not* wired in by default (the integrated deployment is same-origin and does not need it), so add it for a split deployment.
 
 In `src/qallm/api/main.py`:
 
@@ -140,11 +133,12 @@ When deploying:
 
 ```
 docker run \
-  -e QALLM_SERVE_FRONTEND=false \
   -e QALLM_CORS_ORIGINS=https://qallm.example.org \
   -p 8000:8000 \
   qallm-api
 ```
+
+(API-only because this image was built without the frontend dist; see step 2.)
 
 ### 4. Set up TLS
 
@@ -161,7 +155,7 @@ After deployment:
 ```
 # API health check
 curl https://api.qallm.example.org/api/health
-# Should return {"status": "ok"}
+# Should return {"status": "online"}
 
 # CORS preflight
 curl -X OPTIONS https://api.qallm.example.org/api/health \
@@ -220,7 +214,7 @@ If you have already split the deployment and want to go back:
 
 ```
 docker run -p 8000:8000 qallm-api
-# Defaults: QALLM_SERVE_FRONTEND=true, frontend served at /
+# An image built with the frontend dist serves the UI at / automatically.
 ```
 
 Visit `http://localhost:8000` and the integrated UI loads. No CORS issues because everything is same-origin.

--- a/docs/qallm-overview.html
+++ b/docs/qallm-overview.html
@@ -1,0 +1,464 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>QALLM — Execution-Based Quality Assessment of AI-Generated Code</title>
+<style>
+  @import url('https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,400;0,9..144,600;0,9..144,900;1,9..144,400&family=Spline+Sans+Mono:wght@400;500;600&family=Newsreader:ital,opsz@0,6..72;1,6..72&display=swap');
+
+  :root {
+    --ink: #14140f;
+    --paper: #f4f1e8;
+    --paper-2: #eae5d6;
+    --accent: #9a3b1b;       /* terracotta */
+    --accent-2: #2d4a3e;     /* deep green */
+    --gold: #b08436;
+    --rule: #cdc6b4;
+    --muted: #6b6657;
+  }
+
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+
+  body {
+    background: var(--paper);
+    color: var(--ink);
+    font-family: 'Newsreader', Georgia, serif;
+    font-size: 18px;
+    line-height: 1.55;
+    background-image:
+      radial-gradient(circle at 15% 10%, rgba(154,59,27,0.04), transparent 40%),
+      radial-gradient(circle at 85% 90%, rgba(45,74,62,0.05), transparent 45%);
+  }
+
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 0 32px; }
+
+  /* ── Masthead ── */
+  header {
+    border-bottom: 3px double var(--ink);
+    padding: 56px 0 28px;
+    margin-bottom: 8px;
+  }
+  .kicker {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 12px;
+    letter-spacing: 0.32em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 20px;
+  }
+  h1 {
+    font-family: 'Fraunces', serif;
+    font-weight: 900;
+    font-size: clamp(38px, 6vw, 68px);
+    line-height: 0.98;
+    letter-spacing: -0.02em;
+    margin-bottom: 22px;
+  }
+  h1 em { font-style: italic; color: var(--accent); }
+  .standfirst {
+    font-size: clamp(19px, 2.4vw, 24px);
+    max-width: 60ch;
+    color: #36342b;
+    line-height: 1.45;
+  }
+  .byline {
+    margin-top: 24px;
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 13px;
+    color: var(--muted);
+    letter-spacing: 0.02em;
+  }
+
+  /* ── The claim ── */
+  .claim {
+    margin: 48px 0;
+    padding: 36px 40px;
+    background: var(--ink);
+    color: var(--paper);
+    border-radius: 2px;
+    position: relative;
+  }
+  .claim .lead {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.3em;
+    text-transform: uppercase;
+    color: var(--gold);
+    margin-bottom: 16px;
+  }
+  .claim p {
+    font-family: 'Fraunces', serif;
+    font-size: clamp(22px, 3vw, 30px);
+    line-height: 1.3;
+    font-weight: 400;
+  }
+  .claim strong { color: #e8a85c; font-weight: 600; }
+
+  /* ── Section headings ── */
+  h2 {
+    font-family: 'Fraunces', serif;
+    font-weight: 900;
+    font-size: 13px;
+    letter-spacing: 0.28em;
+    text-transform: uppercase;
+    color: var(--accent-2);
+    margin: 56px 0 24px;
+    padding-bottom: 10px;
+    border-bottom: 1px solid var(--rule);
+    display: flex;
+    justify-content: space-between;
+    align-items: baseline;
+  }
+  h2 .num {
+    font-family: 'Spline Sans Mono', monospace;
+    color: var(--gold);
+    font-size: 12px;
+  }
+
+  p.body { margin-bottom: 18px; max-width: 68ch; }
+  .lede { font-size: 20px; color: #36342b; }
+
+  /* ── Pipeline flow ── */
+  .flow {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 0;
+    margin: 8px 0 12px;
+    border: 1px solid var(--ink);
+  }
+  .stage {
+    padding: 22px 18px;
+    border-right: 1px solid var(--rule);
+    position: relative;
+    background: var(--paper);
+  }
+  .stage:last-child { border-right: none; }
+  .stage .s-num {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 11px;
+    color: var(--accent);
+    letter-spacing: 0.15em;
+  }
+  .stage .s-name {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 19px;
+    margin: 6px 0 8px;
+    line-height: 1.1;
+  }
+  .stage .s-desc { font-size: 14.5px; color: var(--muted); line-height: 1.4; }
+
+  /* ── The gap, two columns ── */
+  .gap-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: 0;
+    border: 1px solid var(--ink);
+    margin: 8px 0;
+  }
+  .gap-col { padding: 28px 30px; }
+  .gap-col.static { background: var(--paper-2); border-right: 1px solid var(--ink); }
+  .gap-col.dyn { background: var(--ink); color: var(--paper); }
+  .gap-col h3 {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    margin-bottom: 14px;
+  }
+  .gap-col.static h3 { color: var(--accent); }
+  .gap-col.dyn h3 { color: var(--gold); }
+  .gap-col ul { list-style: none; }
+  .gap-col li {
+    padding: 7px 0;
+    font-size: 15.5px;
+    border-bottom: 1px dotted rgba(120,110,90,0.35);
+  }
+  .gap-col.dyn li { border-bottom-color: rgba(200,190,160,0.2); }
+  .gap-col .verdict {
+    margin-top: 16px;
+    font-family: 'Fraunces', serif;
+    font-style: italic;
+    font-size: 18px;
+  }
+  .gap-col.static .verdict { color: var(--accent); }
+  .gap-col.dyn .verdict { color: #e8a85c; }
+
+  /* ── Metrics ── */
+  .metrics {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 18px;
+    margin: 8px 0;
+  }
+  .metric {
+    border: 1px solid var(--rule);
+    border-top: 3px solid var(--accent);
+    padding: 22px 22px 24px;
+    background: #faf8f1;
+  }
+  .metric:nth-child(2) { border-top-color: var(--accent-2); }
+  .metric:nth-child(3) { border-top-color: var(--gold); }
+  .metric .m-name {
+    font-family: 'Fraunces', serif;
+    font-weight: 600;
+    font-size: 19px;
+    margin-bottom: 8px;
+  }
+  .metric .m-q { font-size: 15px; color: var(--muted); margin-bottom: 14px; line-height: 1.4; }
+  .metric .m-def {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 12.5px;
+    color: var(--accent-2);
+    background: var(--paper-2);
+    padding: 8px 10px;
+    border-radius: 2px;
+    line-height: 1.5;
+  }
+
+  /* ── Audience cards ── */
+  .aud {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 0;
+    border: 1px solid var(--ink);
+  }
+  .aud-col { padding: 24px 26px; border-right: 1px solid var(--rule); }
+  .aud-col:last-child { border-right: none; }
+  .aud-col .a-who {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 11px;
+    letter-spacing: 0.18em;
+    text-transform: uppercase;
+    color: var(--accent);
+    margin-bottom: 12px;
+  }
+  .aud-col p { font-size: 15.5px; line-height: 1.5; color: #36342b; }
+
+  /* ── Definitions list ── */
+  .deflist { border-top: 1px solid var(--rule); margin-top: 8px; }
+  .defrow {
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    gap: 24px;
+    padding: 16px 0;
+    border-bottom: 1px solid var(--rule);
+  }
+  .defrow dt {
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 13px;
+    color: var(--accent-2);
+    font-weight: 600;
+  }
+  .defrow dd { font-size: 16px; color: #36342b; }
+
+  /* ── Footer ── */
+  footer {
+    margin: 64px 0 48px;
+    padding-top: 24px;
+    border-top: 3px double var(--ink);
+    font-family: 'Spline Sans Mono', monospace;
+    font-size: 12.5px;
+    color: var(--muted);
+    display: flex;
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 12px;
+  }
+  footer a { color: var(--accent); text-decoration: none; }
+
+  .note {
+    font-size: 13.5px;
+    color: var(--muted);
+    font-style: italic;
+    margin-top: 12px;
+  }
+
+  @media (max-width: 820px) {
+    .flow, .gap-grid, .metrics, .aud { grid-template-columns: 1fr; }
+    .stage, .gap-col.static, .aud-col { border-right: none; border-bottom: 1px solid var(--rule); }
+    .defrow { grid-template-columns: 1fr; gap: 4px; }
+  }
+
+  /* staggered load */
+  header, .claim, section { animation: rise 0.7s cubic-bezier(0.2,0.7,0.2,1) backwards; }
+  .claim { animation-delay: 0.1s; }
+  section:nth-of-type(1) { animation-delay: 0.18s; }
+  section:nth-of-type(2) { animation-delay: 0.26s; }
+  section:nth-of-type(3) { animation-delay: 0.34s; }
+  @keyframes rise { from { opacity: 0; transform: translateY(16px); } to { opacity: 1; transform: none; } }
+</style>
+</head>
+<body>
+<div class="wrap">
+
+  <header>
+    <div class="kicker">MSc Thesis · University of Amsterdam · MNS Group</div>
+    <h1>QALLM: execution decides<br>what static analysis can <em>only guess</em>.</h1>
+    <p class="standfirst">
+      A research instrument that measures and improves the quality of AI-generated Python notebooks
+      against a chosen quality model, by treating every static finding as a hypothesis and using
+      execution as the judge.
+    </p>
+    <div class="byline">
+      Supervisors: Dr. Zhiming Zhao (MNS), Dr. Nafis Tanveer Islam · Aligned with the EVERSE programme
+      and Volentir et&nbsp;al. (QRS 2025)
+    </div>
+  </header>
+
+  <div class="claim">
+    <div class="lead">The core claim</div>
+    <p>
+      Code can pass every static check and still be wrong. QALLM finds the defects static
+      analysis misses, <strong>confirms</strong> which findings are real, and
+      <strong>proves</strong> a repair fixed them, by running the code.
+    </p>
+  </div>
+
+  <section>
+    <h2>The verification gap <span class="num">01</span></h2>
+    <p class="body lede">
+      Static analysers are valuable and necessary. They are also structurally blind to runtime
+      behaviour: they reason about source text, not about what the code does when executed.
+    </p>
+    <div class="gap-grid">
+      <div class="gap-col static">
+        <h3>Static analysis alone</h3>
+        <ul>
+          <li>Style: clean</li>
+          <li>Security smells: none</li>
+          <li>Complexity: acceptable</li>
+        </ul>
+        <div class="verdict">Is the function actually correct? Unknown.</div>
+      </div>
+      <div class="gap-col dyn">
+        <h3>With QALLM (execution)</h3>
+        <ul>
+          <li>Tests generated and run in a sandbox</li>
+          <li>Runtime defects surfaced with reproductions</li>
+          <li>Findings confirmed, refuted, or proven fixed</li>
+        </ul>
+        <div class="verdict">Answered, with runtime evidence.</div>
+      </div>
+    </div>
+    <p class="note">
+      Pilot across 31 functions and three models showed a 91.3% false-confidence rate: code that
+      passed every static check yet carried a logic bug, surfaced only on execution.
+    </p>
+  </section>
+
+  <section>
+    <h2>The pipeline <span class="num">02</span></h2>
+    <p class="body">
+      A bounded, budget-capped loop. Establish a baseline, then repair with an LLM and re-verify,
+      round after round, with a judge accepting or abandoning each variant. The LLM acts as test
+      generator and code repairer through its API with quantitative feedback; it is not trained.
+    </p>
+    <div class="flow">
+      <div class="stage">
+        <div class="s-num">STAGE 1</div>
+        <div class="s-name">Ingestion</div>
+        <div class="s-desc">Notebooks, scripts, archives, or a git repo parsed into code units; magics stripped, cells preserved.</div>
+      </div>
+      <div class="stage">
+        <div class="s-num">STAGE 2</div>
+        <div class="s-name">Static analysis</div>
+        <div class="s-desc">Radon, Bandit, Ruff, TruffleHog, and optional SonarQube, normalised per EVERSE dimension.</div>
+      </div>
+      <div class="stage">
+        <div class="s-num">STAGE 3</div>
+        <div class="s-name">Execution verification</div>
+        <div class="s-desc">Generate tests, run in a sandbox, score the round, feed failures back into the next repair.</div>
+      </div>
+      <div class="stage">
+        <div class="s-num">STAGE 4</div>
+        <div class="s-name">Quality reporting</div>
+        <div class="s-desc">Per-dimension verdict, accept/abandon lineage, cost, and the exported evidence metrics.</div>
+      </div>
+    </div>
+    <p class="note">
+      Stages map 1:1 to the package layout: qallm.ingestion, qallm.analysis, qallm.verification,
+      qallm.utils, with qallm.orchestrator as the conductor.
+    </p>
+  </section>
+
+  <section>
+    <h2>Findings as hypotheses <span class="num">03</span></h2>
+    <p class="body">
+      Each static finding is adjudicated by execution, then fixes are proven. The classification
+      is type-aware: complexity and maintainability are properties of the source, not runtime
+      behaviour, so they are never claimed as execution-confirmable.
+    </p>
+    <dl class="deflist">
+      <div class="defrow">
+        <dt>confirmed</dt>
+        <dd>A targeted test reproduced the finding: a reliability test that fails, or a security exploit that succeeds. The finding is real.</dd>
+      </div>
+      <div class="defrow">
+        <dt>refuted</dt>
+        <dd>The targeted test ran cleanly. A candidate false positive, stated cautiously: not reproduced is not the same as proven absent.</dd>
+      </div>
+      <div class="defrow">
+        <dt>verified&nbsp;fixed</dt>
+        <dd>After repair, the reproducing test shows the defect is gone. A proven fix, not an asserted one.</dd>
+      </div>
+      <div class="defrow">
+        <dt>not&nbsp;fixed</dt>
+        <dd>The repair satisfied the static tool but the defect survives execution. A failure mode static-only pipelines cannot see.</dd>
+      </div>
+    </dl>
+  </section>
+
+  <section>
+    <h2>Three metrics, reproducible <span class="num">04</span></h2>
+    <p class="body">
+      Each is produced per session and aggregated count-weighted across sessions, exported as
+      JSON and CSV. Rates are null, never zero, when their denominator is empty, so an absent
+      measurement is never read as a measured absence.
+    </p>
+    <div class="metrics">
+      <div class="metric">
+        <div class="m-name">Verification gap</div>
+        <div class="m-q">What share of execution-found defects did static analysis miss entirely?</div>
+        <div class="m-def">execution-only ÷ (confirmed&nbsp;findings + execution-only)</div>
+      </div>
+      <div class="metric">
+        <div class="m-name">Confirmation rate</div>
+        <div class="m-q">Of static findings execution could test, how many did it reproduce?</div>
+        <div class="m-def">confirmed ÷ (confirmed + refuted)</div>
+      </div>
+      <div class="metric">
+        <div class="m-name">Verified-fix rate</div>
+        <div class="m-q">Of confirmed findings re-tested after repair, how many were provably fixed?</div>
+        <div class="m-def">verified&nbsp;fixed ÷ (verified&nbsp;fixed + not&nbsp;fixed)</div>
+      </div>
+    </div>
+  </section>
+
+  <section>
+    <h2>What this means for you <span class="num">05</span></h2>
+    <div class="aud">
+      <div class="aud-col">
+        <div class="a-who">Thesis committee</div>
+        <p>A falsifiable claim with three reproducible metrics, an honest method (correlation vs causation stated), and a research instrument that runs end to end. The verification gap is the empirical contribution.</p>
+      </div>
+      <div class="aud-col">
+        <div class="a-who">Research peers</div>
+        <p>Open implementation, a clean ablation isolating the value of feedback, and an evidence export you can re-run. QALLM sits on top of SonarQube and friends; it does not compete with them.</p>
+      </div>
+      <div class="aud-col">
+        <div class="a-who">Research-software stakeholders</div>
+        <p>A way to quality-gate AI-generated notebook code that answers "is it correct", not just "is it tidy", and proves fixes rather than asserting them. Local or hosted models, your choice.</p>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div>QALLM · Execution-Based Quality Assessment of AI-Generated Code in Jupyter Notebooks</div>
+    <div><a href="https://github.com/assaban/qallm-uva">github.com/assaban/qallm-uva</a></div>
+  </footer>
+
+</div>
+</body>
+</html>


### PR DESCRIPTION
Branch: `docs/audit-accuracy` (off `dev`, after #84)
**2 commits.** Docs only, no code changed. (Backend untouched, so the test suite is unaffected.)

You asked for an extensive, accurate audit of the project docs plus a presentation artifact. I read every factual claim in the key docs against the current code and corrected the divergences, rather than trusting the prose. Here is exactly what I found.

## README.md: what was wrong (now fixed)

1. **The CLI quickstart was broken.** It documented `qallm --source notebook.ipynb`, but the real CLI takes `source` as a **positional** argument (`qallm notebook.ipynb`). Every quickstart command would have failed for a new user. Fixed in the Docker exec example and all three local examples.
2. **The entire static-vs-execution layer was undocumented.** Confirm/refute, verified fixes, the verification gap, and the three exported metrics, our last several sessions and the current thesis contribution, were missing from the README. Added a dedicated section with a diagram, the four verdicts, and the three metric definitions.
3. **The Stage 2 diagram listed only Radon and Bandit.** The code also runs Ruff, TruffleHog, and optional SonarQube. Diagram updated.
4. **The repository layout was stale.** It omitted real modules (`config.py`, `cost.py`, `improvement.py`, `jupyter.py`, `metrics_export.py`, `orchestrator_models.py`, `cli_observability.py`), the `common/` and `sample_data/` dirs, and the new analysis/verification modules. Corrected to match the actual tree.
5. **The Status section was months stale.** It claimed the frontend was "on a feature branch" and profiles were "landing in dev", both long done. Rewritten to reflect current `dev`.
6. **The documentation map** omitted several design docs that now exist. Expanded.

## docs/deployment.md: what was wrong (now fixed)

1. **A non-existent config toggle.** It referenced `QALLM_SERVE_FRONTEND=true/false` in five places. No such setting exists. The real control is the presence of a frontend dist, resolved via `QALLM_FRONTEND_DIST`. Section 2 rewritten to describe the actual mounting logic.
2. **Wrong health response.** It said the health check returns `{"status": "ok"}`; the endpoint actually returns `{"status": "online"}`. Corrected.
3. **CORS framing.** The CORS middleware is not wired in by default; the doc now states it is an addition for split deployments, not existing code.

## Checked and found correct (no change needed)

- The CLI entry point `qallm = qallm.run_qallm:main` in pyproject.toml.
- The `--strategy / --rounds / --llm / --oracle / --stage` flags and their defaults.
- The `.env.example` keys and the four-stage package mapping.
- The EVERSE dimension table and the quality-profile JSON example.
- The four mermaid diagrams render (count balanced; added the gap diagram as a fifth).

One thing I noticed but did **not** change, because it is a code question for you, not a docs fix: `config.py` defaults `OPENAI_MODEL` to `gpt-5-mini`, while `.env.example` shows `gpt-4o-mini`. They disagree. The docs aren't wrong about either in isolation, but you may want to align the two so the default is unambiguous. Flagging rather than silently picking one.

## The presentation artifact

`qallm-overview.html` (also at `docs/qallm-overview.html`): a single self-contained HTML one-pager for the three audiences (committee, peers, stakeholders). Editorial/academic aesthetic, refined not flashy, since it is committee-facing. Covers the claim, the gap, the pipeline, findings-as-hypotheses, the three metrics with exact definitions, and an audience section. Opens in any browser, prints to one page, no assets beyond Google Fonts. Grounded entirely in the audited facts and honest about limits (correlation vs causation, refuted is not proven-absent).

## Verify locally

```
# docs only; nothing to build. To view the artifact:
open docs/qallm-overview.html      # or xdg-open / a browser
# sanity-check the README has no broken CLI flag or stale toggle:
grep -n "\-\-source" README.md          # (no matches)
grep -rn "QALLM_SERVE_FRONTEND" docs/   # (no matches)
```
