### PR TITLE
feat: origin-agnostic framing + batch retention mode (metrics_only)

### DIFF
--- a/docs/guides/running-experiments.md
+++ b/docs/guides/running-experiments.md
@@ -53,6 +53,14 @@ python scripts/run_gap_experiment.py \
     --llm fedllm --rounds 5 --confirm
 ```
 
+By default a batch gap run uses `--retention metrics_only`: it keeps the gap
+data in `summary.json` and skips the per-unit round directories, which is far
+less disk on a large dataset (those directories are one folder per code unit
+per round). Pass `--retention full` to keep every variant's provenance for
+deep inspection. Note `--confirm` forces `full` automatically, because
+confirm/refute and verify-fixes reconstruct their inputs from the per-round
+artefacts on disk.
+
 HumanEvalFix validation track:
 
 ```

--- a/docs/showcase/qallm-overview.html
+++ b/docs/showcase/qallm-overview.html
@@ -297,9 +297,10 @@
     <div class="kicker">MSc Thesis · University of Amsterdam · MNS Group</div>
     <h1>QALLM: execution decides<br>what static analysis can <em>only guess</em>.</h1>
     <p class="standfirst">
-      A research instrument that measures and improves the quality of AI-generated Python notebooks
+      A research instrument that measures and improves the quality of Python notebooks and scripts
       against a chosen quality model, by treating every static finding as a hypothesis and using
-      execution as the judge.
+      execution as the judge. It assesses code on its quality, not its origin; AI-generated code is
+      the motivating case, since it is produced faster than it can be reviewed.
     </p>
     <div class="byline">
       Supervisors: Dr. Zhiming Zhao (MNS), Dr. Nafis Tanveer Islam · Aligned with the EVERSE programme
@@ -449,7 +450,7 @@
       </div>
       <div class="aud-col">
         <div class="a-who">Research-software stakeholders</div>
-        <p>A way to quality-gate AI-generated notebook code that answers "is it correct", not just "is it tidy", and proves fixes rather than asserting them. Local or hosted models, your choice.</p>
+        <p>A way to quality-gate notebook code that answers "is it correct", not just "is it tidy", and proves fixes rather than asserting them, whatever produced the code. Local or hosted models, your choice.</p>
       </div>
     </div>
   </section>

--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -53,6 +53,13 @@ def main() -> None:
     parser.add_argument("--confirm", action="store_true",
                         help="Also run confirm/refute (RQ2) and verify-fixes (RQ3) per "
                              "session. Makes extra LLM calls; off by default.")
+    parser.add_argument("--retention", default="metrics_only",
+                        choices=["full", "metrics_only"],
+                        help="Artefact retention. 'metrics_only' (default) skips the "
+                             "per-unit round directories and keeps the gap data in "
+                             "summary.json, far less disk on large datasets. 'full' "
+                             "writes every variant's provenance. --confirm forces 'full' "
+                             "since it reads per-round artefacts from disk.")
     parser.add_argument("--log-level", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"])
     args = parser.parse_args()
@@ -72,6 +79,7 @@ def main() -> None:
         stage=args.stage,
         pattern=args.pattern,
         confirm=args.confirm,
+        artefact_retention=args.retention,
     )
     result = run_gap_experiment(config)
 

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -48,6 +48,10 @@ class GapExperimentConfig:
     stage: str = "implementation"
     pattern: str = "*.ipynb"  # which files in the dataset to run
     confirm: bool = False     # also run confirm/refute + verify-fixes (RQ2/RQ3); costs LLM calls
