### PR TITLE
Review: CI workflow + staging deploy script

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+# Quality gate only: install, lint, and run the test suite on every push and
+# pull request to dev or main. This workflow does NOT deploy anywhere; it has
+# no access to the staging VM. Deployment stays manual via scripts/deploy.sh,
+# so nothing here can reach UvA infrastructure.
+
+on:
+  push:
+    branches: [dev, main]
+  pull_request:
+    branches: [dev, main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.10", "3.12"]
+
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Install the package and its dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -e .
+
+      - name: Lint with ruff
+        run: |
+          pip install ruff
+          ruff check src/qallm
+
+      - name: Run the test suite
+        run: pytest -q --tb=short

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -228,3 +228,23 @@ Visit `http://localhost:8000` and the integrated UI loads. No CORS issues becaus
 - Sharing the project with reviewers who can clone the repo and run `docker compose up`.
 
 The split-deployment instructions in this document exist for completeness and as a deployment guide if anyone (you or a future user) wants to take QALLM beyond the thesis. They are not needed for the thesis itself.
+
+## Continuous integration and staging deploys
+
+### CI (quality gate)
+
+`.github/workflows/ci.yml` runs on every push and pull request to `dev` and `main`. It installs the package, lints `src/qallm` with ruff, and runs the full test suite on Python 3.10 and 3.12. It does **not** deploy anything and has no access to any server: it is purely a merge gate, so a red run means do not merge. Deployment is deliberately kept separate from CI so that no external system (GitHub Actions, tokens) can reach the research VM.
+
+### Staging deploy (manual, on the VM)
+
+The staging server tracks a branch (default `dev`) and is updated by hand with `scripts/deploy.sh`, run on the VM after a merge:
+
+```
+cd ~/qallm-uva
+./scripts/deploy.sh                  # deploy the tracked branch (dev)
+QALLM_BRANCH=main ./scripts/deploy.sh   # deploy a different branch or tag
+```
+
+The script fast-forwards the tracked branch, rebuilds the image, restarts the container, prunes the old image, and polls `/api/health` so a broken deploy fails loudly. It refuses to run if the working tree has uncommitted changes or if `.env` is missing, both of which would otherwise cause silent or confusing failures on a shared box.
+
+This is the recommended model for a dev/staging VM: the test gate is automated, the deploy is a single auditable command, and nothing outside the VM holds credentials to it. If QALLM later becomes a longer-lived service under a single owner, full push-to-deploy can be revisited then, weighing the convenience against giving a CI runner SSH access to the infrastructure.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,7 @@ dependencies = [
     "fastapi",
     "uvicorn[standard]",
     "python-multipart",
+    "httpx",
 ]
 
 [project.optional-dependencies]

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+#
+# deploy.sh: pull the latest code and (re)deploy QALLM on this server.
+#
+# Intended for the dev/staging VM. Run it by hand after merging to the
+# tracked branch; it is deliberately not wired to any webhook or CI runner,
+# so nothing external has access to this machine.
+#
+# Usage:
+#   ./scripts/deploy.sh              # deploy the default branch (dev)
+#   QALLM_BRANCH=main ./scripts/deploy.sh   # deploy a different branch/tag
+#
+# It is safe to re-run: it fast-forwards the tracked branch, rebuilds the
+# image, restarts the container, and prunes the old image layer.
+
+set -euo pipefail
+
+# The branch (or tag) this server tracks. Override with QALLM_BRANCH.
+BRANCH="${QALLM_BRANCH:-dev}"
+
+# Resolve the repo root from this script's location, so the script works
+# regardless of the current working directory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_DIR="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_DIR}"
+
+echo "==> Deploying QALLM from branch '${BRANCH}' in ${REPO_DIR}"
+
+# Refuse to deploy on top of uncommitted local changes: on a shared box,
+# silent overwrites are worse than a clear stop.
+if ! git diff --quiet || ! git diff --cached --quiet; then
+  echo "ERROR: working tree has uncommitted changes. Commit or stash first." >&2
+  exit 1
+fi
+
+# A .env with real API keys must exist before we build; the app needs it.
+if [ ! -f .env ]; then
+  echo "ERROR: .env not found. Copy .env.example to .env and set your keys." >&2
+  exit 1
+fi
+
+echo "==> Fetching and fast-forwarding ${BRANCH}"
+git fetch origin --prune
+git checkout "${BRANCH}"
+git pull --ff-only origin "${BRANCH}"
+
+CURRENT="$(git rev-parse --short HEAD)"
+echo "==> Now at ${CURRENT}"
+
+echo "==> Building and restarting the container"
+docker compose up -d --build
+
+echo "==> Pruning dangling images"
+docker image prune -f >/dev/null 2>&1 || true
+
+# Give the API a moment, then check health so a broken deploy fails loudly.
+echo "==> Waiting for the API to come up"
+PORT="${API_PORT:-8000}"
+for i in $(seq 1 30); do
+  if curl -fsS "http://localhost:${PORT}/api/health" >/dev/null 2>&1; then
+    echo "==> Healthy. Deployed ${BRANCH} @ ${CURRENT} on port ${PORT}."
+    exit 0
+  fi
+  sleep 2
+done
+
+echo "ERROR: API did not report healthy within 60s. Check: docker compose logs" >&2
+exit 1

--- a/src/qallm/analysis/normalization/radon_normalizer.py
+++ b/src/qallm/analysis/normalization/radon_normalizer.py
@@ -64,11 +64,15 @@ class RadonNormalizer(ToolNormalizer):
         return findings
 
     def _severity_from_cc(self, cc: int) -> str:
-        if cc >= 20: return "CRITICAL"
-        if cc >= 15: return "HIGH"
+        if cc >= 20:
+            return "CRITICAL"
+        if cc >= 15:
+            return "HIGH"
         return "MEDIUM"
 
     def _severity_from_mi(self, mi: float) -> str:
-        if mi < 40: return "CRITICAL"
-        if mi < 60: return "HIGH"
+        if mi < 40:
+            return "CRITICAL"
+        if mi < 60:
+            return "HIGH"
         return "MEDIUM"

--- a/src/qallm/repair/agents/llm_repair_agent.py
+++ b/src/qallm/repair/agents/llm_repair_agent.py
@@ -135,14 +135,14 @@ Source Code:
                 text = "\n".join(blocks)
             else:
                 lines = text.splitlines()
-                text = "\n".join(l for l in lines if not l.strip().startswith(BT))
+                text = "\n".join(line for line in lines if not line.strip().startswith(BT))
         return text.strip()
 
     @staticmethod
     def _validate_compile(code: str, filename: str) -> tuple[bool, str | None]:
         """Check if code compiles. Returns (is_valid, error_message)."""
         try:
-            result = compile(code, filename, "exec")
+            compile(code, filename, "exec")
             return True, None
         except SyntaxError as e:
             return False, f"SyntaxError at line {e.lineno}: {e.msg}"


### PR DESCRIPTION
Branch: `ci/deploy-and-pipeline` (off `dev`, after #86)
**1 commit.** Suite: **502 passed**, ruff clean (CI will be green on the first run).

Sets up the two-tier model we discussed for the VM: automated quality gate in CI, manual one-command deploy on the server. CI has no access to the VM by design.

## Tier 2: CI quality gate (`.github/workflows/ci.yml`)

Runs on push and PR to `dev` and `main`. Installs the package, lints `src/qallm` with ruff, runs the full suite on Python 3.10 and 3.12. Deploys nothing, holds no credentials, has no path to the VM. A red run means do not merge.

## Tier 1: staging deploy (`scripts/deploy.sh`)

Run by hand on the VM after a merge:

```
cd ~/qallm-uva
./scripts/deploy.sh                      # deploy dev (the tracked branch)
QALLM_BRANCH=main ./scripts/deploy.sh    # deploy a different branch/tag
```

It fast-forwards the tracked branch, rebuilds, restarts, prunes the old image, and polls `/api/health` so a broken deploy fails loudly instead of leaving a half-up container. It refuses to run with uncommitted changes or a missing `.env`, the two things that cause silent or confusing failures on a shared box.

## Supporting fixes (so CI is green on first run)

These matter: without them the first CI run would be red, which defeats the point of a gate.

- **Declared `httpx` as an explicit dependency.** The tests use FastAPI's `TestClient`, which needs `httpx`. It was only present transitively here, so a clean CI install would have failed to collect the API tests. Now explicit.
- **Fixed 6 pre-existing ruff findings** in `src/qallm`, unrelated to our feature work: inline `if x: return` (E701) in `radon_normalizer.py`, an ambiguous variable name `l` (E741) and an unused `compile()` result (F841) in `llm_repair_agent.py`. Behaviour is unchanged; these were latent style issues the new lint step surfaced.

## Docs

Added a "Continuous integration and staging deploys" section to `deployment.md`: documents the gate, the deploy command, and the reasoning (CI separate from deploy so nothing external reaches the infrastructure). Written so Nafis can use it when he takes the system over.

## Why not full push-to-deploy

Documented in the commit and the doc: full CD would mean storing a VM deploy key as a GitHub secret, giving a CI runner SSH access to UvA research infrastructure that Joseph explicitly called experimental. For a thesis dev/staging box, the manual deploy gets ~all the convenience for a fraction of the blast radius. Revisit if QALLM becomes a longer-lived owned service.

## Verify locally

```
pip install -e . --break-system-packages
ruff check src/qallm        # clean
pytest -q                   # 502 passed
bash -n scripts/deploy.sh   # syntax OK
```
