### PR TITLE
Review: skip non-analyzable units + orchestrator import fix

### DIFF
--- a/src/qallm/ingestion/ingestion_manager.py
+++ b/src/qallm/ingestion/ingestion_manager.py
@@ -1,4 +1,5 @@
 import os
+import logging
 import tempfile
 import zipfile
 from pathlib import Path
@@ -7,6 +8,9 @@ import git  # Requires pip install gitpython
 
 from qallm.common.model import CodeUnit
 from qallm.ingestion.ingestion_model import NotebookAdapter
+from qallm.ingestion.triviality import assess_triviality
+
+logger = logging.getLogger(__name__)
 
 
 class IngestionManager:
@@ -14,9 +18,20 @@ class IngestionManager:
 
     def __init__(self):
         self.nb_adapter = NotebookAdapter()
+        # Units skipped as non-analyzable, recorded for auditability and
+        # reporting (e.g. "N files skipped, nothing to verify").
+        self.skipped: list[dict] = []
 
     def collect(self, source: str) -> List[CodeUnit]:
-        """Collects units from single files, directories, ZIPs, or GitHub URLs."""
+        """Collect analyzable units from files, directories, ZIPs, or git URLs.
+
+        Units with nothing to analyze (empty or import-only files, the bare
+        __init__.py case) are filtered out so they do not consume analysis,
+        test-generation, and LLM-repair resources or skew the metrics.
+        """
+        return self._filter_trivial(self._collect_raw(source))
+
+    def _collect_raw(self, source: str) -> List[CodeUnit]:
         if source.startswith(("http://", "https://")):
             return self._handle_git(source)
 
@@ -31,6 +46,25 @@ class IngestionManager:
             with open(path, 'r') as f:
                 return [CodeUnit(f.read(), 0, path)]
         return []
+
+    def _filter_trivial(self, units: List[CodeUnit]) -> List[CodeUnit]:
+        kept: List[CodeUnit] = []
+        for unit in units:
+            verdict = assess_triviality(unit.source_code)
+            if verdict.is_trivial:
+                self.skipped.append({
+                    "path": str(unit.original_path),
+                    "cell_index": unit.cell_index,
+                    "reason": verdict.reason,
+                })
+                logger.info("Skipping non-analyzable unit %s (cell %s): %s",
+                            unit.original_path, unit.cell_index, verdict.reason)
+            else:
+                kept.append(unit)
+        if self.skipped:
+            logger.info("Ingestion skipped %d non-analyzable unit(s); kept %d.",
+                        len(self.skipped), len(kept))
+        return kept
 
     def _handle_git(self, url: str) -> List[CodeUnit]:
         tmp_dir = tempfile.mkdtemp()