+    # Batch runs default to metrics_only: skip the per-unit round directories
+    # (thousands of small files across a dataset) and keep the gap data in
+    # summary.json. Pass "full" to retain every variant's provenance.
+    artefact_retention: str = "metrics_only"
 
     def to_manifest(self) -> dict:
         return {
@@ -77,6 +81,23 @@ def _discover_inputs(dataset_dir: Path, pattern: str) -> list[Path]:
     return sorted(dataset_dir.rglob(pattern))
 
 
+def _effective_retention(config: GapExperimentConfig) -> str:
+    """Resolve retention, accounting for confirm's disk dependency.
+
+    confirm/refute and verify-fixes reconstruct their inputs from the on-disk
+    round_0 artefacts, so metrics_only (which does not write them) is
+    incompatible with --confirm. When both are requested, full retention wins
+    and the caller is told why.
+    """
+    if config.confirm and config.artefact_retention == "metrics_only":
+        logger.info(
+            "artefact_retention=metrics_only is incompatible with --confirm "
+            "(confirm/verify read per-round artefacts from disk); using 'full'."
+        )
+        return "full"
+    return config.artefact_retention
+
+
 def _default_orchestrator_factory(config: GapExperimentConfig):
     from qallm.orchestrator import QALLMOrchestrator
     return QALLMOrchestrator(
@@ -86,6 +107,7 @@ def _default_orchestrator_factory(config: GapExperimentConfig):
         rounds=config.rounds,
         oracle=config.oracle,
         judge_strategy=config.judge_strategy,
+        artefact_retention=_effective_retention(config),
         stage=config.stage,
     )
 
@@ -179,10 +201,15 @@ def _run_one(
         orch = orchestrator_factory(config)
         summary = orch.run(str(input_path))
         report_dir = summary.get("report_dir")
-        gap_rounds = (
-            compute_gap_rounds_from_dir(report_dir)
-            if report_dir and os.path.isdir(report_dir) else []
-        )
+        # Prefer gap rounds persisted in the summary (metrics_only retention,
+        # where per-round artefacts are not on disk). Fall back to reading the
+        # per-round directories when running with full retention.
+        if summary.get("gap_rounds"):
+            gap_rounds = summary["gap_rounds"]
+        elif report_dir and os.path.isdir(report_dir):
+            gap_rounds = compute_gap_rounds_from_dir(report_dir)
+        else:
+            gap_rounds = []
         session_id = os.path.basename(report_dir) if report_dir else str(input_path)
 
         confirm_summary = None

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -125,6 +125,7 @@ class QALLMOrchestrator:
             run_id: str | None = None,
             reporter: QualityReporter | None = None,
             tags: list[str] | None = None,
+            artefact_retention: str = "full",
     ) -> None:
         """Construct the orchestrator.
 
@@ -168,7 +169,10 @@ class QALLMOrchestrator:
             self.reporter = reporter
         else:
             effective_run_id = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
-            self.reporter = QualityReporter("outputs/quality_reporter", effective_run_id)
+            self.reporter = QualityReporter(
+                "outputs/quality_reporter", effective_run_id,
+                artefact_retention=artefact_retention,
+            )
 
         self.stage = stage if isinstance(stage, LifecycleStage) else LifecycleStage(stage)
         # Canonicalise the verifier name. ``rl`` is a legacy alias for the
@@ -723,6 +727,15 @@ class QALLMOrchestrator:
             "test_persistence": self.verification_manager.get_stability_summary(),
             "tracks": tracks_dict,
             "sessions": sessions_data,
+            # Absolute path to this run's output directory, so batch runners
+            # can locate per-round artefacts (full retention) or just read the
+            # gap data below (metrics_only).
+            "report_dir": str(self.reporter.report_dir),
+            # When artefacts are not written per round (metrics_only
+            # retention), the gap data is accumulated in memory and persisted
+            # here so the gap rate stays computable from summary.json alone.
+            "gap_rounds": self.reporter.gap_rounds,
+            "artefact_retention": self.reporter.artefact_retention,
         }
         self.reporter._ensure_dir()
         summary_path = self.reporter.report_dir / "summary.json"

--- a/src/qallm/utils/reporter.py
+++ b/src/qallm/utils/reporter.py
@@ -76,7 +76,12 @@ class QualityReporter:
     The orchestrator constructs one per run.
     """
 
-    def __init__(self, base_dir: str = "outputs/reports", run_id: Optional[str] = None) -> None:
+    def __init__(
+        self,
+        base_dir: str = "outputs/reports",
+        run_id: Optional[str] = None,
+        artefact_retention: str = "full",
+    ) -> None:
         # Allow run_id override for deterministic test directories. The default
         # is "{timestamp}_{short-uuid}", the same shape the web upload/analyse
         # paths use, so every session directory has a consistent name and two
@@ -86,6 +91,24 @@ class QualityReporter:
             f"{datetime.now().strftime('%Y%m%d_%H%M%S')}_{uuid.uuid4().hex[:8]}"
         )
         self.report_dir = Path(base_dir) / self.run_id
