### PR TITLE
feat(experiments): complete the gap runner with batch

### DIFF
--- a/docs/experiments/protocol.md
+++ b/docs/experiments/protocol.md
@@ -225,18 +225,19 @@ from these artefacts and is always available after a run.
 
 ### 6.3 Confirm/refute and verify-fixes
 
-The confirmation and verified-fix rates require the on-demand steps, which use
-the LLM and so are not run automatically:
+The confirmation (RQ2) and verified-fix (RQ3) rates require generating and
+running targeted tests, which use the LLM, so they are opt-in.
 
-- Confirm/refute: `POST /api/session/{id}/confirm-findings` (or the "Run
-  confirm/refute" action in the web UI gap panel).
-- Verify fixes: `POST /api/session/{id}/verify-fixes` with the confirmed
-  findings (or the "Verify fixes" action).
+For a whole dataset in one command, pass `--confirm` to the batch runner
+(section 6.6); it runs confirm/refute and verify-fixes for every session,
+reconstructing their inputs from the persisted artefacts, and folds all three
+rates into the aggregate. This is the recommended path for the thesis.
 
-These record their summaries on the session so the export includes the
-confirmation and verified-fix rates. Run them for every session that
-contributes those two metrics, or report clearly that a given table reports
-the gap rate only.
+For a single session interactively, the web UI gap panel offers "Run
+confirm/refute" and "Verify fixes" actions (backed by
+`POST /api/session/{id}/confirm-findings` and
+`POST /api/session/{id}/verify-fixes`), useful for inspecting one notebook in
+detail.
 
 ### 6.4 Export and aggregate
 
@@ -264,6 +265,30 @@ For each reported number, record: commit hash, provider and model(s), strategy,
 oracle, rounds, judge, seed (where applicable), dataset subset and size,
 `units_skipped`, and whether confirm/verify were run. State which rates are
 null (no denominator) rather than presenting them as zero.
+
+### 6.6 One command for the whole track
+
+`scripts/run_gap_experiment.py` runs the whole verification-gap track over a
+dataset and writes `results.jsonl` (resumable), `aggregate.json`,
+`metrics.csv`, and `manifest.json`.
+
+```
+# RQ1 only (free, no extra LLM calls): the verification-gap rate
+python scripts/run_gap_experiment.py \
+    --dataset data/li_notebooks --output runs/gap_full \
+    --llm fedllm --rounds 5
+
+# All three metrics (RQ1 + RQ2 + RQ3): adds confirm/refute and verify-fixes
+python scripts/run_gap_experiment.py \
+    --dataset data/li_notebooks --output runs/gap_full_confirmed \
+    --llm fedllm --rounds 5 --confirm
+```
+
+With `--confirm`, the runner reconstructs the confirm/refute and verify-fixes
+inputs from each session's artefacts (round 0 source for confirmation, the
+final accepted source for verified fixes), so one invocation yields all three
+aggregate rates. Without it, only the gap rate is computed. The aggregate is
+count-weighted across sessions.
 
 ## 7. Threats to validity
 

--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -50,6 +50,9 @@ def main() -> None:
                         choices=["initialization", "implementation", "publication"])
     parser.add_argument("--pattern", default="*.ipynb",
                         help="Glob for dataset files (default *.ipynb; use *.py for scripts).")
+    parser.add_argument("--confirm", action="store_true",
+                        help="Also run confirm/refute (RQ2) and verify-fixes (RQ3) per "
+                             "session. Makes extra LLM calls; off by default.")
     parser.add_argument("--log-level", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     args = parser.parse_args()
@@ -68,6 +71,7 @@ def main() -> None:
         judge_strategy=args.judge_strategy,
         stage=args.stage,
         pattern=args.pattern,
+        confirm=args.confirm,
     )
     result = run_gap_experiment(config)
 
@@ -78,6 +82,11 @@ def main() -> None:
     print(f"Verification gap rate: {rate if rate is not None else 'n/a (no denominator)'}")
     print(f"Execution-only bugs: {agg.get('total_execution_only_bugs')}   "
           f"Confirmed findings: {agg.get('total_confirmed_findings')}")
+    if args.confirm:
+        cr = agg.get("confirmation_rate")
+        vr = agg.get("verified_fix_rate")
+        print(f"Confirmation rate: {cr if cr is not None else 'n/a'}   "
+              f"Verified-fix rate: {vr if vr is not None else 'n/a'}")
     print(f"Outputs in: {args.output}")
 
 

