### PR TITLE
Review: FedLLM (EGI) provider

### DIFF
--- a/src/qallm/api/core.py
+++ b/src/qallm/api/core.py
@@ -93,6 +93,8 @@ MODEL_CATALOG = [
     {"id": "openai:gpt-5.4",          "provider": "openai",    "model": "gpt-5.4",          "label": "OpenAI / gpt-5.4"},
     {"id": "anthropic:claude-haiku-4.5", "provider": "anthropic", "model": "claude-haiku-4-5-20251001", "label": "Anthropic / Claude Haiku 4.5"},
     {"id": "anthropic:claude-sonnet-4",  "provider": "anthropic", "model": "claude-sonnet-4-20250514",  "label": "Anthropic / Claude Sonnet 4"},
+    {"id": "fedllm:gpt-oss-120b",      "provider": "fedllm",    "model": "gpt-oss-120b",      "label": "FedLLM / gpt-oss-120b (EGI)"},
+    {"id": "fedllm:gpt-oss-20b",       "provider": "fedllm",    "model": "gpt-oss-20b",       "label": "FedLLM / gpt-oss-20b (EGI)"},
 ]
 
 
@@ -104,6 +106,8 @@ def check_model_available(entry: dict) -> bool:
         return bool(settings.ANTHROPIC_API_KEY)
     elif provider == "ollama":
         return bool(settings.OLLAMA_BASE_URL)
+    elif provider == "fedllm":
+        return bool(settings.FEDLLM_API_KEY)
     return False
 
 
@@ -115,7 +119,7 @@ def parse_model_id(model_id: str) -> tuple[str, str]:
     if ":" in model_id and not model_id.startswith("gemma"):
         # provider:model format (but not ollama names like gemma3:4b)
         parts = model_id.split(":", 1)
-        if parts[0] in ("openai", "anthropic", "ollama"):
+        if parts[0] in ("openai", "anthropic", "ollama", "fedllm"):
             return parts[0], parts[1]
 
     for entry in MODEL_CATALOG:

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -10,6 +10,12 @@ class Settings:
     OPENAI_API_KEY: str | None = os.getenv("OPENAI_API_KEY")
     OPENAI_MODEL: str = os.getenv("OPENAI_MODEL", "gpt-5-mini")
 
+    # FedLLM (EGI federated LLM inference): an OpenAI-compatible API.
+    # https://docs.egi.eu/documentation/803/users/ai/fedllm/
+    FEDLLM_API_KEY: str | None = os.getenv("FEDLLM_API_KEY")
+    FEDLLM_BASE_URL: str = os.getenv("FEDLLM_BASE_URL", "https://llm.ai.egi.eu/v1")
+    FEDLLM_MODEL: str = os.getenv("FEDLLM_MODEL", "gpt-oss-120b")
+
     ANTHROPIC_API_KEY: str | None = os.getenv("ANTHROPIC_API_KEY")
     ANTHROPIC_MODEL: str = os.getenv("ANTHROPIC_MODEL", "claude-haiku-4-5-20251001")
 

--- a/src/qallm/jupyter.py
+++ b/src/qallm/jupyter.py
@@ -84,7 +84,7 @@ def _make_arg_parser():
                    help="Path for the line magic; omitted for the cell magic.")
     p.add_argument("--strategy", default="feedback",
                    choices=["hypothesis", "oneshot", "feedback"])
-    p.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama"])
+    p.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama", "fedllm"])
     p.add_argument("--model", default=None)
     p.add_argument("--rounds", type=int, default=3)
     p.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])