+        # Artefact retention controls how much per-round provenance is written.
+        #   "full"         : write every variant's source/static/verification/
+        #                    tests under lineage/ and abandoned/ (default; best
+        #                    for interactive single runs and deep inspection).
+        #   "metrics_only" : skip those per-unit round directories (the bulk of
+        #                    the disk footprint on large batch runs) but still
+        #                    accumulate the gap data in memory so the gap rate
+        #                    remains computable from summary.json. Use for big
+        #                    dataset experiments where per-file provenance for
+        #                    thousands of units is neither needed nor wanted.
+        if artefact_retention not in ("full", "metrics_only"):
+            raise ValueError(
+                f"artefact_retention must be 'full' or 'metrics_only', "
+                f"got {artefact_retention!r}"
+            )
+        self.artefact_retention = artefact_retention
+        # Gap rounds accumulated in memory when retention skips disk artefacts.
+        self.gap_rounds: list[dict] = []
         # The directory is created lazily, on the first artefact write, NOT
         # here. Constructing a reporter (which the orchestrator does in its
         # own constructor) must not leave an empty session directory on disk
@@ -96,6 +119,28 @@ class QualityReporter:
     def _ensure_dir(self) -> None:
         """Create the session directory on first use. Idempotent."""
         self.report_dir.mkdir(parents=True, exist_ok=True)
+
+    def _accumulate_gap_round(self, round_dict: dict) -> None:
+        """Merge one unit's gap report into the in-memory per-round totals.
+
+        Used in metrics_only retention, where per-unit round directories are
+        not written. Multiple units can contribute to the same round, so
+        findings and execution-only functions are merged by round number,
+        matching how compute_gap_rounds_from_dir merges across unit
+        subdirectories on disk.
+        """
+        rno = round_dict.get("round")
+        existing = next((r for r in self.gap_rounds if r.get("round") == rno), None)
+        if existing is None:
+            self.gap_rounds.append(round_dict)
+            return
+        existing.setdefault("findings", []).extend(round_dict.get("findings", []))
+        eo = existing.setdefault("execution_only_functions", [])
+        eo.extend(round_dict.get("execution_only_functions", []))
+        existing["execution_only_functions"] = sorted(set(eo))
+        # Refresh the summary counts to match the merged lists.
+        summary = existing.setdefault("summary", {})
+        summary["execution_only"] = len(existing["execution_only_functions"])
 
     # ----- baseline -----
 