--- a/src/qallm/experiments/confirm_verify.py
+++ b/src/qallm/experiments/confirm_verify.py
@@ -1,0 +1,183 @@
+"""Batch confirm/refute and verify-fixes from a session's persisted artefacts.
+
+The web endpoints drive confirm/refute and verify-fixes from in-memory
+session state. The batch runner has no such session: it constructs the
+orchestrator directly and works from what each run persists to disk. This
+module reconstructs the inputs those two steps need purely from the report
+directory, so the batch path produces the same RQ2 (confirmation) and RQ3
+(verified-fix) numbers the UI does, without depending on API session state.
+
+What it reads from the report dir:
+* Baseline (round 0) source and static findings, to confirm/refute each
+  finding against the original code.
+* The final accepted source per unit (the last lineage round), to re-run a
+  confirmed finding's reproducing test against the repaired code.
+
+These steps make LLM calls (the targeted-test generation in confirm/refute),
+so the runner only invokes this when explicitly asked.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+logger = logging.getLogger(__name__)
+
+
+def _read_text(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def _read_json(path: str):
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return json.load(fh)
+    except (OSError, json.JSONDecodeError):
+        return None
+
+
+def _baseline_units(report_dir: str) -> dict[str, dict]:
+    """Map unit name -> {source, findings} from the round_0 (baseline) artefacts.
+
+    Round 0 is the original code before any repair, the right basis for
+    confirm/refute. Looks under lineage/round_0 (baseline is always accepted).
+    """
+    units: dict[str, dict] = {}
+    base = os.path.join(report_dir, "lineage", "round_0")
+    if not os.path.isdir(base):
+        return units
+    for unit_seg in sorted(os.listdir(base)):
+        unit_dir = os.path.join(base, unit_seg)
+        if not os.path.isdir(unit_dir):
+            continue
+        source = _read_text(os.path.join(unit_dir, "source.py"))
+        findings = _read_json(os.path.join(unit_dir, "static.json")) or []
+        if source:
+            units[unit_seg] = {"source": source, "findings": findings}
+    return units
+
+
+def _final_sources(report_dir: str) -> dict[str, str]:
+    """Map unit name -> final accepted source (highest-numbered lineage round).
+
+    The last accepted round is the repaired code, the basis for verify-fixes.
+    """
+    finals: dict[str, str] = {}
+    lineage = os.path.join(report_dir, "lineage")
+    if not os.path.isdir(lineage):
+        return finals
+    round_dirs = []
+    for round_name in os.listdir(lineage):
+        if not round_name.startswith("round_"):
+            continue
+        try:
+            round_dirs.append((int(round_name.replace("round_", "")), round_name))
+        except ValueError:
+            continue
+    for _, round_name in sorted(round_dirs):  # ascending: later overwrites earlier
+        round_path = os.path.join(lineage, round_name)
+        for unit_seg in os.listdir(round_path):
+            unit_dir = os.path.join(round_path, unit_seg)
+            source = _read_text(os.path.join(unit_dir, "source.py"))
+            if source:
+                finals[unit_seg] = source
+    return finals
+
+
+def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None) -> dict:
+    """Run confirm/refute (RQ2) and verify-fixes (RQ3) from disk artefacts.
+
+    Returns {"confirm_summary": {...} | None, "verify_summary": {...} | None}
+    matching the shapes the endpoints record on session state, so
+    build_session_metrics can consume them unchanged. Summaries are None when
+    there was nothing to do (no findings, or no repaired source).
+    """
+    from qallm.verification.confirm_refute import FindingConfirmer
+    from qallm.verification.verified_fix import verify_fixes
+    from qallm.verification.extractor import extract_functions_from_source
+    from qallm.analysis.gap_analysis import function_spans, _function_for_line
+
+    baseline = _baseline_units(report_dir)
+    if not baseline:
+        return {"confirm_summary": None, "verify_summary": None}
+
+    confirmer = FindingConfirmer(testgen_llm, tracker)
+    confirmed = refuted = inconclusive = not_testable = 0
+    confirmed_verdicts: list[dict] = []
+
+    for name, unit in baseline.items():
+        findings = unit["findings"]
+        if not findings:
+            continue
+        source = unit["source"]
+        spans = function_spans(source)
+        funcs = {f.name: f for f in extract_functions_from_source(source, name)}
+        for fname, func in funcs.items():
+            fn_findings = [
+                f for f in findings
+                if _function_for_line(spans, int(f.get("line", 0) or 0)) == fname
+            ]
+            if not fn_findings:
+                continue
+            report = confirmer.confirm_findings(
+                func=func,
+                findings=fn_findings,
+                source_code=source,
+                source_filename=name if name.endswith(".py") else f"{name}.py",
+            )
+            confirmed += report.confirmed
+            refuted += report.refuted
+            inconclusive += report.inconclusive
+            not_testable += report.not_testable
+            for v in report.verdicts:
+                d = v.to_dict()
+                d["file"] = name
+                if d.get("verdict") == "confirmed":
+                    confirmed_verdicts.append(d)
+
+    denom = confirmed + refuted
+    confirm_summary = {
+        "confirmed": confirmed,
+        "refuted": refuted,
+        "inconclusive": inconclusive,
+        "not_execution_testable": not_testable,
+        "confirmation_rate": (confirmed / denom) if denom else None,
+    }
+
+    # Verify fixes: re-run each confirmed finding's reproducing test against
+    # the final (repaired) source for its unit.
+    verify_summary = None
+    if confirmed_verdicts:
+        finals = _final_sources(report_dir)
+        by_file: dict[str, list[dict]] = {}
+        for f in confirmed_verdicts:
+            by_file.setdefault(f.get("file") or "", []).append(f)
+        verified_fixed = not_fixed = vinconclusive = 0
+        for name, file_findings in by_file.items():
+            repaired_source = finals.get(name)
+            if not repaired_source:
+                vinconclusive += len(file_findings)
+                continue
+            report = verify_fixes(
+                confirmed_findings=file_findings,
+                repaired_source=repaired_source,
+                source_filename=name if name.endswith(".py") else f"{name}.py",
+            )
+            verified_fixed += report.verified_fixed
+            not_fixed += report.not_fixed
+            vinconclusive += report.inconclusive
+        vdenom = verified_fixed + not_fixed
+        verify_summary = {
+            "verified_fixed": verified_fixed,
+            "not_fixed": not_fixed,
+            "inconclusive": vinconclusive,
+            "verified_fix_rate": (verified_fixed / vdenom) if vdenom else None,
+        }
+
+    return {"confirm_summary": confirm_summary, "verify_summary": verify_summary}

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -6,13 +6,13 @@ turning the per-session work described in the experiment protocol into one
 command. Results stream to JSONL so a long run is resumable, and a final
 aggregate JSON and per-session CSV are written for the thesis.
 
-Scope: this runner produces the verification-gap rate (RQ1), which is derived
-purely from each session's persisted artefacts and needs no extra LLM calls.
-The confirmation rate (RQ2) and verified-fix rate (RQ3) require the on-demand
-confirm/refute and verify-fixes steps, which are per-function and LLM-driven;
-the per-session metric record here leaves those fields null, and the export
-plumbing (qallm.metrics_export) already carries them, so a later pass can fill
-them in without changing this file's output shape.
+Scope: by default this runner produces the verification-gap rate (RQ1),
+which is derived purely from each session's persisted artefacts and needs no
+extra LLM calls. With confirm=True (the --confirm CLI flag) it also runs
+confirm/refute (RQ2) and verify-fixes (RQ3) per session, reconstructing their
+inputs from the same artefacts (see qallm.experiments.confirm_verify); those
+steps make LLM calls, so they are opt-in. All three rates flow through the
+same per-session record and aggregate.
 """
 
 from __future__ import annotations
