### PR TITLE
Review: env setup script + bootstrap confidence intervals + Doc improvement

### DIFF
--- a/README.md
+++ b/README.md
@@ -356,6 +356,7 @@ To keep one source of truth, each document owns a domain. When they overlap, the
 | Thesis structure and metric definitions | [`docs/thesis-draft-scaffold.md`](docs/thesis-draft-scaffold.md) | none |
 | Reproducible experiment protocol (both tracks) | [`docs/experiments/protocol.md`](docs/experiments/protocol.md) | none |
 | Project roadmap (priorities and rationale) | [`docs/roadmap.md`](docs/roadmap.md) | none |
+| Running experiments directly (venv setup) | [`docs/running-experiments.md`](docs/running-experiments.md) | none |
 | Interactive verification-gap explainer (standalone, shareable) | [`docs/verification-gap-explainer.html`](docs/verification-gap-explainer.html) | none |
 | HumanEvalFix experiment detail | [`docs/experiments/humaneval.md`](docs/experiments/humaneval.md) | none |
 | Production deployment (split FE/API, CORS, TLS, ops) | [`docs/deployment.md`](docs/deployment.md) | quickstart only, links out |

--- a/docs/experiments/protocol.md
+++ b/docs/experiments/protocol.md
@@ -7,8 +7,6 @@ persisted artefacts and the commands here. It records the environment, the
 exact inputs, what each metric measures and its formula, how to run each
 experiment, and how results are exported and aggregated.
 
-Dashes are avoided as punctuation throughout, per the project convention.
-
 ## 1. What is being evaluated, and the claim
 
 QALLM treats each static finding as a hypothesis and uses execution to

--- a/docs/experiments/protocol.md
+++ b/docs/experiments/protocol.md
@@ -148,6 +148,13 @@ Across sessions, rates are recomputed from summed counts (count-weighted), not
 averaged, so a session with one finding does not weigh equally with a session
 with fifty. `aggregate_sessions` in `qallm.metrics_export` does this.
 
+Each aggregate rate also carries a bootstrap 95% confidence interval
+(`confidence_intervals` in the aggregate output). The interval is computed by
+resampling sessions with replacement (sessions are the independent unit, since
+findings cluster within them) and recomputing the pooled rate, so the headline
+figures are reported as a point estimate with an interval rather than a bare
+number. Report the interval alongside each rate in the results chapter.
+
 ## 5. HumanEvalFix track (summary)
 
 Full detail in `docs/experiments/humaneval.md`. In brief:

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -2,8 +2,7 @@
 
 A grounded plan for what makes QALLM great, ordered by leverage. This is not a
 wish list; every item below is justified by the current state of the code, the
-audit findings, or a concrete thesis need. Dashes are avoided as punctuation
-per the project convention.
+audit findings, or a concrete thesis need. 
 
 ## Where QALLM is today (honest snapshot)
 

--- a/docs/running-experiments.md
+++ b/docs/running-experiments.md
@@ -1,0 +1,89 @@
+# Running QALLM directly (venv) for experiments
+
+The Docker image is the easiest way to run the web app, but for the
+experiments (HumanEvalFix and the verification-gap dataset runs) it is usually
+simpler to run QALLM directly in a Python virtual environment on the machine,
+so you can point at local notebook directories and watch progress in the
+terminal. This is the setup for that path.
+
+Dashes are avoided as punctuation per the project convention.
+
+## One-time setup
+
+From the repository root:
+
+```
+./scripts/setup.sh --experiments
+```
+
+This is idempotent (safe to re-run). It creates a `.venv`, upgrades pip, and
+installs QALLM with the experiments extra (`pip install -e ".[experiments]"`,
+which pulls in the `datasets` package needed for HumanEvalFix). Use it without
+`--experiments` if you only need the base pipeline.
+
+## Activate the environment
+
+A script cannot change your current shell's environment, so activation is one
+manual step you run yourself:
+
+```
+source .venv/bin/activate
+```
+
+Your prompt should then start with `(.venv)`, for example:
+
+```
+(.venv) mohssin@nis05:~/qallm-uva$
+```
+
+That confirms you are inside the virtual environment. Everything below assumes
+the environment is active.
+
+## Run an experiment
+
+Verification-gap track over a local notebook dataset (the thesis figures):
+
+```
+# pilot first to gauge latency and rate limits
+python scripts/run_gap_experiment.py \
+    --dataset data/notebooks_pilot --output runs/gap_pilot \
+    --llm fedllm --rounds 3
+
+# all three metrics (RQ1 + RQ2 + RQ3) in one run
+python scripts/run_gap_experiment.py \
+    --dataset data/li_notebooks --output runs/gap_full \
+    --llm fedllm --rounds 5 --confirm
+```
+
+HumanEvalFix validation track:
+
+```
+python scripts/run_humaneval.py \
+    --output runs/heval_pilot \
+    --models fedllm:gpt-oss-120b \
+    --strategies feedback \
+    --sample-size 20 --rounds 3 --seed 42
+```
+
+See `docs/experiments/protocol.md` for what each run measures and how to
+report it.
+
+## Credentials
+
+Hosted models need credentials in the environment (or a `.env` file the app
+loads). FedLLM is free for VO users; set `FEDLLM_API_KEY`. Confirm the model
+list for your VO before a long run:
+
+```
+curl https://llm.ai.egi.eu/v1/models -H "Authorization: Bearer $FEDLLM_API_KEY"
+```
+
+## Troubleshooting
+
+- `(.venv)` not in your prompt: you have not activated the environment in this
+  shell. Re-run `source .venv/bin/activate`.
+- `ModuleNotFoundError: No module named 'datasets'`: the experiments extra is
+  not installed. Re-run `./scripts/setup.sh --experiments` (or
+  `pip install -e ".[experiments]"` with the venv active).
+- A new shell or SSH session does not keep the activation; re-activate per
+  session, or add the `source` line to your shell profile on the VM.