@@ -149,6 +194,21 @@ class QualityReporter:
         """
         self._ensure_dir()
         bucket = "lineage" if accepted else "abandoned"
+
+        if self.artefact_retention == "metrics_only":
+            # Skip the per-unit round directory (the bulk of the disk
+            # footprint), but still compute the gap data this round would
+            # have contributed, so the gap rate stays computable from
+            # summary.json without re-reading any files. Mirrors exactly what
+            # compute_gap_rounds_from_dir would derive from the on-disk
+            # source.py/static.json/verification.json for this unit.
+            from qallm.analysis.gap_analysis import build_gap_report
+            verification = [_session_dict(s) for s in tested.sessions]
+            unit_report = build_gap_report(
+                round_number, code_unit.source_code, analysed.findings, verification
+            )
+            self._accumulate_gap_round(unit_report.to_dict())
+            return self.report_dir
         # Per-unit subdirectories let multi-unit sessions co-exist within
         # lineage/round_N/ without filename collisions.
         round_dir = (

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -422,3 +422,98 @@ class TestUnitSegmentCleanNames:
         assert out.name == "count_chars.py__0"
         # And it's short.
         assert len(out.name) < 30
+
+
+# ---------- artefact retention: metrics_only ----------
+
+def _tested_with_bug(unit: CodeUnit, function_name: str = "f") -> TestedCodeUnit:
+    """A TestedCodeUnit whose single session has a failing test (a bug)."""
+    from qallm.repair.repair_model import RepairedCodeUnit, RepairResult
+
+    repaired_result = RepairResult(
+        file_path=str(unit.original_path),
+        repaired_source=unit.source_code,
+        explanation="stub",
+        compiles=True,
+    )
+    repaired = RepairedCodeUnit(
+        analysis_result=AnalysedCodeUnit(code_unit=unit, findings=[], raw_tool_results=[]),
+        repaired_result=repaired_result,
+    )
+    session = TestGenerationSession(
+        function_name=function_name, source_code=unit.source_code,
+        oracle="crash", model="stub", total_rounds=1,
+    )
+    session.rounds.append(RoundResult(
+        round_number=1,
+        generated_test=GeneratedTest(
+            function_name=function_name, oracle="crash",
+            test_code="def test_f(): assert f() == 1", is_valid=True,
+            generation_error=None, model="stub", provider="stub",
+            input_tokens=0, output_tokens=0,
+        ),
+        execution=ExecutionResult(passed=0, failed=1, total=1, coverage_percent=100.0),
+        reward=RewardBreakdown(total=0.0),
+        cumulative_coverage=100.0,
+        cumulative_bugs=1,
+    ))
+    return TestedCodeUnit(repaired_unit=repaired, sessions=[session])
+
+
+def test_metrics_only_rejects_bad_value(tmp_path: Path):
+    with pytest.raises(ValueError):
+        QualityReporter(base_dir=str(tmp_path), run_id="r", artefact_retention="bogus")
+
+
+def test_metrics_only_writes_no_round_dirs_but_keeps_gap(tmp_path: Path):
+    src = "def f():\n    return 0\n"  # returns 0; the test expects 1 -> a bug
+    unit = _code_unit(tmp_path / "src", source=src, name="f.py")
+    tested = _tested_with_bug(unit)
+
+    r = QualityReporter(base_dir=str(tmp_path), run_id="mo",
+                        artefact_retention="metrics_only")
+    out = r.save_round_artefacts(
+        round_number=0, unit_id="f.py::0", code_unit=unit,
+        analysed=_analysed(unit), tested=tested,
+        profile_verdict=_profile_verdict(), judge_verdict_dict=None, accepted=True,
+    )
+    # No per-unit round directory was written.
+    assert not (out / "lineage" / "round_00").exists()
+    assert not (out / "abandoned").exists()
+    # But the gap data was accumulated in memory.
+    assert len(r.gap_rounds) == 1
+    assert r.gap_rounds[0]["round"] == 0
+    # The function has an execution-found bug and no static finding -> gap.
+    assert "f" in r.gap_rounds[0]["execution_only_functions"]
+
+
+def test_metrics_only_gap_matches_full_retention(tmp_path: Path):
+    """The whole point: metrics_only must yield the same gap as full."""
+    from qallm.analysis.gap_analysis import compute_gap_rounds_from_dir
+
+    src = "def f():\n    return 0\n"
+    unit = _code_unit(tmp_path / "src", source=src, name="f.py")
+
+    # full retention: write artefacts, then read gap from disk
+    r_full = QualityReporter(base_dir=str(tmp_path / "full"), run_id="full",
+                             artefact_retention="full")
+    r_full.save_round_artefacts(
+        round_number=0, unit_id="f.py::0", code_unit=unit,
+        analysed=_analysed(unit), tested=_tested_with_bug(unit),
+        profile_verdict=_profile_verdict(), judge_verdict_dict=None, accepted=True,
+    )
+    disk_gap = compute_gap_rounds_from_dir(str(r_full.report_dir))
+
+    # metrics_only: gap accumulated in memory, no disk artefacts
+    r_mo = QualityReporter(base_dir=str(tmp_path / "mo"), run_id="mo",
+                           artefact_retention="metrics_only")
+    r_mo.save_round_artefacts(
+        round_number=0, unit_id="f.py::0", code_unit=unit,
+        analysed=_analysed(unit), tested=_tested_with_bug(unit),
+        profile_verdict=_profile_verdict(), judge_verdict_dict=None, accepted=True,
+    )
+    mem_gap = r_mo.gap_rounds
+
+    # Same execution-only functions in the same round -> same gap signal.
+    assert disk_gap[0]["execution_only_functions"] == mem_gap[0]["execution_only_functions"]
+    assert disk_gap[0]["round"] == mem_gap[0]["round"]

--- a/web/frontend/src/App.tsx
+++ b/web/frontend/src/App.tsx
@@ -97,7 +97,7 @@ export default function App() {
                 </span>
               )}
             </div>
-            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Quality Assessment of AI-Generated Code</h1>
+            <h1 className="mt-2 text-3xl font-semibold tracking-tight">Execution-Based Code Quality Assessment</h1>
             <p className="mt-1 max-w-2xl text-sm text-slate-500">Baseline, then LLM repair and execution-based verification across budget-capped rounds, judged against a quality model.</p>
           </div>
           {state.sessionId && (

--- a/web/frontend/tsconfig.json
+++ b/web/frontend/tsconfig.json
@@ -7,6 +7,7 @@
     "moduleDetection": "force", "noEmit": true, "jsx": "react-jsx",
     "strict": true, "noUnusedLocals": false, "noUnusedParameters": false,
     "noFallthroughCasesInSwitch": true,
+    "ignoreDeprecations": "5.0",
     "baseUrl": ".", "paths": { "@/*": ["src/*"] }
   },
   "include": ["src"]


### PR DESCRIPTION
Two improvements plus a build fix.

1. Origin-agnostic framing. QALLM assesses code on its quality, not its origin; AI-generated code is the motivating case, not the limit. The app tagline (App.tsx) changes from "Quality Assessment of AI-Generated Code" to "Execution-Based Code Quality Assessment", and the overview showcase standfirst/takeaway are reworded to say so explicitly. The thesis title is intentionally unchanged (it is legitimately motivated by AI-generated code); only the product positioning moves.

2. Batch retention mode. Large dataset runs wrote one directory per code unit per round under lineage/ and abandoned/, the bulk of the disk footprint. QualityReporter gains artefact_retention ("full" default | "metrics_only"). In metrics_only, save_round_artefacts skips the per-unit directory but computes the gap data in memory (mirroring exactly what compute_gap_rounds_from_dir would derive on disk) and accumulates it; the orchestrator persists reporter.gap_rounds into summary.json. The gap runner prefers summary["gap_rounds"] and falls back to reading the directories, so the gap rate is identical either way. A test asserts metrics_only yields the same execution-only functions as full retention.

   Interaction handled: --confirm reconstructs confirm/verify inputs from the per-round artefacts on disk, so it is incompatible with metrics_only. The runner forces "full" when --confirm is set and logs why. Batch defaults to metrics_only; the CLI exposes --retention.

3. Build fix (pre-existing, now fatal): tsconfig baseUrl deprecation became a hard error in TypeScript 5.9 and broke the frontend build. Added "ignoreDeprecations": "5.0" (the value TS 5.9 accepts), keeping baseUrl for the @/* alias. tsc --noEmit and vite build are both clean again.

Tests: 3 new in test_reporter.py (metrics_only rejects bad value; writes no round dirs but keeps gap; gap matches full retention). Suite: 584 passed; ruff clean; frontend builds.