@@ -47,6 +47,7 @@ class GapExperimentConfig:
     judge_strategy: str = "lexicographic"
     stage: str = "implementation"
     pattern: str = "*.ipynb"  # which files in the dataset to run
+    confirm: bool = False     # also run confirm/refute + verify-fixes (RQ2/RQ3); costs LLM calls
 
     def to_manifest(self) -> dict:
         return {
@@ -59,6 +60,7 @@ class GapExperimentConfig:
             "judge_strategy": self.judge_strategy,
             "stage": self.stage,
             "pattern": self.pattern,
+            "confirm": self.confirm,
         }
 
 
@@ -182,12 +184,27 @@ def _run_one(
             if report_dir and os.path.isdir(report_dir) else []
         )
         session_id = os.path.basename(report_dir) if report_dir else str(input_path)
+
+        confirm_summary = None
+        verify_summary = None
+        if config.confirm and report_dir and os.path.isdir(report_dir):
+            # RQ2/RQ3: reconstruct inputs from disk and run confirm + verify.
+            # Uses the orchestrator's own test-gen LLM and token tracker.
+            from qallm.experiments.confirm_verify import confirm_and_verify_from_dir
+            cv = confirm_and_verify_from_dir(
+                report_dir,
+                testgen_llm=getattr(orch, "testgen_llm", None) or getattr(orch, "llm", None),
+                tracker=getattr(orch, "tracker", None),
+            )
+            confirm_summary = cv["confirm_summary"]
+            verify_summary = cv["verify_summary"]
+
         m = build_session_metrics(
             session_id=session_id,
             summary=summary,
             gap_rounds=gap_rounds,
-            confirm_summary=None,   # RQ2/RQ3 not run in this batch pass
-            verify_summary=None,
+            confirm_summary=confirm_summary,
+            verify_summary=verify_summary,
         )
         return {"input": str(input_path), "metrics": m.to_dict(), "error": None}
     except Exception as e:  # one bad notebook should not sink the run

