### PR TITLE
feat(verification): drop incoherent-oracle tests to prevent false bugs

### DIFF
--- a/docs/methodology-decisions.md
+++ b/docs/methodology-decisions.md
@@ -58,3 +58,28 @@ When a methodology decision is made, append a new section as `MD-NNN: short titl
 9. **Implications**: for the pilot, for the thesis chapters, for future work.
 
 Decisions are append-only. To overturn a decision, add a new entry that explicitly references the one it overrides; do not edit the old entry.
+
+---
+
+## MD-002: Drop incoherent-oracle tests before execution (false-BUG prevention)
+
+1. **Date / context**: arose from a report where a generated test fired a spurious failure: it called the function under test with `n = 1000` but compared the result against an oracle helper evaluated at `100`.
+
+2. **Decision**: before a generated test suite is executed, deterministically remove any test whose oracle is evaluated at a different constant input than the function under test (FUT), and add a prompt rule discouraging the LLM from producing them.
+
+3. **What it was before**: generated tests were validated only for unsatisfiable fixtures (setup errors). A test that ran but asserted against a mismatched-input oracle would fail and be counted as a BUG.
+
+4. **Why we changed it**: this is a soundness requirement for the central claim. QALLM's contribution is that execution-based verification is a trustworthy corrective to the false confidence of static analysis. If execution itself fires on malformed oracles, the verification-gap and confirmation rates inflate with false bugs, defects attributed to the code that are actually artifacts of the test. A reported bug must be a property of the code under test, not of the test. Removing these tests keeps the bug counts (and hence all three metrics) sound.
+
+5. **Alternatives considered**:
+   - *Quarantine and flag rather than drop*: preserves more information but adds reporting surface and risk; deferred. Dropping is the conservative, easily-defended move.
+   - *Try to detect wrong expected values in general*: undecidable, and would risk discarding good tests. Rejected. We flag ONLY the unambiguous constant-vs-constant input mismatch between the FUT and a module-local oracle helper.
+   - *Prompt-only prevention*: necessary but not sufficient (probabilistic). Used in addition to the deterministic strip.
+
+6. **Cost impact**: negligible; one extra AST pass per generated suite, no extra LLM calls.
+
+7. **Implementation**: `find_incoherent_oracle_tests` / `strip_incoherent_oracle_tests` in `src/qallm/verification/test_validator.py`; wired into `TestGenerator.generate` in `src/qallm/verification/generator.py` alongside fixture stripping; prompt rule 9 in `src/qallm/verification/prompts.py`.
+
+8. **Test coverage**: `tests/test_incoherent_oracle.py` (11 cases): flags intermediate-variable and inline mismatches; never flags same-input tests, weak assertions, unrelated production functions, non-constant inputs, or helperless suites; safe on syntax errors.
+
+9. **Implications**: makes the bug-count denominators sound, which strengthens RQ1 (verification gap) and RQ2 (confirmation) against the examiner question "how do you know your execution-found bugs are real and not test artifacts?". The threats-to-validity section should cite this as a deliberate conservative filter. The number of tests dropped this way is itself a small reportable measure of generated-test quality.

--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -20,7 +20,10 @@ from qallm.verification.prompts import (
     build_feedback_prompt
 )
 from qallm.verification.sandbox import CodeExtractor
-from qallm.verification.test_validator import strip_unsatisfied_fixture_tests
+from qallm.verification.test_validator import (
+    strip_unsatisfied_fixture_tests,
+    strip_incoherent_oracle_tests,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -134,6 +137,29 @@ class TestGenerator:
                     validation_error = (
                         "All generated tests requested undefined fixtures "
                         f"({', '.join(discarded)}); nothing left to run."
+                    )
+
+        # Drop tests whose oracle is evaluated at a different input than the
+        # function under test: such a failure is an artifact of the test, not
+        # a defect in the code, so letting it run would record a false bug and
+        # undermine the validity of the execution-based verdict. Conservative:
+        # only unambiguous constant-vs-constant mismatches are removed.
+        if is_valid:
+            stripped_code, incoherent = strip_incoherent_oracle_tests(
+                test_code, func.name
+            )
+            if incoherent:
+                logger.warning(
+                    "Discarded %d test(s) for %s with an oracle evaluated at a "
+                    "different input than the call (false-bug risk): %s",
+                    len(incoherent), func.name, ", ".join(incoherent),
+                )
+                test_code = stripped_code
+                is_valid, validation_error = _validate_test_code(test_code)
+                if not is_valid:
+                    validation_error = (
+                        "All generated tests had incoherent oracles "
+                        f"({', '.join(incoherent)}); nothing left to run."
                     )
 
         if not is_valid:

--- a/src/qallm/verification/prompts.py
+++ b/src/qallm/verification/prompts.py
@@ -33,6 +33,10 @@ boundary conditions.
 6. Every test must contain at least one assert statement or pytest.raises.
 7. Do not use external libraries beyond pytest and the standard library.
 8. Do not mock the function under test; call it directly.
+9. If a test computes an expected value with a helper, that helper MUST be \
+called with the SAME input you passed to the function under test. Never \
+compare the result for one input against the expected value for a different \
+input (e.g. result of f(1000) must not be compared to expected(100)).
 """
 
 

--- a/src/qallm/verification/test_validator.py
+++ b/src/qallm/verification/test_validator.py
@@ -174,3 +174,157 @@ def strip_unsatisfied_fixture_tests(code: str) -> tuple[str, list[str]]:
     except Exception:  # noqa: BLE001 - unparse should not fail, but be safe
         return code, []
     return rewritten, sorted(to_remove)
+
+
+# ── Incoherent-oracle detection ──────────────────────────────────────────
+#
+# A generated test can run without error yet assert something meaningless,
+# the most common form being an oracle evaluated at a different input than the
+# function under test (FUT). For example:
+#
+#     def test_large():
+#         n = 1000
+#         result = complex_branching(n)
+#         assert result == _expected_total(100)   # oracle uses 100, not n=1000
+#
+# This produces a *false* BUG: a failure that is an artifact of the test, not a
+# defect in the code. That directly threatens the validity of QALLM's
+# execution-based verdicts (a reported bug must be a property of the code, not
+# of a malformed test). We therefore detect and drop such tests before they
+# run, deterministically and conservatively.
+#
+# Conservatism is the priority: we flag ONLY the unambiguous case where, in a
+# single equality/inequality comparison, the FUT is invoked (directly, or via a
+# local variable assigned from a FUT call) with one constant input, and a
+# module-local oracle helper is invoked with a DIFFERENT constant input. We do
+# not attempt to judge whether an expected literal value is "correct" in
+# general (undecidable, and would risk discarding good tests). Unrelated
+# production functions are not treated as oracles, only helpers defined in the
+# test module itself.
+
+
+def _module_local_oracle_helpers(tree: ast.Module, fut_name: str) -> set[str]:
+    """Module-local functions that look like oracle helpers.
+
+    Any function defined at module level in the test file that is neither the
+    function under test nor a test_* function is a candidate oracle helper
+    (commonly a ``_expected_*`` reimplementation of the expected result).
+    """
+    helpers: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if node.name != fut_name and not node.name.startswith("test_"):
+                helpers.add(node.name)
+    return helpers
+
+
+def _first_arg_literal(call: ast.Call, const_binds: dict[str, object]) -> object | None:
+    """The first positional argument of ``call`` as a constant, if knowable.
+
+    Resolves a direct literal, or a local variable previously bound to a
+    literal. Returns None when the argument is not a simple constant (so we
+    only ever compare known-constant against known-constant).
+    """
+    if not call.args:
+        return None
+    arg = call.args[0]
+    if isinstance(arg, ast.Constant):
+        return arg.value
+    if isinstance(arg, ast.Name) and arg.id in const_binds:
+        return const_binds[arg.id]
+    return None
+
+
+def find_incoherent_oracle_tests(code: str, fut_name: str) -> dict[str, tuple[object, object]]:
+    """Map test name -> (fut_input, oracle_input) for incoherent-oracle tests.
+
+    A test is incoherent when, in one comparison, the function under test is
+    fed one constant input and a module-local oracle helper is fed a different
+    constant input. Only such tests are returned; everything else is left for
+    execution to judge.
+    """
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return {}
+
+    oracle_helpers = _module_local_oracle_helpers(tree, fut_name)
+    if not oracle_helpers:
+        return {}
+
+    flagged: dict[str, tuple[object, object]] = {}
+    for fn in tree.body:
+        if not isinstance(fn, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        if not fn.name.startswith("test_"):
+            continue
+
+        const_binds: dict[str, object] = {}
+        fut_arg_of: dict[str, object] = {}  # local var -> FUT input that produced it
+        for node in ast.walk(fn):
+            if isinstance(node, ast.Assign) and len(node.targets) == 1 \
+                    and isinstance(node.targets[0], ast.Name):
+                target = node.targets[0].id
+                value = node.value
+                if isinstance(value, ast.Constant):
+                    const_binds[target] = value.value
+                elif isinstance(value, ast.Call) and isinstance(value.func, ast.Name) \
+                        and value.func.id == fut_name:
+                    lit = _first_arg_literal(value, const_binds)
+                    if lit is not None:
+                        fut_arg_of[target] = lit
+
+        for cmp in ast.walk(fn):
+            if not isinstance(cmp, ast.Compare):
+                continue
+            fut_inputs: set[object] = set()
+            oracle_inputs: set[object] = set()
+            for operand in [cmp.left, *cmp.comparators]:
+                if isinstance(operand, ast.Call) and isinstance(operand.func, ast.Name):
+                    if operand.func.id == fut_name:
+                        lit = _first_arg_literal(operand, const_binds)
+                        if lit is not None:
+                            fut_inputs.add(lit)
+                    elif operand.func.id in oracle_helpers:
+                        lit = _first_arg_literal(operand, const_binds)
+                        if lit is not None:
+                            oracle_inputs.add(lit)
+                elif isinstance(operand, ast.Name) and operand.id in fut_arg_of:
+                    fut_inputs.add(fut_arg_of[operand.id])
+            mismatches = [(f, o) for f in fut_inputs for o in oracle_inputs if f != o]
+            if mismatches:
+                flagged[fn.name] = mismatches[0]
+                break
+
+    return flagged
+
+
+def strip_incoherent_oracle_tests(code: str, fut_name: str) -> tuple[str, list[str]]:
+    """Remove tests whose oracle is evaluated at a different input than the FUT.
+
+    Same contract as ``strip_unsatisfied_fixture_tests``: returns the rewritten
+    code and the sorted list of removed test names, preserving every other
+    top-level statement. Returns the code unchanged on parse failure or when
+    nothing needs removing.
+    """
+    flagged = find_incoherent_oracle_tests(code, fut_name)
+    if not flagged:
+        return code, []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return code, []
+
+    to_remove = set(flagged.keys())
+    tree.body = [
+        node for node in tree.body
+        if not (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in to_remove
+        )
+    ]
+    try:
+        rewritten = ast.unparse(tree)
+    except Exception:  # noqa: BLE001 - unparse should not fail, but be safe
+        return code, []
+    return rewritten, sorted(to_remove)

--- a/tests/test_incoherent_oracle.py
+++ b/tests/test_incoherent_oracle.py
@@ -1,0 +1,128 @@
+"""Tests for incoherent-oracle detection (false-BUG prevention).
+
+A generated test that feeds the function under test one input but its oracle
+helper a different input produces a failure that is an artifact of the test,
+not a defect in the code. These must be dropped before execution so they do
+not inflate QALLM's bug counts. The conservative requirement is paramount:
+legitimate tests must never be flagged.
+"""
+
+from qallm.verification.test_validator import (
+    find_incoherent_oracle_tests,
+    strip_incoherent_oracle_tests,
+)
+
+FUT = "complex_branching"
+
+
+# ── must FLAG (genuinely incoherent) ──
+
+def test_flags_intermediate_variable_mismatch():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_large():\n"
+        "    n = 1000\n"
+        "    result = complex_branching(n)\n"
+        "    assert result == _expected_total(100)\n"
+    )
+    flagged = find_incoherent_oracle_tests(code, FUT)
+    assert "test_large" in flagged
+    assert flagged["test_large"] == (1000, 100)
+
+
+def test_flags_inline_mismatch():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_x():\n"
+        "    assert complex_branching(1000) == _expected_total(100)\n"
+    )
+    assert "test_x" in find_incoherent_oracle_tests(code, FUT)
+
+
+def test_strip_removes_only_the_incoherent_test():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_good():\n"
+        "    assert complex_branching(10) == _expected_total(10)\n"
+        "def test_bad():\n"
+        "    assert complex_branching(1000) == _expected_total(100)\n"
+    )
+    rewritten, removed = strip_incoherent_oracle_tests(code, FUT)
+    assert removed == ["test_bad"]
+    assert "def test_good" in rewritten
+    assert "def test_bad" not in rewritten
+    assert "def _expected_total" in rewritten   # helper preserved
+
+
+# ── must NOT flag (legitimate) ──
+
+def test_same_literal_is_fine():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_small():\n"
+        "    assert complex_branching(10) == _expected_total(10)\n"
+    )
+    assert find_incoherent_oracle_tests(code, FUT) == {}
+
+
+def test_same_variable_both_sides_is_fine():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_n():\n"
+        "    n = 31\n"
+        "    assert complex_branching(n) == _expected_total(n)\n"
+    )
+    assert find_incoherent_oracle_tests(code, FUT) == {}
+
+
+def test_weak_assertion_no_oracle_is_fine():
+    code = (
+        "def test_large():\n"
+        "    result = complex_branching(1000)\n"
+        "    assert result >= 0\n"
+    )
+    assert find_incoherent_oracle_tests(code, FUT) == {}
+
+
+def test_unrelated_production_function_not_treated_as_oracle():
+    # decode_len is NOT defined in the test module, so it is not an oracle
+    # helper; different inputs to two production functions are legitimate.
+    code = (
+        "def test_two():\n"
+        "    assert encode(5) == decode_len(10)\n"
+    )
+    assert find_incoherent_oracle_tests(code, "encode") == {}
+
+
+def test_no_helpers_means_nothing_flagged():
+    code = (
+        "def test_a():\n"
+        "    assert complex_branching(10) == 19\n"
+    )
+    assert find_incoherent_oracle_tests(code, FUT) == {}
+
+
+def test_non_constant_inputs_are_not_flagged():
+    # If inputs are not simple constants we cannot prove incoherence; leave it.
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_dyn(some_value):\n"
+        "    assert complex_branching(some_value) == _expected_total(some_value * 2)\n"
+    )
+    assert find_incoherent_oracle_tests(code, FUT) == {}
+
+
+def test_syntax_error_is_safe():
+    code = "def test_broken(:\n    pass\n"
+    rewritten, removed = strip_incoherent_oracle_tests(code, FUT)
+    assert rewritten == code and removed == []
+
+
+def test_no_change_returns_original():
+    code = (
+        "def _expected_total(n):\n    return n\n"
+        "def test_ok():\n"
+        "    assert complex_branching(5) == _expected_total(5)\n"
+    )
+    rewritten, removed = strip_incoherent_oracle_tests(code, FUT)
+    assert removed == [] and rewritten == code


### PR DESCRIPTION
A generated test can run without error yet assert something meaningless: the common form is an oracle helper evaluated at a different input than the function under test, e.g. complex_branching(1000) compared to _expected_total(100). Such a failure is an artifact of the test, not a defect in the code, but it was counted as a BUG. That threatens the validity of QALLM's central claim: if execution-based verification is the trustworthy corrective to static analysis's false confidence, it must not itself fire on malformed oracles, or the verification-gap and confirmation rates inflate with false bugs.

Fix (deterministic detection + prompt prevention):

* test_validator.find_incoherent_oracle_tests / strip_incoherent_oracle_tests: an AST check, same contract as the fixture stripper, that flags ONLY the unambiguous case: in one comparison, the FUT is called (directly or via a local assigned from a FUT call) with one constant input while a module-local oracle helper is called with a DIFFERENT constant input. It does not judge expected values in general (undecidable) and does not treat unrelated production functions as oracles, so legitimate tests are not flagged. Conservative by design: when in doubt, keep the test.

* generator.generate: runs the strip after fixture stripping, logs discarded tests, and re-validates (if nothing remains, the suite is marked invalid with a clear reason).

* prompts: system rule 9 tells the model the oracle helper must use the same input as the call.

* docs/methodology-decisions.md: recorded as MD-002 with the soundness rationale, alternatives (quarantine, general wrong-value detection, prompt-only) and why rejected, and the threats-to-validity framing.

Tests: tests/test_incoherent_oracle.py (11): flags intermediate-variable and inline mismatches and strips only the offending test (helpers and good tests preserved); never flags same-input tests, weak assertions, unrelated production functions, non-constant inputs, or helperless suites; safe on syntax errors. Suite: 555 passed; ruff clean.