--- a/src/qallm/ingestion/triviality.py
+++ b/src/qallm/ingestion/triviality.py
@@ -1,0 +1,88 @@
+"""Detect code units with nothing to analyze, so they can be skipped.
+
+Empty and import-only files (a bare ``__init__.py`` is the canonical case)
+have no functions, classes, or executable logic. Running them through static
+analysis, test generation, and LLM repair rounds costs API tokens and time,
+and pollutes the metric denominators with units that could never have a
+finding or a verifiable defect. Skipping them at ingestion keeps the metrics
+honest (a file with nothing to verify should not count as verified) and
+saves resources.
+
+"Trivial" is defined structurally from the AST, not by byte length: a unit
+is trivial when it contains no function or class definitions and no
+executable statements beyond the inert scaffolding that carries no logic to
+verify, namely module docstrings, imports, ``pass``, ``...`` (Ellipsis), and
+dunder/``__all__`` assignments of literals. Anything with a real statement
+(a call, a loop, a non-trivial assignment, a conditional) is kept.
+
+If the source does not parse, it is NOT treated as trivial: a syntax error
+is a real signal the pipeline should see, not a unit to silently drop.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+
+@dataclass
+class TrivialityResult:
+    is_trivial: bool
+    reason: str  # human-readable, recorded for auditability
+
+
+def _is_inert_statement(node: ast.stmt) -> bool:
+    """True if a top-level statement carries no logic to verify."""
+    # Imports: structural, nothing to execute meaningfully.
+    if isinstance(node, (ast.Import, ast.ImportFrom)):
+        return True
+    # Bare pass / Ellipsis (...) expression.
+    if isinstance(node, ast.Pass):
+        return True
+    if isinstance(node, ast.Expr):
+        value = node.value
+        # Module docstring or a bare string/constant expression (e.g. ...).
+        if isinstance(value, ast.Constant):
+            return True
+        return False
+    # __all__ = [...] or other dunder assignment to a literal: metadata only.
+    if isinstance(node, (ast.Assign, ast.AnnAssign)):
+        targets = node.targets if isinstance(node, ast.Assign) else [node.target]
+        names = [t.id for t in targets if isinstance(t, ast.Name)]
+        is_dunder = bool(names) and all(
+            n.startswith("__") and n.endswith("__") or n == "__all__" for n in names
+        )
+        value = node.value
+        is_literal = value is None or isinstance(
+            value, (ast.Constant, ast.List, ast.Tuple, ast.Set, ast.Dict)
+        )
+        if is_dunder and is_literal:
+            return True
+        return False
+    return False
+
+
+def assess_triviality(source_code: str) -> TrivialityResult:
+    """Decide whether a unit has nothing worth running through the pipeline."""
+    if not source_code or not source_code.strip():
+        return TrivialityResult(True, "Empty file (no content).")
+
+    try:
+        tree = ast.parse(source_code)
+    except SyntaxError:
+        # A syntax error is a real finding; do not skip it.
+        return TrivialityResult(False, "Source does not parse; kept for analysis.")
+
+    # Any function or class is analyzable by definition.
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            return TrivialityResult(False, "Contains functions or classes.")
+
+    # No defs: trivial only if every top-level statement is inert.
+    non_inert = [n for n in tree.body if not _is_inert_statement(n)]
+    if not non_inert:
+        return TrivialityResult(
+            True, "No functions, classes, or executable statements (imports/comments only)."
+        )
+
+    return TrivialityResult(False, "Contains executable statements.")

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -79,7 +79,7 @@ from qallm.llm.transcript import (
 from qallm.profiles import IMPLEMENTATION_DEFAULT, QualityProfile
 from qallm.utils.reporter import QualityReporter
 from qallm.verification.models import OracleType, TestedCodeUnit
-from test_persistence import TestStabilityConfig
+from qallm.verification.test_persistence import TestStabilityConfig
 from qallm.verification.verification_manager import VerificationManager
 from qallm.analysis.analysis_manager import AnalysisManager
 from qallm.repair.repair_manager import RepairManager
@@ -710,6 +710,8 @@ class QALLMOrchestrator:
             # sync with the profile definition without us inventing fields.
             "profile": self.profile.to_dict(),
             "units_analyzed": len(units),
+            "units_skipped": len(self.ingestion_manager.skipped),
+            "skipped_units": self.ingestion_manager.skipped,
             "functions_verified": len(sessions_data),
             "rounds_accepted_total": total_accepted,
             "rounds_abandoned_total": total_abandoned,

--- a/tests/test_ingestion_skip_trivial.py
+++ b/tests/test_ingestion_skip_trivial.py
@@ -1,0 +1,54 @@
+"""IngestionManager filters non-analyzable units and records what it skipped."""
+
+import os
+import tempfile
+from pathlib import Path
+
+from qallm.ingestion.ingestion_manager import IngestionManager
+
+
+def _write(d, name, content):
+    p = Path(d) / name
+    p.write_text(content)
+    return p
+
+
+def test_directory_scan_skips_empty_and_import_only():
+    with tempfile.TemporaryDirectory() as d:
+        _write(d, "__init__.py", "")                       # empty -> skip
+        _write(d, "exports.py", "from .core import A\n")   # import-only -> skip
+        _write(d, "core.py", "def a():\n    return 1\n")   # real -> keep
+        mgr = IngestionManager()
+        units = mgr.collect(d)
+        kept_paths = {Path(u.original_path).name for u in units}
+        assert kept_paths == {"core.py"}
+        assert len(mgr.skipped) == 2
+        reasons = {s["path"].split("/")[-1]: s["reason"] for s in mgr.skipped}
+        assert "__init__.py" in reasons and "exports.py" in reasons
+
+
+def test_single_empty_file_yields_no_units():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, "empty.py", "# just a header comment\n")
+        mgr = IngestionManager()
+        units = mgr.collect(str(p))
+        assert units == []
+        assert len(mgr.skipped) == 1
+
+
+def test_real_file_is_kept():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, "logic.py", "def f(x):\n    return x * 2\n")
+        mgr = IngestionManager()
+        units = mgr.collect(str(p))
+        assert len(units) == 1
+        assert mgr.skipped == []
+
+
+def test_syntax_error_file_is_not_skipped():
+    with tempfile.TemporaryDirectory() as d:
+        p = _write(d, "broken.py", "def f(:\n    pass\n")
+        mgr = IngestionManager()
+        units = mgr.collect(str(p))
+        assert len(units) == 1          # kept: a syntax error is a real signal
+        assert mgr.skipped == []

--- a/tests/test_triviality.py
+++ b/tests/test_triviality.py
@@ -1,0 +1,89 @@
+"""Tests for the triviality detector (skipping non-analyzable units)."""
+
+from qallm.ingestion.triviality import assess_triviality
+
+
+# ── trivial cases (should be skipped) ──
+
+def test_empty_string():
+    assert assess_triviality("").is_trivial
+
+
+def test_whitespace_only():
+    assert assess_triviality("   \n\n  \t\n").is_trivial
+
+
+def test_comment_only():
+    assert assess_triviality("# just a comment\n# another\n").is_trivial
+
+
+def test_module_docstring_only():
+    assert assess_triviality('"""A package."""\n').is_trivial
+
+
+def test_import_only_init():
+    src = "from .core import Thing\nimport os\n"
+    assert assess_triviality(src).is_trivial
+
+
+def test_all_declaration_only():
+    src = '"""pkg."""\nfrom .x import A, B\n__all__ = ["A", "B"]\n'
+    assert assess_triviality(src).is_trivial
+
+
+def test_dunder_version_only():
+    src = '__version__ = "1.0.0"\n__author__ = "x"\n'
+    assert assess_triviality(src).is_trivial
+
+
+def test_pass_and_ellipsis():
+    assert assess_triviality("pass\n").is_trivial
+    assert assess_triviality("...\n").is_trivial
+
+
+# ── non-trivial cases (must be kept) ──
+
+def test_function_kept():
+    assert not assess_triviality("def f():\n    return 1\n").is_trivial
+
+
+def test_class_kept():
+    assert not assess_triviality("class C:\n    pass\n").is_trivial
+
+
+def test_executable_statement_kept():
+    # A real call at module level is logic worth analyzing.
+    assert not assess_triviality("print('hi')\n").is_trivial
+
+
+def test_loop_kept():
+    assert not assess_triviality("for i in range(3):\n    print(i)\n").is_trivial
+
+
+def test_real_assignment_kept():
+    # Non-dunder computed assignment is logic.
+    assert not assess_triviality("x = compute() + 1\n").is_trivial
+
+
+def test_conditional_kept():
+    assert not assess_triviality("if True:\n    do()\n").is_trivial
+
+
+def test_all_with_function_kept():
+    src = '"""pkg."""\n__all__ = ["f"]\ndef f():\n    return 1\n'
+    assert not assess_triviality(src).is_trivial
+
+
+# ── syntax errors must NOT be skipped ──
+
+def test_syntax_error_is_kept():
+    res = assess_triviality("def broken(:\n    pass\n")
+    assert not res.is_trivial
+    assert "parse" in res.reason.lower()
+
+
+# ── reason is populated for auditability ──
+
+def test_reason_present_for_trivial():
+    assert assess_triviality("").reason
+    assert assess_triviality("import os\n").reason


### PR DESCRIPTION
Branch: `feature/skip-trivial-units` (off `dev`, after #88)

Two related correctness/efficiency changes.

1. Fix a broken import in the orchestrator. It did a bare top-level `from test_persistence import TestStabilityConfig`, which only resolved when the working directory happened to expose that path. It broke test collection for every module importing the orchestrator (12 collection errors) and would have failed in the Docker container. Corrected to `from qallm.verification.test_persistence import TestStabilityConfig`.

2. Skip units with nothing to analyze. Empty and import-only files (the bare __init__.py case) have no functions, classes, or executable logic, yet they were run through static analysis, test generation, and LLM repair rounds, costing tokens and time and polluting the metric denominators (a file with nothing to verify should not count as verified).

   New qallm.ingestion.triviality.assess_triviality decides triviality structurally from the AST, not by byte length: trivial means no function/class definitions and no executable statements beyond inert scaffolding (module docstrings, imports, pass, ..., and dunder/__all__ literal assignments). A syntax error is explicitly NOT trivial: it is a real signal the pipeline should see, never silently dropped.

   IngestionManager.collect now filters trivial units centrally (covering single files, directories, ZIPs, and git sources) and records each skip (path, cell, reason) on `self.skipped` for auditability. The orchestrator surfaces `units_skipped` and `skipped_units` in summary.json, so the thesis can report how many files were non-analyzable.

Tests: test_triviality.py (17 cases: empty/whitespace/comment/docstring/ import-only/__all__/dunder/pass/ellipsis skipped; functions/classes/calls/ loops/conditionals/real-assignments kept; syntax error kept) and test_ingestion_skip_trivial.py (4 cases: directory scan filters, single trivial file yields no units, real file kept, syntax-error file kept). Suite: 535 passed; ruff clean.