--- a/tests/test_confirm_verify_batch.py
+++ b/tests/test_confirm_verify_batch.py
@@ -1,0 +1,82 @@
+"""Tests for the batch confirm/verify-from-disk helper."""
+
+import json
+import os
+from pathlib import Path
+
+from qallm.experiments.confirm_verify import (
+    _baseline_units,
+    _final_sources,
+    confirm_and_verify_from_dir,
+)
+
+
+def _make_session(tmp_path: Path):
+    """A report dir with a baseline (round_0) and a repaired (round_1)."""
+    rd = tmp_path / "session_1"
+    base = rd / "lineage" / "round_0" / "unit"
+    base.mkdir(parents=True)
+    (base / "source.py").write_text("def f(x):\n    return x - 1\n")
+    (base / "static.json").write_text(json.dumps([
+        {"tool": "sonar", "type": "RELIABILITY", "severity": "HIGH",
+         "line": 2, "message": "off-by-one", "rule_id": "S1"},
+    ]))
+    repaired = rd / "lineage" / "round_1" / "unit"
+    repaired.mkdir(parents=True)
+    (repaired / "source.py").write_text("def f(x):\n    return x + 1\n")
+    (repaired / "static.json").write_text(json.dumps([]))
+    return rd
+
+
+def test_baseline_units_reads_round_0(tmp_path):
+    rd = _make_session(tmp_path)
+    units = _baseline_units(str(rd))
+    assert "unit" in units
+    assert "x - 1" in units["unit"]["source"]
+    assert len(units["unit"]["findings"]) == 1
+
+
+def test_final_sources_takes_latest_round(tmp_path):
+    rd = _make_session(tmp_path)
+    finals = _final_sources(str(rd))
+    # round_1 is later than round_0, so the repaired source wins.
+    assert "x + 1" in finals["unit"]
+
+
+def test_empty_report_dir_returns_none_summaries(tmp_path):
+    rd = tmp_path / "empty"
+    rd.mkdir()
+    out = confirm_and_verify_from_dir(str(rd), testgen_llm=None)
+    assert out["confirm_summary"] is None
+    assert out["verify_summary"] is None
+
+
+class _FakeLLM:
+    """Returns a reproducing test that fails on the buggy code (x - 1) and
+    passes on the repaired code (x + 1), so the finding confirms and the fix
+    verifies."""
+    def chat(self, system, prompt, tracker=None):
+        class R:
+            content = (
+                "```python\n"
+                "def test_f_off_by_one():\n"
+                "    assert f(3) == 4\n"
+                "```\n"
+            )
+            error = None
+            input_tokens = 0
+            output_tokens = 0
+        return R()
+
+
+def test_confirm_and_verify_end_to_end(tmp_path):
+    rd = _make_session(tmp_path)
+    out = confirm_and_verify_from_dir(str(rd), testgen_llm=_FakeLLM())
+    cs = out["confirm_summary"]
+    assert cs is not None
+    # The reliability finding should confirm (test fails on x - 1).
+    assert cs["confirmed"] >= 1
+    vs = out["verify_summary"]
+    assert vs is not None
+    # And the fix should verify (same test passes on x + 1).
+    assert vs["verified_fixed"] >= 1


### PR DESCRIPTION
 confirm/verify (RQ2+RQ3)

The gap runner produced only RQ1 (verification-gap rate); RQ2 (confirmation) and RQ3 (verified-fix) still needed manual per-session clicking in the UI. This completes the verification-gap track so one command yields all three aggregate rates for the thesis.

New qallm.experiments.confirm_verify:
* Reconstructs confirm/refute and verify-fixes inputs from a session's persisted artefacts rather than from API session state, keeping the batch path artefact-driven and consistent with how the gap rate is computed.
* Confirms each finding against the round-0 (baseline) source; verifies fixes by re-running each confirmed finding's reproducing test against the final accepted (repaired) source.
* Returns confirm_summary / verify_summary in the same shapes the endpoints record, so build_session_metrics consumes them unchanged.

gap_runner: GapExperimentConfig gains `confirm` (off by default, since it makes LLM calls). When set, _run_one runs confirm/verify per session using the orchestrator's own testgen LLM and tracker, and folds all three rates into the per-session record and the count-weighted aggregate.

CLI: scripts/run_gap_experiment.py gains --confirm and prints the confirmation and verified-fix rates when it is set.

docs/experiments/protocol.md: section 6.3 rewritten (batch --confirm is the recommended path; the UI actions are for single-session inspection) and a new 6.6 showing the one-command invocations for RQ1-only and all-three.

Caught during testing: the confirmer needs a .py source filename or its generated test fails to import the function (silently yielding confirmed=0). The helper now ensures the suffix; a test pins the end-to-end confirm+verify path against real before/after sources.

Tests: test_confirm_verify_batch.py (4: baseline-units reader, final-source reader takes the latest round, empty dir yields null summaries, end-to-end confirm + verify with a fake LLM returning a real reproducing test). Suite: 543 passed; ruff clean.