### PR TITLE
fix(report): show each round's actual repaired source per function

### DIFF
--- a/src/qallm/verification/verification_manager.py
+++ b/src/qallm/verification/verification_manager.py
@@ -180,6 +180,16 @@ class VerificationManager:
                 self.store.attach_session(key, session)
             else:
                 session = record.session
+                # The session persists across rounds, but the source it
+                # describes does not: after a repair, this round runs against
+                # the repaired source. Refresh it so the per-round
+                # verification record (and the report's "Function under test"
+                # view) reflects the code actually tested this round, not the
+                # round-0 snapshot frozen at session creation. Without this,
+                # a function whose body changed but whose tests did not run
+                # again would display its original (pre-repair) source every
+                # round.
+                session.source_code = source
 
             module_name = f"source_{path.stem}_c{unit.cell_index}"
 

--- a/tests/test_verification_function_filter.py
+++ b/tests/test_verification_function_filter.py
@@ -262,3 +262,50 @@ class TestOriginalOnlyFiltering:
             ]
             assert "_helper" not in called_func_names
             assert called_func_names == ["add"]
+
+
+class TestSessionSourceRefresh:
+    """The reused per-function session reflects each round's actual source.
+
+    Regression: a function whose body was repaired but whose session is
+    reused across rounds used to keep its round-0 source_code forever, so the
+    report's "Function under test" showed the original (pre-repair) code every
+    round even though the code on disk was correctly repaired.
+    """
+
+    def test_reused_session_source_updates_after_repair(self, tmp_path):
+        path = tmp_path / "demo.py"
+        original_source = "def f(x):\n    return eval(x)\n"
+        repaired_source = "def f(x):\n    return ast.literal_eval(x)\n"
+
+        vm = _make_verification_manager()
+
+        # Round 1 runs against the original source.
+        unit_r1 = _build_repaired_unit(original_source, original_source, path)
+        # Round 2 runs against the repaired source for the same function.
+        unit_r2 = _build_repaired_unit(original_source, repaired_source, path)
+
+        with patch.object(vm.generator, "generate") as fake_gen, \
+             patch("qallm.verification.verification_manager.run_tests") as fake_run:
+            fake_gen.return_value = MagicMock(
+                test_code="def test_dummy(): pass", is_valid=True,
+                generation_error=None, oracle="crash", model="stub",
+                provider="stub",
+            )
+            fake_run.return_value = MagicMock(
+                stdout="", stderr="", execution_error=None,
+                tests_passed=1, tests_failed=0, tests_errored=0,
+                coverage_percent=100.0, bugs_found=0,
+            )
+
+            vm.verify(unit_r1, round_number=1)
+            key = vm.store.make_key(path, 0, "f")
+            session_after_r1 = vm.store.get_or_create_record(key, "f").session
+            assert "eval(x)" in session_after_r1.source_code
+
+            vm.verify(unit_r2, round_number=2)
+            session_after_r2 = vm.store.get_or_create_record(key, "f").session
+            # Same persisted session, but its source now reflects round 2.
+            assert session_after_r2 is session_after_r1
+            assert "ast.literal_eval(x)" in session_after_r2.source_code
+            assert "return eval(x)" not in session_after_r2.source_code


### PR DESCRIPTION
Reported: in the per-round report, dangerous() displayed identical source in every round despite being repaired (eval -> ast.literal_eval, shell=True -> list form, pickle removed). Investigation of the persisted artefacts showed the repair was real: source.py on disk differs correctly per round. The bug was that verification.json stored the round-0 source for that function in every round, and the report faithfully rendered that stale snapshot.

Root cause: in VerificationManager.verify, the per-function TestGenerationSession is created once with source_code=<current source> and then reused across rounds (the test store persists it). On the reuse path the session's source_code was never refreshed, so it kept its round-0 value for the life of the run. Functions whose body changed but whose session was reused therefore reported their pre-repair source every round. It surfaced most visibly on dangerous(), which has no executed tests, so the displayed source was the only per-round signal and it never moved.

Fix: on the session-reuse path, set session.source_code = source (the current round's repaired source). This flows into each round's verification.json and thus the report's "Function under test" view. One line; baseline (round 0) still creates the session with round-0 source as before, so round 0 is unchanged and rounds >= 1 now reflect what was actually tested.

Regression test (test_verification_function_filter.py::TestSessionSourceRefresh): verify() run twice on the same function key with eval -> ast.literal_eval; asserts the reused session is the same object but its source_code updates from round 1 to round 2. Confirmed the test fails without the fix and passes with it.

Suite: 544 passed; ruff clean.

Note (not addressed here): the report's test_complex_branching_large is a faulty *generated* test (asserts complex_branching(1000) == _expected_total(100), mismatched n), not a code defect. Test-quality issue, separate concern.