### PR TITLE
fix(reporter): create session dir lazily; prune empty session dirs

### DIFF
--- a/src/qallm/api/routers/sessions_library.py
+++ b/src/qallm/api/routers/sessions_library.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+import shutil
 
 from fastapi import APIRouter, HTTPException
 
@@ -45,6 +46,43 @@ def _read_json(path: str):
 def _is_session_dir(path: str) -> bool:
     """A session directory is one that has a summary.json."""
     return os.path.isfile(os.path.join(path, "summary.json"))
+
+
+def _dir_has_any_file(path: str) -> bool:
+    """True if the directory tree contains at least one regular file."""
+    for _root, _dirs, files in os.walk(path):
+        if files:
+            return True
+    return False
+
+
+def prune_empty_sessions(sessions_dir: str | None = None) -> list[str]:
+    """Remove session directories that contain no files at all.
+
+    A run that was constructed but never wrote artefacts (e.g. an old probe,
+    or a run that failed before the baseline) can leave an empty directory.
+    This conservatively removes ONLY directories with no regular file anywhere
+    inside, so a directory holding any artefact is never touched. Returns the
+    list of removed directory names.
+    """
+    base = sessions_dir or _sessions_dir()
+    if not os.path.isdir(base):
+        return []
+    removed: list[str] = []
+    for name in sorted(os.listdir(base)):
+        path = os.path.join(base, name)
+        if not os.path.isdir(path):
+            continue
+        if _dir_has_any_file(path):
+            continue  # holds artefacts; never remove
+        try:
+            shutil.rmtree(path)
+            removed.append(name)
+        except OSError as e:
+            logger.warning("Could not remove empty session dir %s: %s", path, e)
+    if removed:
+        logger.info("Pruned %d empty session director(ies).", len(removed))
+    return removed
 
 
 def _summarise(session_id: str, summary: dict) -> dict:
@@ -136,3 +174,14 @@ async def get_session_report(session_id: str):
             return {"id": session_id, "markdown": fh.read()}
     except OSError as exc:
         raise HTTPException(status_code=500, detail=str(exc)) from exc
+
+
+@router.post("/api/library/prune-empty")
+async def prune_empty():
+    """Remove session directories that contain no artefacts at all.
+
+    Conservative housekeeping: only directories with no file anywhere inside
+    are removed, so nothing holding results is ever touched.
+    """
+    removed = prune_empty_sessions()
+    return {"removed": removed, "count": len(removed)}

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -724,6 +724,7 @@ class QALLMOrchestrator:
             "tracks": tracks_dict,
             "sessions": sessions_data,
         }