--- a/src/qallm/llm/fedllm_provider.py
+++ b/src/qallm/llm/fedllm_provider.py
@@ -1,0 +1,39 @@
+"""FedLLM (EGI federated LLM inference) models.
+
+FedLLM exposes an OpenAI-compatible API (LiteLLM gateway in front of vLLM
+backends), so it reuses the OpenAI provider's chat logic, token tracking,
+and response handling, overriding only the endpoint, key, default model,
+and provider label. See:
+https://docs.egi.eu/documentation/803/users/ai/fedllm/
+
+Configure via FEDLLM_API_KEY (required), and optionally FEDLLM_BASE_URL
+(default https://llm.ai.egi.eu/v1) and FEDLLM_MODEL (default gpt-oss-120b).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from qallm.config import settings
+from qallm.llm.openai_provider import OpenAIModel
+
+logger = logging.getLogger(__name__)
+
+
+class FedLLMModel(OpenAIModel):
+
+    def __init__(self, model_id: str | None = None) -> None:
+        super().__init__(model_id or settings.FEDLLM_MODEL)
+
+    def is_configured(self) -> bool:
+        return bool(settings.FEDLLM_API_KEY)
+
+    def _provider_label(self) -> str:
+        return "fedllm"
+
+    def _build_client(self):
+        import openai
+        return openai.OpenAI(
+            api_key=settings.FEDLLM_API_KEY,
+            base_url=settings.FEDLLM_BASE_URL,
+        )

--- a/src/qallm/llm/openai_provider.py
+++ b/src/qallm/llm/openai_provider.py
@@ -27,25 +27,35 @@ class OpenAIModel(LLMModel):
     def is_configured(self) -> bool:
         return bool(settings.OPENAI_API_KEY)
 
+    def _provider_label(self) -> str:
+        """Provider tag recorded on responses. Overridable by subclasses."""
+        return "openai"
+
+    def _build_client(self):
+        """Construct the OpenAI-compatible client. Overridable by subclasses
+        that point at a different OpenAI-compatible endpoint (e.g. FedLLM)."""
+        import openai
+        return openai.OpenAI(api_key=settings.OPENAI_API_KEY)
+
     def chat(self, system: str, user: str, tracker: TokenTracker | None = None) -> LLMResponse:
         from qallm.llm.transcript import timer
 
+        label = self._provider_label()
         if not self.is_configured():
-            resp = LLMResponse(content="", provider="openai", model=self._model_id,
-                               error="OPENAI_API_KEY not configured")
+            resp = LLMResponse(content="", provider=label, model=self._model_id,
+                               error=f"{label} API key not configured")
             self._capture(system, user, resp, 0.0)
             return resp
 
         if tracker and tracker.remaining <= 0:
-            resp = LLMResponse(content="", provider="openai", model=self._model_id,
+            resp = LLMResponse(content="", provider=label, model=self._model_id,
                                error=f"Token budget exhausted ({tracker.budget} tokens used)")
             self._capture(system, user, resp, 0.0)
             return resp
 
         with timer() as t:
             try:
-                import openai
-                client = openai.OpenAI(api_key=settings.OPENAI_API_KEY)
+                client = self._build_client()
 
                 kwargs: dict = {
                     "model": self._model_id,
@@ -69,11 +79,11 @@ class OpenAIModel(LLMModel):
                     input_tokens=usage.prompt_tokens if usage else 0,
                     output_tokens=usage.completion_tokens if usage else 0,
                     model=response.model,
-                    provider="openai",
+                    provider=label,
                 )
             except Exception as e:
-                logger.error("OpenAI API error [%s]: %s", self._model_id, e)
-                resp = LLMResponse(content="", provider="openai", model=self._model_id, error=str(e))
+                logger.error("%s API error [%s]: %s", label, self._model_id, e)
+                resp = LLMResponse(content="", provider=label, model=self._model_id, error=str(e))
 
         if tracker:
             tracker.record(resp)

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -69,6 +69,7 @@ from qallm.llm.anthropic_provider import AnthropicModel
 from qallm.llm.base import LLMModel, TokenTracker
 from qallm.llm.ollama_provider import OllamaModel
 from qallm.llm.openai_provider import OpenAIModel
+from qallm.llm.fedllm_provider import FedLLMModel
 from qallm.llm.transcript import (
     TranscriptRecorder,
     active_recorder,
@@ -78,7 +79,7 @@ from qallm.llm.transcript import (
 from qallm.profiles import IMPLEMENTATION_DEFAULT, QualityProfile
 from qallm.utils.reporter import QualityReporter
 from qallm.verification.models import OracleType, TestedCodeUnit
-from qallm.verification.test_persistence import TestStabilityConfig
+from test_persistence import TestStabilityConfig
 from qallm.verification.verification_manager import VerificationManager
 from qallm.analysis.analysis_manager import AnalysisManager
 from qallm.repair.repair_manager import RepairManager
@@ -97,6 +98,7 @@ LLM_PROVIDERS = {
     "ollama": OllamaModel,
     "openai": OpenAIModel,
     "anthropic": AnthropicModel,
+    "fedllm": FedLLMModel,
 }
 
 

--- a/src/qallm/run_qallm.py
+++ b/src/qallm/run_qallm.py
@@ -20,7 +20,7 @@ def main():
                         choices=["feedback", "rl", "oneshot", "hypothesis"],
                         help="Verification strategy ablation (default: feedback; "
                              "'rl' is a back-compat alias for 'feedback')")
-    parser.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama"])
+    parser.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama", "fedllm"])
     parser.add_argument("--model", default=None, help="Specific model name (e.g. gpt-4o-mini)")
     parser.add_argument("--rounds", type=int, default=5, help="Iterative feedback rounds (default: 5)")
     parser.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])

--- a/tests/test_fedllm_catalog.py
+++ b/tests/test_fedllm_catalog.py
@@ -1,0 +1,36 @@
+"""FedLLM appears in the web UI model catalog and availability is correct."""
+
+from qallm.api.core import MODEL_CATALOG, check_model_available, parse_model_id
+from qallm.config import settings
+
+
+def test_fedllm_in_catalog():
+    providers = {e["provider"] for e in MODEL_CATALOG}
+    assert "fedllm" in providers
+    fed = [e for e in MODEL_CATALOG if e["provider"] == "fedllm"]
+    assert any(e["model"] == "gpt-oss-120b" for e in fed)
+
+
+def test_fedllm_availability_follows_key(monkeypatch):
+    entry = {"provider": "fedllm"}
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", None)
+    assert check_model_available(entry) is False
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", "sk-fed")
+    assert check_model_available(entry) is True
+
+
+def test_parse_fedllm_model_id():
+    assert parse_model_id("fedllm:gpt-oss-120b") == ("fedllm", "gpt-oss-120b")
+
+
+def test_models_endpoint_lists_fedllm(monkeypatch):
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", "sk-fed")
+    from fastapi.testclient import TestClient
+    from qallm.api.main import app
+    client = TestClient(app)
+    res = client.get("/api/verification/models")
+    assert res.status_code == 200
+    models = res.json()["models"]
+    fed = [m for m in models if m["provider"] == "fedllm"]
+    assert fed, "FedLLM models should be listed"
+    assert all(m["available"] for m in fed), "should be available when key is set"

--- a/tests/test_fedllm_provider.py
+++ b/tests/test_fedllm_provider.py
@@ -1,0 +1,62 @@
+"""Tests for the FedLLM (EGI) OpenAI-compatible provider."""
+
+from unittest.mock import patch, MagicMock
+
+from qallm.llm.fedllm_provider import FedLLMModel
+from qallm.config import settings
+
+
+def test_default_model_from_settings():
+    assert FedLLMModel().name() == settings.FEDLLM_MODEL
+
+
+def test_explicit_model_id_overrides_default():
+    assert FedLLMModel("gpt-oss-20b").name() == "gpt-oss-20b"
+
+
+def test_provider_label_is_fedllm():
+    assert FedLLMModel()._provider_label() == "fedllm"
+
+
+def test_is_configured_follows_fedllm_key(monkeypatch):
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", None)
+    assert FedLLMModel().is_configured() is False
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", "sk-test")
+    assert FedLLMModel().is_configured() is True
+
+
+def test_is_configured_independent_of_openai_key(monkeypatch):
+    monkeypatch.setattr(settings, "OPENAI_API_KEY", "sk-openai")
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", None)
+    assert FedLLMModel().is_configured() is False
+
+
+def test_build_client_uses_fedllm_base_url_and_key(monkeypatch):
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", "sk-fed")
+    monkeypatch.setattr(settings, "FEDLLM_BASE_URL", "https://llm.ai.egi.eu/v1")
+    captured = {}
+
+    class FakeOpenAI:
+        def __init__(self, api_key=None, base_url=None):
+            captured["api_key"] = api_key
+            captured["base_url"] = base_url
+
+    fake_openai = MagicMock()
+    fake_openai.OpenAI = FakeOpenAI
+    with patch.dict("sys.modules", {"openai": fake_openai}):
+        FedLLMModel()._build_client()
+    assert captured["api_key"] == "sk-fed"
+    assert captured["base_url"] == "https://llm.ai.egi.eu/v1"
+
+
+def test_unconfigured_chat_returns_clean_error(monkeypatch):
+    monkeypatch.setattr(settings, "FEDLLM_API_KEY", None)
+    resp = FedLLMModel().chat("sys", "user")
+    assert resp.error is not None
+    assert resp.provider == "fedllm"
+    assert resp.content == ""
+
+
+def test_registered_in_provider_map():
+    from qallm.orchestrator import LLM_PROVIDERS
+    assert LLM_PROVIDERS["fedllm"] is FedLLMModel

--- a/web/frontend/src/screens/UploadScreen.tsx
+++ b/web/frontend/src/screens/UploadScreen.tsx
@@ -223,7 +223,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
           </select>
           {selectedModel && !selectedModel.available && (
             <p className="text-xs text-red-500">
-              Set {selectedModel.provider === "openai" ? "OPENAI_API_KEY" : selectedModel.provider === "anthropic" ? "ANTHROPIC_API_KEY" : "OLLAMA_BASE_URL"} to enable this model.
+              Set {({ openai: "OPENAI_API_KEY", anthropic: "ANTHROPIC_API_KEY", ollama: "OLLAMA_BASE_URL", fedllm: "FEDLLM_API_KEY" }[selectedModel.provider]) ?? "the provider's API key"} to enable this model.
             </p>
           )}
         </div>


### PR DESCRIPTION
Branch: `feature/fedllm-provider` (off `dev`, after #87)
**1 commit.** Suite: **510 passed** (502 + 8 new), ruff clean.

Adds EGI's FedLLM as a fourth LLM provider. The happy surprise: FedLLM is **OpenAI-compatible** (LiteLLM gateway over vLLM), base URL `https://llm.ai.egi.eu/v1`, `Authorization: Bearer <key>`, standard `/chat/completions`. So this is a thin, low-risk addition, not a new client.

## What changed

- **Refactored `OpenAIModel`** to make two things overridable: `_build_client()` (how the OpenAI-compatible client is constructed) and `_provider_label()` (the tag on responses). OpenAI behaviour is unchanged; this just creates a clean seam.
- **New `FedLLMModel`** subclasses it and overrides only the endpoint, key, default model, and label. It reuses all the chat logic, token tracking, gpt-5 handling, and error paths.
- **Config**: `FEDLLM_API_KEY`, `FEDLLM_BASE_URL` (default `https://llm.ai.egi.eu/v1`), `FEDLLM_MODEL` (default `gpt-oss-120b`).
- **Wiring**: registered `"fedllm"` in the orchestrator provider map; added to `--llm` choices in the CLI and the Jupyter magic.
- **`.env.example`**: documents the three variables and where to get a key.

`FedLLMModel.is_configured()` reads the FedLLM key only, so it is not falsely considered ready just because `OPENAI_API_KEY` happens to be set (there is a test for exactly this).

### Extra changes
 
- **`src/qallm/api/core.py`**: added two FedLLM entries to `MODEL_CATALOG` (`gpt-oss-120b`, `gpt-oss-20b`), a `fedllm` branch in `check_model_available` (reads `FEDLLM_API_KEY`), and `fedllm` in the `parse_model_id` prefix list so a `fedllm:model` id round-trips.
- **`web/frontend/src/screens/UploadScreen.tsx`**: the "set X to enable this model" hint had a hardcoded three-way ternary that would have mislabeled FedLLM as needing `OLLAMA_BASE_URL`. Replaced with a provider→env-var map covering all four (now shows `FEDLLM_API_KEY`).
- **`tests/test_fedllm_catalog.py`** (new): asserts FedLLM is in the catalog, availability follows the key, the id parses, and `/api/verification/models` actually lists FedLLM as available when the key is set.

## Cost

FedLLM models aren't in `MODEL_RATES`, so `calculate_cost_usd` returns `0.0` for them, which is correct since the service is free. No change needed; the budget caps still apply on tokens/time/rounds.

## How to use it (on the VM)

In `.env`:
```
FEDLLM_API_KEY=sk-...            # the key Nafis provided
FEDLLM_MODEL=gpt-oss-120b        # or another model the VO exposes
```
Then:
```
qallm <source> --strategy feedback --llm fedllm --rounds 5
```

## Smoke-test before a full run (do this first on the VM)

Confirm the key and endpoint work, and see which models your VO actually exposes:
```
# list models
curl https://llm.ai.egi.eu/v1/models -H "Authorization: Bearer $FEDLLM_API_KEY" | jq .

# one completion
curl https://llm.ai.egi.eu/v1/chat/completions \
  -H "Authorization: Bearer $FEDLLM_API_KEY" \
  -H "Content-Type: application/json" \
  -d '{"model":"gpt-oss-120b","messages":[{"role":"user","content":"Hello!"}]}' | jq .
```
If `/v1/models` lists a different set than expected, set `FEDLLM_MODEL` to one of those. The docs note available models vary by VO and there may be rate limits, so for the full HumanEvalFix run, start with a small `--sample`/few notebooks to gauge latency and limits before the whole dataset.

I verified from here that `https://llm.ai.egi.eu/v1/models` is reachable and responds (403 to an unauthenticated request, which is the right behaviour). I did not make an authenticated call with Nafis's key from the sandbox; the integration is covered by unit tests that assert the client is built with the FedLLM base URL and key.

## Verify locally

```
pip install -e . --break-system-packages
pytest -q tests/test_fedllm_provider.py    # 8 passed
pytest -q                                  # 510 passed
ruff check src/qallm
```