--- a/docs/running-experiments.md
+++ b/docs/running-experiments.md
@@ -6,8 +6,6 @@ simpler to run QALLM directly in a Python virtual environment on the machine,
 so you can point at local notebook directories and watch progress in the
 terminal. This is the setup for that path.
 
-Dashes are avoided as punctuation per the project convention.
-
 ## One-time setup
 
 From the repository root:

--- a/docs/thesis-draft-scaffold.md
+++ b/docs/thesis-draft-scaffold.md
@@ -6,9 +6,6 @@ and where the supporting evidence comes from in the QALLM system. Placeholders
 in [brackets] mark numbers to be filled from real runs. The point is a
 foundation that is honest about what has been shown and what has not.
 
-Throughout, dashes are avoided as punctuation per the author's convention;
-commas, semicolons, and colons are used instead.
-
 ---
 
 ## Abstract

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+#
+# QALLM environment setup (for running the pipeline and experiments directly,
+# i.e. not in Docker). Idempotent: safe to run repeatedly.
+#
+# Usage:
+#   ./scripts/setup.sh              # venv + base install
+#   ./scripts/setup.sh --experiments  # also install the experiments extra
+#
+# After it finishes, activate the venv in your shell:
+#   source .venv/bin/activate
+#
+# The prompt should then show (.venv) at the front, e.g.
+#   (.venv) mohssin@nis05:~/qallm-uva$
+#
+# A script cannot activate the venv in your current shell for you (a child
+# process cannot change its parent's environment), so the activate step is
+# printed for you to run. Everything else is automated.
+
+set -euo pipefail
+
+# Run from the repository root regardless of where the script is invoked.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+WITH_EXPERIMENTS=0
+for arg in "$@"; do
+  case "$arg" in
+    --experiments) WITH_EXPERIMENTS=1 ;;
+    -h|--help)
+      sed -n '2,20p' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+
+# 1. Pick a Python. Prefer python3; require 3.10+.
+PYTHON="${PYTHON:-python3}"
+if ! command -v "$PYTHON" >/dev/null 2>&1; then
+  echo "ERROR: '$PYTHON' not found. Install Python 3.10+ or set PYTHON=..." >&2
+  exit 1
+fi
+PY_VER="$("$PYTHON" -c 'import sys; print("%d.%d" % sys.version_info[:2])')"
+echo "Using $PYTHON (Python $PY_VER)"
+
+# 2. Create the venv if it does not exist (idempotent).
+if [ ! -d ".venv" ]; then
+  echo "Creating virtual environment in .venv ..."
+  "$PYTHON" -m venv .venv
+else
+  echo "Virtual environment .venv already exists; reusing it."
+fi
+
+# 3. Install into the venv's interpreter directly (no activation needed for
+#    the install itself; activation is for your interactive shell afterwards).
+VENV_PY=".venv/bin/python"
+echo "Upgrading pip ..."
+"$VENV_PY" -m pip install --upgrade pip >/dev/null
+
+if [ "$WITH_EXPERIMENTS" -eq 1 ]; then
+  echo "Installing QALLM with the experiments extra ..."
+  "$VENV_PY" -m pip install -e ".[experiments]"
+else
+  echo "Installing QALLM (base) ..."
+  "$VENV_PY" -m pip install -e .
+fi
+
+echo ""
+echo "Setup complete."
+echo ""
+echo "Activate the environment in your shell now:"
+echo ""
+echo "    source .venv/bin/activate"
+echo ""
+echo "Your prompt should then start with (.venv). To run an experiment:"
+echo ""
+if [ "$WITH_EXPERIMENTS" -eq 1 ]; then
+  echo "    python scripts/run_gap_experiment.py --dataset <dir> --output runs/gap --llm fedllm"
+else
+  echo "    (re-run with --experiments to enable the HumanEvalFix / dataset runs)"
+fi