+        self.reporter._ensure_dir()
         summary_path = self.reporter.report_dir / "summary.json"
         summary_path.write_text(
             json.dumps(summary, indent=2, default=str), encoding="utf-8"

--- a/src/qallm/utils/reporter.py
+++ b/src/qallm/utils/reporter.py
@@ -80,6 +80,15 @@ class QualityReporter:
         # to a timestamp so concurrent sessions don't collide.
         self.run_id = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
         self.report_dir = Path(base_dir) / self.run_id
+        # The directory is created lazily, on the first artefact write, NOT
+        # here. Constructing a reporter (which the orchestrator does in its
+        # own constructor) must not leave an empty session directory on disk
+        # if the run never produces anything, e.g. an ingest-only probe or a
+        # run that fails before the baseline. Every write path calls
+        # _ensure_dir() first.
+
+    def _ensure_dir(self) -> None:
+        """Create the session directory on first use. Idempotent."""
         self.report_dir.mkdir(parents=True, exist_ok=True)
 
     # ----- baseline -----
@@ -89,6 +98,7 @@ class QualityReporter:
 
         Returns the directory the artefacts were written to.
         """
+        self._ensure_dir()
         baseline_dir = self.report_dir / "round_00_baseline"
         baseline_dir.mkdir(parents=True, exist_ok=True)
         stem = analysed.code_unit.original_path.stem
@@ -131,6 +141,7 @@ class QualityReporter:
 
         Returns the directory written to.
         """
+        self._ensure_dir()
         bucket = "lineage" if accepted else "abandoned"
         # Per-unit subdirectories let multi-unit sessions co-exist within
         # lineage/round_N/ without filename collisions.

--- a/tests/test_prune_empty_sessions.py
+++ b/tests/test_prune_empty_sessions.py
@@ -1,0 +1,56 @@
+"""Tests for pruning empty session directories."""
+
+import os
+from pathlib import Path
+
+from qallm.api.routers.sessions_library import prune_empty_sessions
+
+
+def test_removes_empty_dirs_only(tmp_path: Path):
+    base = tmp_path / "quality_reporter"
+    base.mkdir()
+    # Two empty session dirs (the bug's residue).
+    (base / "empty_1").mkdir()
+    (base / "empty_2").mkdir()
+    # One empty dir with an empty subdir (still no files) -> should be removed.
+    (base / "empty_nested" / "lineage").mkdir(parents=True)
+    # A real session with artefacts -> must be kept.
+    real = base / "real_session" / "lineage" / "round_00" / "unit"
+    real.mkdir(parents=True)
+    (real / "source.py").write_text("def f(): return 1\n")
+    (base / "real_session" / "summary.json").write_text("{}")
+
+    removed = prune_empty_sessions(str(base))
+
+    assert set(removed) == {"empty_1", "empty_2", "empty_nested"}
+    assert not (base / "empty_1").exists()
+    assert not (base / "empty_nested").exists()
+    # The real session is untouched.
+    assert (base / "real_session" / "summary.json").exists()
+    assert (real / "source.py").exists()
+
+
+def test_never_removes_dir_with_any_file(tmp_path: Path):
+    base = tmp_path / "q"
+    base.mkdir()
+    # A dir whose only content is a single deeply-nested file must survive.
+    d = base / "has_one_file" / "a" / "b" / "c"
+    d.mkdir(parents=True)
+    (d / "lonely.json").write_text("{}")
+    removed = prune_empty_sessions(str(base))
+    assert removed == []
+    assert (d / "lonely.json").exists()
+
+
+def test_missing_base_dir_is_safe(tmp_path: Path):
+    assert prune_empty_sessions(str(tmp_path / "does_not_exist")) == []
+
+
+def test_ignores_loose_files_at_base(tmp_path: Path):
+    base = tmp_path / "q"
+    base.mkdir()
+    (base / "a_loose_file.zip").write_text("x")   # not a dir; ignored
+    (base / "empty").mkdir()
+    removed = prune_empty_sessions(str(base))
+    assert removed == ["empty"]
+    assert (base / "a_loose_file.zip").exists()

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -128,8 +128,21 @@ def _profile_verdict() -> ProfileVerdict:
 # ---------- constructor ----------
 
 
-def test_reporter_creates_run_directory(tmp_path: Path):
+def test_reporter_does_not_create_dir_on_construction(tmp_path: Path):
+    # Regression: constructing a reporter must NOT create the session
+    # directory. The orchestrator builds a reporter in its own constructor,
+    # so eager creation left an empty directory on disk for every orchestrator
+    # built but never run (e.g. ingest-only probes), producing bursts of empty
+    # session folders. The directory must appear only on the first write.
     r = _reporter(tmp_path)
+    assert not r.report_dir.exists()
+    assert r.report_dir.name == "test"
+
+
+def test_reporter_creates_run_directory_on_first_write(tmp_path: Path):
+    r = _reporter(tmp_path)
+    assert not r.report_dir.exists()
+    r._ensure_dir()
     assert r.report_dir.exists()
     assert r.report_dir.is_dir()
     assert r.report_dir.name == "test"


### PR DESCRIPTION
Reported: outputs/quality_reporter accumulated many empty session directories, created in bursts at identical timestamps (e.g. 16 dirs at one second, all total 0), far more than one per real run.

Root cause: QualityReporter.__init__ created its session directory eagerly (report_dir.mkdir in the constructor), and the orchestrator builds a QualityReporter in its own constructor. So every orchestrator instantiated but not run, e.g. the /api/session/ingest path that builds an orchestrator only to call ingestion_manager.collect, or any run that failed before the baseline, left an empty directory behind. A burst of such constructions produced a burst of empty dirs.

Fix (root): make directory creation lazy. The constructor no longer creates the dir; a new _ensure_dir() does, and is called at the start of every write path (save_baseline, save_round_artefacts) and before the orchestrator writes summary.json. The subdir writes already used mkdir(parents=True), so this is safe: a reporter that never writes now leaves no trace, while every real run creates its directory on first artefact exactly as before.

Housekeeping for the dirs already on disk: new prune_empty_sessions in the sessions library removes session directories that contain no file anywhere inside (conservative: a directory holding any artefact is never touched), exposed as POST /api/library/prune-empty.

Tests:
* test_reporter.py: replaced the test that asserted eager creation (it encoded the bug) with two tests: construction creates no dir; _ensure_dir creates it. The existing baseline/round-save tests already prove writes create the dir.
* test_prune_empty_sessions.py (4): removes only fileless dirs (including empty nested ones); never removes a dir with any file even deeply nested; safe on a missing base dir; ignores loose files at the base.

Suite: 560 passed; ruff clean.