### PR TITLE
fix(ci): declare pytest-asyncio and set asyncio_mode so async tests run

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,7 @@ dependencies = [
     "hypothesis",
     "pytest",
     "pytest-cov",
+    "pytest-asyncio",
     "pytest-json-report",
     "coverage",
     "scipy",
@@ -43,6 +44,14 @@ jupyter = [
 
 [project.scripts]
 qallm = "qallm.run_qallm:main"
+
+[tool.pytest.ini_options]
+# auto: async test functions are run by pytest-asyncio without each needing an
+# explicit @pytest.mark.asyncio decorator. The async tests in tests/test_jobs.py
+# and tests/test_api_jobs.py rely on this; under the default "strict" mode they
+# would be skipped or errored, so this setting is required for them to run.
+asyncio_mode = "auto"
+testpaths = ["tests"]
 
 [tool.setuptools.packages.find]
 where = ["src"]


### PR DESCRIPTION
CI was red on clean runners: tests/test_jobs.py and tests/test_api_jobs.py import pytest_asyncio, which was not a declared dependency, so a fresh `pip install -e .` did not provide it (it was present only transitively on dev machines). Same class as the earlier undeclared-httpx issue.

Two-part fix, because declaring the package alone is not enough:

1. Added pytest-asyncio to dependencies, so `pip install -e .` (what CI runs) pulls it. This clears the ModuleNotFoundError / collection errors.

2. Set asyncio_mode = "auto" in a new [tool.pytest.ini_options] block. The 21 async tests across those two files are plain `async def test_...` with no @pytest.mark.asyncio decorators; under pytest-asyncio's default "strict" mode they would be skipped or errored rather than run. With auto mode they execute. Without this, CI collection would pass but the async tests would silently not run, which is worse than a visible failure.

Verified by reproducing the failure (force-uninstall pytest-asyncio -> collection error), then `pip install -e .` -> all 21 async tests run and pass. Also added testpaths = ["tests"] to scope discovery.

Suite: 539 passed, no skips.