--- a/src/qallm/metrics_export.py
+++ b/src/qallm/metrics_export.py
@@ -156,6 +156,12 @@ class AggregateMetrics:
     total_not_fixed: int = 0
     total_cost_usd: float = 0.0
     per_session: list[dict] = field(default_factory=list)
+    # Per-session (numerator, denominator) pairs for each rate, captured from
+    # the typed SessionMetrics so the bootstrap CI does not depend on the
+    # lossy per-session dict (which omits some counts).
+    _gap_pairs: list[tuple[int, int]] = field(default_factory=list)
+    _conf_pairs: list[tuple[int, int]] = field(default_factory=list)
+    _fix_pairs: list[tuple[int, int]] = field(default_factory=list)
 
     @property
     def verification_gap_rate(self) -> float | None:
@@ -174,6 +180,29 @@ class AggregateMetrics:
         return _rate(self.total_verified_fixed,
                      self.total_verified_fixed + self.total_not_fixed)
 
+    def confidence_intervals(self) -> dict[str, Any]:
+        """Bootstrap 95% CIs for the three rates, resampling by session.
+
+        Sessions are the independent unit (findings cluster within them), so
+        the CI is computed by resampling sessions with replacement and
+        recomputing each pooled rate. Gives the headline figures an interval
+        rather than a bare point estimate.
+        """
+        from qallm.stats import bootstrap_rate_ci
+
+        gap_num = [p[0] for p in self._gap_pairs]
+        gap_den = [p[1] for p in self._gap_pairs]
+        conf_num = [p[0] for p in self._conf_pairs]
+        conf_den = [p[1] for p in self._conf_pairs]
+        fix_num = [p[0] for p in self._fix_pairs]
+        fix_den = [p[1] for p in self._fix_pairs]
+
+        return {
+            "verification_gap_rate": bootstrap_rate_ci(gap_num, gap_den),
+            "confirmation_rate": bootstrap_rate_ci(conf_num, conf_den),
+            "verified_fix_rate": bootstrap_rate_ci(fix_num, fix_den),
+        }
+
     def to_dict(self) -> dict[str, Any]:
         return {
             "n_sessions": self.n_sessions,
@@ -186,6 +215,7 @@ class AggregateMetrics:
             "total_verified_fixed": self.total_verified_fixed,
             "total_not_fixed": self.total_not_fixed,
             "verified_fix_rate": self.verified_fix_rate,
+            "confidence_intervals": self.confidence_intervals(),
             "total_cost_usd": round(self.total_cost_usd, 6),
             "per_session": self.per_session,
         }
@@ -204,6 +234,13 @@ def aggregate_sessions(sessions: list[SessionMetrics]) -> AggregateMetrics:
         agg.total_not_fixed += (s.not_fixed or 0)
         agg.total_cost_usd += s.cost_usd
         agg.per_session.append(s.to_dict())
+        # Capture per-session (numerator, denominator) for the bootstrap CIs.
+        eo, cf = s.execution_only_bugs, s.confirmed_findings
+        agg._gap_pairs.append((eo, eo + cf))
+        c, r = (s.confirmed or 0), (s.refuted or 0)
+        agg._conf_pairs.append((c, c + r))
+        vf, nf = (s.verified_fixed or 0), (s.not_fixed or 0)
+        agg._fix_pairs.append((vf, vf + nf))
     return agg
 
 

--- a/src/qallm/stats.py
+++ b/src/qallm/stats.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 import argparse
 import csv
 import logging
+import random
 from collections import defaultdict
 
 logger = logging.getLogger(__name__)
@@ -259,3 +260,96 @@ def main():
 
 if __name__ == "__main__":
     main()
