### PR TITLE
fix(experiments): gap runner passed wrong rounds kwarg to orchestrator

### DIFF
--- a/datasets/lab/MANIFEST.md
+++ b/datasets/lab/MANIFEST.md
@@ -17,7 +17,7 @@ The fixtures are organised by what they exercise. Findings below were verified
 against the actual analyzers (Bandit, Radon) and by executing the code, so this
 manifest is an answer key, not an aspiration.
 
-## reliability_gap.py — the verification gap (RQ1)
+## reliability_gap.py: the verification gap (RQ1)
 
 Lint-clean, low-complexity functions that are wrong at runtime. Static analysis
 passes them; execution should find the defect.
@@ -33,7 +33,7 @@ passes them; execution should find the defect.
 Expected: static analysis reports no reliability bug; execution-based
 verification finds defects in all five. These drive the verification-gap rate.
 
-## security_findings.py — confirmation (RQ2)
+## security_findings.py: confirmation (RQ2)
 
 Code Bandit flags. Execution decides which are genuinely reachable.
 
@@ -47,7 +47,7 @@ Expected: security findings present; confirm/refute corroborates the eval and
 shell cases, and `build_query` exercises the path where a finding has no
 execution oracle.
 
-## complexity_findings.py — not execution testable
+## complexity_findings.py: not execution testable
 
 Findings about source structure, not behaviour. The code is correct.
 
@@ -59,7 +59,7 @@ Findings about source structure, not behaviour. The code is correct.
 Expected: complexity/maintainability findings present; no runtime bug; these
 classify as not execution testable, exercising that branch.
 
-## clean_control.py — negative control
+## clean_control.py: negative control
 
 Correct, simple, secure functions. A sound pipeline finds nothing here.
 

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -83,7 +83,7 @@ def _default_orchestrator_factory(config: GapExperimentConfig):
         strategy=config.strategy,
         llm_type=config.llm_type,
         model_name=config.model_name,
-        rounds_per_function=config.rounds,
+        rounds=config.rounds,
         oracle=config.oracle,
         judge_strategy=config.judge_strategy,
         stage=config.stage,

--- a/tests/test_gap_runner.py
+++ b/tests/test_gap_runner.py
@@ -8,6 +8,7 @@ from qallm.experiments.gap_runner import (
     GapExperimentConfig,
     run_gap_experiment,
     _discover_inputs,
+    _default_orchestrator_factory,
 )
 
 
@@ -129,3 +130,29 @@ def test_error_isolated_per_input(tmp_path):
     assert len(result.per_session) == 1     # the good one
     assert len(result.errors) == 1          # the bad one, isolated
     assert "kernel exploded" in result.errors[0]["error"]
+
+
+def test_default_orchestrator_factory_constructs(tmp_path):
+    """The real factory must construct a QALLMOrchestrator without kwarg
+    mismatches.
+
+    Regression: the factory passed rounds_per_function= but the constructor
+    takes rounds=, so every real run failed at construction. The other tests
+    use a fake factory and never exercised this path. This builds the real
+    orchestrator (no network: construction creates no LLM clients) and checks
+    the config is applied.
+    """
+    config = GapExperimentConfig(
+        dataset_dir=tmp_path,
+        output_dir=tmp_path / "out",
+        llm_type="openai",      # construction does not call the API
+        strategy="feedback",
+        rounds=3,
+        oracle="crash",
+        judge_strategy="lexicographic",
+        stage="implementation",
+    )
+    orch = _default_orchestrator_factory(config)
+    assert orch is not None
+    # The rounds value should have been accepted and applied.
+    assert orch.rounds == 3


### PR DESCRIPTION
Running the gap experiment failed at orchestrator construction for every input: "QALLMOrchestrator.__init__() got an unexpected keyword argument 'rounds_per_function'". The default orchestrator factory passed rounds_per_function=, but the constructor's parameter is rounds= (as the API and CLI use). Result: 0 sessions, all inputs errored.

Latent since the gap runner was added (#91): every gap-runner test uses a fake orchestrator factory, so the real _default_orchestrator_factory and its constructor call were never exercised. The other kwargs (strategy, llm_type, model_name, oracle, judge_strategy, stage) are all correct; only the rounds name was wrong.

Fix: rounds_per_function -> rounds in _default_orchestrator_factory.

Regression test: test_default_orchestrator_factory_constructs builds the real orchestrator via the factory (construction creates no LLM clients, so no network) and asserts orch.rounds == 3. This closes the coverage gap that let the bug ship, the real factory is now exercised, not just the fake.

Suite: 581 passed; ruff clean.