### PR TITLE
feat(experiments): batch verification-gap runner over a dataset

### DIFF
--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python3
+"""Run the verification-gap experiment over a dataset of notebooks/scripts.
+
+Examples:
+    # Pilot on a small subset, free FedLLM inference
+    python scripts/run_gap_experiment.py \
+        --dataset data/notebooks_pilot \
+        --output runs/gap_pilot \
+        --llm fedllm \
+        --rounds 3
+
+    # Full dataset
+    python scripts/run_gap_experiment.py \
+        --dataset data/li_notebooks \
+        --output runs/gap_full \
+        --llm fedllm \
+        --rounds 5
+
+Produces results.jsonl (per input, resumable), aggregate.json (count-weighted
+verification-gap rate across the dataset), and metrics.csv. See
+docs/experiments/protocol.md for how this fits the thesis evaluation.
+"""
+
+import argparse
+import logging
+from pathlib import Path
+
+from qallm.experiments.gap_runner import GapExperimentConfig, run_gap_experiment
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__,
+                                     formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("--dataset", required=True,
+                        help="Directory of notebooks/scripts to run.")
+    parser.add_argument("--output", required=True,
+                        help="Directory for results.jsonl, aggregate.json, metrics.csv.")
+    parser.add_argument("--llm", default="fedllm",
+                        choices=["openai", "anthropic", "ollama", "fedllm"])
+    parser.add_argument("--model", default=None,
+                        help="Model id; defaults to the provider's configured model.")
+    parser.add_argument("--strategy", default="feedback",
+                        choices=["feedback", "rl", "oneshot", "hypothesis"])
+    parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--oracle", default="crash",
+                        choices=["crash", "property", "metamorphic"])
+    parser.add_argument("--judge-strategy", default="lexicographic",
+                        choices=["strict", "lexicographic", "model"])
+    parser.add_argument("--stage", default="implementation",
+                        choices=["initialization", "implementation", "publication"])
+    parser.add_argument("--pattern", default="*.ipynb",
+                        help="Glob for dataset files (default *.ipynb; use *.py for scripts).")
+    parser.add_argument("--log-level", default="INFO",
+                        choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    args = parser.parse_args()
+
+    logging.basicConfig(level=getattr(logging, args.log_level),
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+
+    config = GapExperimentConfig(
+        dataset_dir=Path(args.dataset),
+        output_dir=Path(args.output),
+        llm_type=args.llm,
+        model_name=args.model,
+        strategy=args.strategy,
+        rounds=args.rounds,
+        oracle=args.oracle,
+        judge_strategy=args.judge_strategy,
+        stage=args.stage,
+        pattern=args.pattern,
+    )
+    result = run_gap_experiment(config)
+
+    agg = result.aggregate
+    print("\n=== Verification-gap experiment complete ===")
+    print(f"Sessions: {len(result.per_session)}   Errors: {len(result.errors)}")
+    rate = agg.get("verification_gap_rate")
+    print(f"Verification gap rate: {rate if rate is not None else 'n/a (no denominator)'}")
+    print(f"Execution-only bugs: {agg.get('total_execution_only_bugs')}   "
+          f"Confirmed findings: {agg.get('total_confirmed_findings')}")
+    print(f"Outputs in: {args.output}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/qallm/analysis/gap_analysis.py
+++ b/src/qallm/analysis/gap_analysis.py
@@ -232,3 +232,63 @@ def build_gap_report(
     report.execution_only_functions.sort()
 
     return report
+
+
+def compute_gap_rounds_from_dir(report_dir: str) -> list[dict]:
+    """Per-round gap dicts from a session's persisted round artefacts.
+
+    Reads each round's source.py, static.json, and verification.json from the
+    session's report directory (lineage/ accepted and abandoned/ rejected
+    variants), classifies findings per unit, and merges per round. Pure disk
+    reading with no API dependency, so it is usable by the web layer and by
+    batch experiment runners alike.
+    """
+    import json
+    import os
+
+    def _read_json(path: str):
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return json.load(fh)
+        except (OSError, json.JSONDecodeError):
+            return None
+
+    def _read_text(path: str) -> str:
+        try:
+            with open(path, encoding="utf-8") as fh:
+                return fh.read()
+        except OSError:
+            return ""
+
+    reports: dict[int, GapReport] = {}
+    for bucket in ("lineage", "abandoned"):
+        bucket_dir = os.path.join(report_dir, bucket)
+        if not os.path.isdir(bucket_dir):
+            continue
+        for round_name in sorted(os.listdir(bucket_dir)):
+            round_path = os.path.join(bucket_dir, round_name)
+            if not os.path.isdir(round_path):
+                continue
+            try:
+                round_no = int(round_name.replace("round_", ""))
+            except ValueError:
+                continue
+            for unit_seg in sorted(os.listdir(round_path)):
+                unit_dir = os.path.join(round_path, unit_seg)
+                if not os.path.isdir(unit_dir):
+                    continue
+                source = _read_text(os.path.join(unit_dir, "source.py"))
+                findings = _read_json(os.path.join(unit_dir, "static.json")) or []
+                verification = _read_json(os.path.join(unit_dir, "verification.json"))
+                if not source and not findings:
+                    continue
+                unit_report = build_gap_report(round_no, source, findings, verification)
+                merged = reports.setdefault(round_no, GapReport(round=round_no))
+                merged.findings.extend(unit_report.findings)
+                merged.execution_only_functions.extend(
+                    unit_report.execution_only_functions
+                )
+
+    for rep in reports.values():
+        rep.execution_only_functions = sorted(set(rep.execution_only_functions))
+    return [reports[k].to_dict() for k in sorted(reports)]

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -18,7 +18,7 @@ from qallm.api.core import (
     get_state,
     sessions,
 )
-from qallm.analysis.gap_analysis import GapReport, build_gap_report
+from qallm.analysis.gap_analysis import compute_gap_rounds_from_dir
 from qallm.metrics_export import (
     aggregate_sessions,
     build_session_metrics,
@@ -278,53 +278,12 @@ def _resolve_report_dir(session_id: str) -> str | None:
 
 
 def _compute_gap_rounds(report_dir: str) -> list[dict]:
-    """Per-round gap dicts from a session's persisted round artefacts."""
-    def _read_json(path: str):
-        try:
-            with open(path, encoding="utf-8") as fh:
-                return json.load(fh)
-        except (OSError, json.JSONDecodeError):
-            return None
+    """Per-round gap dicts from a session's persisted round artefacts.
 
-    def _read_text(path: str) -> str:
-        try:
-            with open(path, encoding="utf-8") as fh:
-                return fh.read()
-        except OSError:
-            return ""
-
-    reports: dict[int, GapReport] = {}
-    for bucket in ("lineage", "abandoned"):
-        bucket_dir = os.path.join(report_dir, bucket)
-        if not os.path.isdir(bucket_dir):
-            continue
-        for round_name in sorted(os.listdir(bucket_dir)):
-            round_path = os.path.join(bucket_dir, round_name)
-            if not os.path.isdir(round_path):
-                continue
-            try:
-                round_no = int(round_name.replace("round_", ""))
-            except ValueError:
-                continue
-            for unit_seg in sorted(os.listdir(round_path)):
-                unit_dir = os.path.join(round_path, unit_seg)
-                if not os.path.isdir(unit_dir):
-                    continue
-                source = _read_text(os.path.join(unit_dir, "source.py"))
-                findings = _read_json(os.path.join(unit_dir, "static.json")) or []
-                verification = _read_json(os.path.join(unit_dir, "verification.json"))
-                if not source and not findings:
-                    continue
-                unit_report = build_gap_report(round_no, source, findings, verification)
-                merged = reports.setdefault(round_no, GapReport(round=round_no))
-                merged.findings.extend(unit_report.findings)
-                merged.execution_only_functions.extend(
-                    unit_report.execution_only_functions
-                )
-
-    for rep in reports.values():
-        rep.execution_only_functions = sorted(set(rep.execution_only_functions))
-    return [reports[k].to_dict() for k in sorted(reports)]
+    Thin wrapper over the shared reader in qallm.analysis.gap_analysis, kept
+    as a module-local name for the existing call sites in this router.
+    """
+    return compute_gap_rounds_from_dir(report_dir)
 
 
 @router.get("/api/session/{session_id}/gap")

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -1,0 +1,235 @@
+"""Batch runner for the verification-gap track over a dataset.
+
+Runs the QALLM pipeline across a directory of notebooks/scripts and produces
+the verification-gap metric for each session plus a count-weighted aggregate,
+turning the per-session work described in the experiment protocol into one
+command. Results stream to JSONL so a long run is resumable, and a final
+aggregate JSON and per-session CSV are written for the thesis.
+
+Scope: this runner produces the verification-gap rate (RQ1), which is derived
+purely from each session's persisted artefacts and needs no extra LLM calls.
+The confirmation rate (RQ2) and verified-fix rate (RQ3) require the on-demand
+confirm/refute and verify-fixes steps, which are per-function and LLM-driven;
+the per-session metric record here leaves those fields null, and the export
+plumbing (qallm.metrics_export) already carries them, so a later pass can fill
+them in without changing this file's output shape.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Optional
+
+from qallm.analysis.gap_analysis import compute_gap_rounds_from_dir
+from qallm.metrics_export import (
+    SessionMetrics,
+    aggregate_sessions,
+    build_session_metrics,
+    to_csv,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class GapExperimentConfig:
+    dataset_dir: Path
+    output_dir: Path
+    llm_type: str = "fedllm"
+    model_name: Optional[str] = None
+    strategy: str = "feedback"
+    rounds: int = 5
+    oracle: str = "crash"
+    judge_strategy: str = "lexicographic"
+    stage: str = "implementation"
+    pattern: str = "*.ipynb"  # which files in the dataset to run
+
+    def to_manifest(self) -> dict:
+        return {
+            "dataset_dir": str(self.dataset_dir),
+            "llm_type": self.llm_type,
+            "model_name": self.model_name,
+            "strategy": self.strategy,
+            "rounds": self.rounds,
+            "oracle": self.oracle,
+            "judge_strategy": self.judge_strategy,
+            "stage": self.stage,
+            "pattern": self.pattern,
+        }
+
+
+@dataclass
+class GapExperimentResult:
+    aggregate: dict
+    per_session: list[dict] = field(default_factory=list)
+    errors: list[dict] = field(default_factory=list)
+
+
+def _discover_inputs(dataset_dir: Path, pattern: str) -> list[Path]:
+    """Every file under dataset_dir matching the pattern, sorted for
+    determinism."""
+    return sorted(dataset_dir.rglob(pattern))
+
+
+def _default_orchestrator_factory(config: GapExperimentConfig):
+    from qallm.orchestrator import QALLMOrchestrator
+    return QALLMOrchestrator(
+        strategy=config.strategy,
+        llm_type=config.llm_type,
+        model_name=config.model_name,
+        rounds_per_function=config.rounds,
+        oracle=config.oracle,
+        judge_strategy=config.judge_strategy,
+        stage=config.stage,
+    )
+
+
+def _completed_inputs(results_path: Path) -> set[str]:
+    """Inputs already recorded in a prior run, for resumability."""
+    done: set[str] = set()
+    if not results_path.exists():
+        return done
+    with open(results_path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                done.add(json.loads(line)["input"])
+            except (json.JSONDecodeError, KeyError):
+                continue
+    return done
+
+
+def run_gap_experiment(
+    config: GapExperimentConfig,
+    orchestrator_factory: Optional[Callable[..., Any]] = None,
+) -> GapExperimentResult:
+    """Run the pipeline over the dataset and produce gap metrics + aggregate.
+
+    Streams one JSON line per input to results.jsonl (resumable), then writes
+    aggregate.json and metrics.csv. Returns the in-memory result too.
+    """
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+    results_path = config.output_dir / "results.jsonl"
+    manifest_path = config.output_dir / "manifest.json"
+
+    with open(manifest_path, "w", encoding="utf-8") as fh:
+        json.dump(config.to_manifest(), fh, indent=2)
+
+    if orchestrator_factory is None:
+        orchestrator_factory = _default_orchestrator_factory
+
+    inputs = _discover_inputs(config.dataset_dir, config.pattern)
+    already = _completed_inputs(results_path)
+    logger.info("Gap experiment: %d input(s) under %s; %d already done.",
+                len(inputs), config.dataset_dir, len(already))
+
+    metrics: list[SessionMetrics] = []
+    errors: list[dict] = []
+
+    # Re-read prior session rows so the aggregate covers the whole run, not
+    # only this invocation's new sessions.
+    for row in _read_jsonl(results_path):
+        if row.get("error"):
+            errors.append(row)
+        elif row.get("metrics"):
+            metrics.append(_metrics_from_dict(row["metrics"]))
+
+    with open(results_path, "a", encoding="utf-8") as out:
+        for input_path in inputs:
+            key = str(input_path)
+            if key in already:
+                continue
+            row = _run_one(input_path, config, orchestrator_factory)
+            out.write(json.dumps(row) + "\n")
+            out.flush()
+            if row.get("error"):
+                errors.append(row)
+            elif row.get("metrics"):
+                metrics.append(_metrics_from_dict(row["metrics"]))
+
+    aggregate = aggregate_sessions(metrics).to_dict()
+    per_session = [m.to_dict() for m in metrics]
+
+    with open(config.output_dir / "aggregate.json", "w", encoding="utf-8") as fh:
+        json.dump(aggregate, fh, indent=2)
+    with open(config.output_dir / "metrics.csv", "w", encoding="utf-8") as fh:
+        fh.write(to_csv(metrics))
+
+    logger.info("Gap experiment complete: %d session(s), %d error(s). "
+                "Aggregate verification_gap_rate=%s",
+                len(metrics), len(errors), aggregate.get("verification_gap_rate"))
+    return GapExperimentResult(aggregate=aggregate, per_session=per_session, errors=errors)
+
+
+def _run_one(
+    input_path: Path,
+    config: GapExperimentConfig,
+    orchestrator_factory: Callable[..., Any],
+) -> dict:
+    """Run one input and build its per-session metrics from the artefacts."""
+    try:
+        orch = orchestrator_factory(config)
+        summary = orch.run(str(input_path))
+        report_dir = summary.get("report_dir")
+        gap_rounds = (
+            compute_gap_rounds_from_dir(report_dir)
+            if report_dir and os.path.isdir(report_dir) else []
+        )
+        session_id = os.path.basename(report_dir) if report_dir else str(input_path)
+        m = build_session_metrics(
+            session_id=session_id,
+            summary=summary,
+            gap_rounds=gap_rounds,
+            confirm_summary=None,   # RQ2/RQ3 not run in this batch pass
+            verify_summary=None,
+        )
+        return {"input": str(input_path), "metrics": m.to_dict(), "error": None}
+    except Exception as e:  # one bad notebook should not sink the run
+        logger.warning("Input failed: %s: %s", input_path, e)
+        return {"input": str(input_path), "metrics": None, "error": str(e)}
+
+
+def _read_jsonl(path: Path) -> list[dict]:
+    rows: list[dict] = []
+    if not path.exists():
+        return rows
+    with open(path, encoding="utf-8") as fh:
+        for line in fh:
+            line = line.strip()
+            if line:
+                try:
+                    rows.append(json.loads(line))
+                except json.JSONDecodeError:
+                    continue
+    return rows
+
+
+def _metrics_from_dict(d: dict) -> SessionMetrics:
+    """Rebuild a SessionMetrics from its to_dict form (for aggregation)."""
+    return SessionMetrics(
+        session_id=d.get("session_id", ""),
+        model=d.get("model", ""),
+        testgen_model=d.get("testgen_model", ""),
+        oracle=d.get("oracle", ""),
+        rounds=int(d.get("rounds", 0) or 0),
+        units_analyzed=int(d.get("units_analyzed", 0) or 0),
+        functions_verified=int(d.get("functions_verified", 0) or 0),
+        cost_usd=float(d.get("cost_usd", 0.0) or 0.0),
+        tokens=int(d.get("tokens", 0) or 0),
+        static_findings=int(d.get("static_findings", 0) or 0),
+        confirmed_findings=int(d.get("confirmed_findings", 0) or 0),
+        execution_only_bugs=int(d.get("execution_only_bugs", 0) or 0),
+        verification_gap_rate=d.get("verification_gap_rate"),
+        confirmed=d.get("confirmed"),
+        refuted=d.get("refuted"),
+        confirmation_rate=d.get("confirmation_rate"),
+        verified_fixed=d.get("verified_fixed"),
+        not_fixed=d.get("not_fixed"),
+        verified_fix_rate=d.get("verified_fix_rate"),
+    )

--- a/tests/test_gap_runner.py
+++ b/tests/test_gap_runner.py
@@ -1,0 +1,131 @@
+"""Tests for the verification-gap batch runner."""
+
+import json
+import os
+from pathlib import Path
+
+from qallm.experiments.gap_runner import (
+    GapExperimentConfig,
+    run_gap_experiment,
+    _discover_inputs,
+)
+
+
+def _make_dataset(tmp_path: Path, names):
+    d = tmp_path / "data"
+    d.mkdir()
+    for n in names:
+        (d / n).write_text("# notebook placeholder\n")
+    return d
+
+
+def _fake_summary(report_dir, gap):
+    """A fake orchestrator that writes gap artefacts and returns a summary."""
+    os.makedirs(os.path.join(report_dir, "lineage", "round_0", "unit"), exist_ok=True)
+    unit = os.path.join(report_dir, "lineage", "round_0", "unit")
+    Path(os.path.join(unit, "source.py")).write_text(gap["source"])
+    Path(os.path.join(unit, "static.json")).write_text(json.dumps(gap["static"]))
+    Path(os.path.join(unit, "verification.json")).write_text(json.dumps(gap["verification"]))
+    return {
+        "report_dir": report_dir,
+        "model": "fedllm/gpt-oss-120b",
+        "oracle": "crash",
+        "rounds_per_function": 5,
+        "units_analyzed": 1,
+        "functions_verified": 1,
+        "cost": {"total_cost_usd": 0.0, "total_tokens": 1234},
+    }
+
+
+class _FakeOrch:
+    def __init__(self, report_root, idx):
+        self._report_root = report_root
+        self._idx = idx
+
+    def run(self, source):
+        rd = os.path.join(self._report_root, f"session_{self._idx}")
+        # One execution-only bug (function f fails), no static finding: a gap.
+        gap = {
+            "source": "def f(x):\n    return x + 1\n",
+            "static": [],
+            "verification": [
+                {"function": "f", "rounds": [
+                    {"execution": {"passed": 0, "failed": 1, "errors": 0}}]},
+            ],
+        }
+        return _fake_summary(rd, gap)
+
+
+def test_discover_inputs_sorted(tmp_path):
+    d = _make_dataset(tmp_path, ["b.ipynb", "a.ipynb", "c.txt"])
+    found = _discover_inputs(d, "*.ipynb")
+    assert [p.name for p in found] == ["a.ipynb", "b.ipynb"]
+
+
+def test_run_produces_aggregate_and_files(tmp_path):
+    d = _make_dataset(tmp_path, ["n1.ipynb", "n2.ipynb"])
+    out = tmp_path / "out"
+    report_root = tmp_path / "reports"
+    report_root.mkdir()
+
+    counter = {"i": 0}
+
+    def factory(config):
+        counter["i"] += 1
+        return _FakeOrch(str(report_root), counter["i"])
+
+    config = GapExperimentConfig(dataset_dir=d, output_dir=out)
+    result = run_gap_experiment(config, orchestrator_factory=factory)
+
+    # Two sessions, each a pure gap (1 execution-only, 0 confirmed) -> rate 1.0
+    assert len(result.per_session) == 2
+    assert result.aggregate["verification_gap_rate"] == 1.0
+    assert (out / "results.jsonl").exists()
+    assert (out / "aggregate.json").exists()
+    assert (out / "metrics.csv").exists()
+    assert (out / "manifest.json").exists()
+
+
+def test_resumability_skips_completed(tmp_path):
+    d = _make_dataset(tmp_path, ["n1.ipynb", "n2.ipynb"])
+    out = tmp_path / "out"
+    report_root = tmp_path / "reports"
+    report_root.mkdir()
+    counter = {"i": 0}
+
+    def factory(config):
+        counter["i"] += 1
+        return _FakeOrch(str(report_root), counter["i"])
+
+    config = GapExperimentConfig(dataset_dir=d, output_dir=out)
+    run_gap_experiment(config, orchestrator_factory=factory)
+    runs_after_first = counter["i"]
+    # Second invocation should skip both completed inputs.
+    run_gap_experiment(config, orchestrator_factory=factory)
+    assert counter["i"] == runs_after_first  # no new orchestrator runs
+
+
+def test_error_isolated_per_input(tmp_path):
+    d = _make_dataset(tmp_path, ["good.ipynb", "bad.ipynb"])
+    out = tmp_path / "out"
+    report_root = tmp_path / "reports"
+    report_root.mkdir()
+
+    class Factory:
+        def __call__(self, config):
+            # Decide good vs bad by the input is not available here, so use a
+            # counter keyed to insertion; inputs are processed sorted, so
+            # "bad.ipynb" (alphabetically first) is run first.
+            self.n = getattr(self, "n", 0) + 1
+            if self.n == 1:
+                class Boom:
+                    def run(self, source):
+                        raise RuntimeError("kernel exploded")
+                return Boom()
+            return _FakeOrch(str(report_root), 1)
+
+    config = GapExperimentConfig(dataset_dir=d, output_dir=out)
+    result = run_gap_experiment(config, orchestrator_factory=Factory())
+    assert len(result.per_session) == 1     # the good one
+    assert len(result.errors) == 1          # the bad one, isolated
+    assert "kernel exploded" in result.errors[0]["error"]


### PR DESCRIPTION
Turns the verification-gap track's per-session work into one command, the engineering item the experiment protocol kept pointing at. Runs the QALLM pipeline across a directory of notebooks/scripts and produces the verification-gap rate per session plus a count-weighted aggregate, so a dataset run yields the headline thesis figure directly.

Refactor (cleaner layering):
* Extracted the gap-reading logic into qallm.analysis.gap_analysis. compute_gap_rounds_from_dir, a pure disk reader. It previously lived as a private function inside the API router (results.py), which meant any batch consumer would have to import from the web layer. The router now calls the shared function; behaviour is unchanged (gap and bug-detail tests pass).

New qallm.experiments.gap_runner:
* run_gap_experiment walks the dataset (sorted glob, deterministic), runs the orchestrator per input, computes the gap rounds from the persisted artefacts, builds per-session metrics via qallm.metrics_export, and aggregates count-weighted.
* Streams one JSON line per input to results.jsonl and is resumable (a second invocation skips inputs already recorded). Re-reads prior rows so the aggregate covers the whole run, not just the latest invocation.
* Errors are isolated per input: one bad notebook is recorded and skipped, not fatal to the run.
* Writes manifest.json, aggregate.json, and metrics.csv.

CLI: scripts/run_gap_experiment.py (--dataset, --output, --llm, --rounds, --oracle, --judge-strategy, --stage, --pattern), defaulting to FedLLM so the dataset run is free.

Honest scope: this pass produces the verification-gap rate (RQ1), which is derived purely from artefacts and needs no extra LLM calls. The confirmation (RQ2) and verified-fix (RQ3) rates require the per-function, LLM-driven confirm/refute and verify-fixes steps; the per-session record leaves those fields null and the export plumbing already carries them, so a later pass can fill them in without changing this runner's output shape.

Tests: test_gap_runner.py (4: sorted discovery, aggregate + output files written, resumability skips completed inputs, per-input error isolation). The fake orchestrator writes real gap artefacts so the tests exercise the actual gap-computation path. Suite: 539 passed; ruff clean.