+
+
+def bootstrap_rate_ci(
+    numerators: list[int],
+    denominators: list[int],
+    confidence: float = 0.95,
+    n_resamples: int = 2000,
+    seed: int = 42,
+) -> dict:
+    """Bootstrap a confidence interval for a count-weighted rate.
+
+    A rate like the verification gap is a ratio of summed counts across
+    sessions (sum(numerators) / sum(denominators)). The right resampling unit
+    is the SESSION, not the individual finding: findings cluster within
+    sessions, so resampling sessions with replacement and recomputing the
+    pooled rate each time yields a CI that respects that clustering. A
+    per-finding bootstrap would understate the interval.
+
+    Args:
+        numerators: per-session numerator counts (e.g. execution-only bugs).
+        denominators: per-session denominator counts (e.g. confirmed +
+            execution-only), paired with numerators by index.
+        confidence: e.g. 0.95 for a 95% percentile interval.
+        n_resamples: number of bootstrap resamples.
+        seed: for reproducibility.
+
+    Returns a dict with point, ci_low, ci_high, confidence, n_sessions, and
+    method, or point=None when the total denominator is zero (no data to rate).
+    """
+    if len(numerators) != len(denominators):
+        raise ValueError("numerators and denominators must have equal length")
+
+    n = len(numerators)
+    total_denom = sum(denominators)
+    if n == 0 or total_denom == 0:
+        return {
+            "point": None,
+            "ci_low": None,
+            "ci_high": None,
+            "confidence": confidence,
+            "n_sessions": n,
+            "method": "bootstrap_percentile_session_resample",
+        }
+
+    point = sum(numerators) / total_denom
+
+    # A single session cannot yield an interval; report the point only.
+    if n == 1:
+        return {
+            "point": round(point, 4),
+            "ci_low": round(point, 4),
+            "ci_high": round(point, 4),
+            "confidence": confidence,
+            "n_sessions": n,
+            "method": "bootstrap_percentile_session_resample",
+            "note": "Single session; interval is degenerate.",
+        }
+
+    rng = random.Random(seed)
+    rates: list[float] = []
+    indices = range(n)
+    for _ in range(n_resamples):
+        num_sum = 0
+        den_sum = 0
+        for _ in range(n):
+            j = rng.choice(indices)
+            num_sum += numerators[j]
+            den_sum += denominators[j]
+        if den_sum > 0:
+            rates.append(num_sum / den_sum)
+
+    if not rates:
+        return {
+            "point": round(point, 4),
+            "ci_low": None,
+            "ci_high": None,
+            "confidence": confidence,
+            "n_sessions": n,
+            "method": "bootstrap_percentile_session_resample",
+        }
+
+    rates.sort()
+    alpha = 1.0 - confidence
+    lo_idx = int((alpha / 2.0) * len(rates))
+    hi_idx = min(len(rates) - 1, int((1.0 - alpha / 2.0) * len(rates)))
+    return {
+        "point": round(point, 4),
+        "ci_low": round(rates[lo_idx], 4),
+        "ci_high": round(rates[hi_idx], 4),
+        "confidence": confidence,
+        "n_sessions": n,
+        "method": "bootstrap_percentile_session_resample",
+    }

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -118,3 +118,65 @@ def test_wilcoxon_alpha_threshold_respected():
     assert strict["significant"] is False
     lenient = wilcoxon_test(x, y, alpha=0.05)
     assert lenient["significant"] is True
+
+
+# ── bootstrap confidence interval for count-weighted rates ──
+
+from qallm.stats import bootstrap_rate_ci  # noqa: E402
+
+
+def test_bootstrap_point_matches_pooled_rate():
+    # 3 sessions; pooled rate = (1+2+3)/(2+4+6) = 6/12 = 0.5
+    res = bootstrap_rate_ci([1, 2, 3], [2, 4, 6])
+    assert res["point"] == 0.5
+    assert res["n_sessions"] == 3
+
+
+def test_bootstrap_ci_brackets_point():
+    num = [1, 2, 0, 3, 1, 2, 1, 0, 2, 1]
+    den = [2, 4, 2, 5, 3, 4, 2, 2, 4, 3]
+    res = bootstrap_rate_ci(num, den)
+    assert res["ci_low"] <= res["point"] <= res["ci_high"]
+    assert 0.0 <= res["ci_low"] <= 1.0
+    assert 0.0 <= res["ci_high"] <= 1.0
+
+
+def test_bootstrap_is_deterministic_with_seed():
+    num = [1, 2, 0, 3, 1, 2]
+    den = [2, 4, 2, 5, 3, 4]
+    a = bootstrap_rate_ci(num, den, seed=7)
+    b = bootstrap_rate_ci(num, den, seed=7)
+    assert a == b
+
+
+def test_bootstrap_zero_denominator_returns_none_point():
+    res = bootstrap_rate_ci([0, 0], [0, 0])
+    assert res["point"] is None
+    assert res["ci_low"] is None
+
+
+def test_bootstrap_single_session_is_degenerate():
+    res = bootstrap_rate_ci([1], [2])
+    assert res["point"] == 0.5
+    assert res["ci_low"] == res["ci_high"] == 0.5
+    assert "note" in res
+
+
+def test_bootstrap_complete_certainty_tight_interval():
+    # Every session is a pure gap (num == den): rate must be 1.0 with a
+    # degenerate-to-tight interval since every resample also gives 1.0.
+    res = bootstrap_rate_ci([2, 3, 1, 4], [2, 3, 1, 4])
+    assert res["point"] == 1.0
+    assert res["ci_low"] == 1.0 and res["ci_high"] == 1.0
+
+
+def test_bootstrap_mismatched_lengths_raises():
+    import pytest as _pytest
+    with _pytest.raises(ValueError):
+        bootstrap_rate_ci([1, 2], [1])
+
+
+def test_bootstrap_result_is_json_serialisable():
+    import json
+    res = bootstrap_rate_ci([1, 2, 3], [2, 4, 6])
+    json.dumps(res)  # must not raise


### PR DESCRIPTION

Branch: `feature/setup-script-and-bootstrap-ci` (off `dev`, after #100)
**1 commit.** Suite: **580 passed** (572 + 8 new), ruff clean.

Two things: the experiment setup ergonomics you asked for, and a real statistical-rigour feature for the thesis.

## 1. Setup script (`scripts/setup.sh`)

Removes the manual venv dance. From the repo root:

```
./scripts/setup.sh --experiments     # venv + base + datasets extra
source .venv/bin/activate             # the one step a script can't do for you
```

It's idempotent (reuses an existing `.venv`), creates the venv, upgrades pip, and installs the package (with the `[experiments]` extra when `--experiments` is passed). It then prints exactly the `source .venv/bin/activate` line, with the explanation that a child process cannot activate the venv in your parent shell, so that one step is yours. I verified it end to end in a clean copy: fresh venv created, `qallm` imports inside it, re-run reuses the venv, `--experiments` installs the extra.

`docs/running-experiments.md` documents the full venv → activate → run flow (with the `(.venv)` prompt check you described) and a troubleshooting section. Linked from the README docs map.

## 2. Bootstrap confidence intervals (roadmap Tier 1)

A point estimate like "91.3%" invites the examiner question "with what confidence?". Now each of the three aggregate rates carries a 95% CI.

`qallm.stats.bootstrap_rate_ci` is a percentile bootstrap that resamples **sessions** with replacement and recomputes the pooled rate. The methodological choice that matters: sessions are the independent unit because findings cluster within them, so resampling sessions (not individual findings) gives an interval that respects that clustering, a per-finding bootstrap would understate it. Deterministic with a seed, native-typed (JSON-safe, learning from the earlier numpy-bool bug), with explicit degenerate-case handling (zero denominator → null point; single session → degenerate interval).

`AggregateMetrics` now exposes `confidence_intervals()` in its `to_dict`, so `/api/metrics/aggregate` and the experiment `aggregate.json` carry the CIs automatically.

## A real bug the concrete-value test caught

My first version read `confirmed_findings` from the per-session **dict**, which `to_dict()` does not include. That silently made the gap denominator equal the numerator, producing a spurious **1.0** for every run. I caught it because I tested with a known expected value (pooled gap should be 0.75 for my fixture), not just "does it run". Fixed by computing the CI inputs from the **typed** `SessionMetrics` objects during aggregation, not the lossy dict. This is the same lesson as the earlier stats bug: serialisation and dict round-trips lose things, test the numbers, not the execution.

## Tests

8 new in `test_stats.py`: point matches pooled rate, CI brackets the point and stays in [0,1], seed-deterministic, zero-denominator → null, single-session degenerate, complete-certainty tight interval, mismatched lengths raise, JSON-serialisable. Plus the live check that the aggregate emits a correct 0.75 point with a real [0.5, 1.0] interval.

## Verify locally

```
pip install -e . --break-system-packages
pytest -q tests/test_stats.py        # 20 passed
pytest -q                            # 580 passed
ruff check src/qallm
# setup script, in a throwaway clone:
./scripts/setup.sh --experiments && source .venv/bin/activate
python -c "from qallm.metrics_export import SessionMetrics, aggregate_sessions; \
import json; \
a=aggregate_sessions([SessionMetrics(session_id='s',execution_only_bugs=3,confirmed_findings=1)]).to_dict(); \
print(a['confidence_intervals']['verification_gap_rate'])"
```
