### PR TITLE
ci+feat: docker smoke test; surface showcase HTML pages in Docs tab

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,3 +41,53 @@ jobs:
 
       - name: Run the test suite
         run: pytest -q --tb=short
+
+  # Smoke-test the BUILT artifact, not just the source. Several past bugs
+  # rendered fine in an editable dev install but broke in the packaged image
+  # (a non-editable pip install changes __file__ paths, docs/ was not copied,
+  # a frontend library was missing). This job builds the image, starts the
+  # api, and curls the endpoints that depend on packaging being correct, so
+  # that whole class of "works in dev, breaks in the container" is caught in
+  # CI. It builds only; it never touches the staging VM.
+  docker-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the code
+        uses: actions/checkout@v4
+
+      - name: Build the image
+        run: docker build -t qallm:ci .
+
+      - name: Start the api container
+        run: |
+          docker run -d --name qallm-ci -p 8000:8000 qallm:ci
+          # Wait for the app to come up (up to ~60s).
+          for i in $(seq 1 30); do
+            if curl -fsS http://localhost:8000/api/health >/dev/null 2>&1; then
+              echo "api is up"; break
+            fi
+            sleep 2
+          done
+
+      - name: Smoke-test packaged endpoints
+        run: |
+          set -e
+          # Health.
+          curl -fsS http://localhost:8000/api/health | tee /dev/stderr | grep -q online
+          # Models catalogue (depends on the packaged core, not the repo).
+          curl -fsS http://localhost:8000/api/verification/models | tee /dev/stderr | grep -q '"id"'
+          # Docs list must be non-empty in the container (this caught the
+          # "No docs found" packaging bug: docs/ not copied, wrong __file__).
+          docs_json=$(curl -fsS http://localhost:8000/api/docs)
+          echo "$docs_json"
+          echo "$docs_json" | grep -q '"readme"'
+          # README must render to HTML (markdown dependency present).
+          curl -fsS http://localhost:8000/api/docs/readme | grep -q '<h1'
+
+      - name: Container logs on failure
+        if: failure()
+        run: docker logs qallm-ci || true
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f qallm-ci || true

--- a/src/qallm/api/routers/docs.py
+++ b/src/qallm/api/routers/docs.py
@@ -30,6 +30,7 @@ from pathlib import Path
 
 import markdown
 from fastapi import APIRouter, HTTPException
+from fastapi.responses import HTMLResponse
 
 logger = logging.getLogger(__name__)
 
@@ -86,12 +87,19 @@ def _resolve(rel: str) -> Path | None:
 
 # The curated set surfaced in the UI. Keys are stable ids used by the
 # frontend; values are (title, path-relative-to-a-doc-root). README first.
-_DOCS: dict[str, tuple[str, str]] = {
-    "readme": ("Overview (README)", "README.md"),
-    "workflow": ("How QALLM works", "docs/architecture/workflow-design.md"),
-    "surpassing": ("Why execution beats static analysis", "docs/concepts/surpassing-static-analysers.md"),
-    "running-experiments": ("Running experiments", "docs/guides/running-experiments.md"),
-    "roadmap": ("Roadmap", "docs/thesis/roadmap.md"),
+# Each entry: id -> (title, repo-relative path, kind). "md" docs are rendered
+# to HTML inline in the Docs tab; "html" docs are complete standalone pages
+# (their own <style>, layout) and are opened in a new tab via the raw endpoint
+# rather than injected inline, where their full-page markup would clash with
+# the app shell.
+_DOCS: dict[str, tuple[str, str, str]] = {
+    "readme": ("Overview (README)", "README.md", "md"),
+    "workflow": ("How QALLM works", "docs/architecture/workflow-design.md", "md"),
+    "surpassing": ("Why execution beats static analysis", "docs/concepts/surpassing-static-analysers.md", "md"),
+    "running-experiments": ("Running experiments", "docs/guides/running-experiments.md", "md"),
+    "roadmap": ("Roadmap", "docs/thesis/roadmap.md", "md"),
+    "overview-page": ("QALLM overview (page)", "docs/showcase/qallm-overview.html", "html"),
+    "gap-explainer": ("The verification gap (interactive)", "docs/showcase/verification-gap-explainer.html", "html"),
 }
 
 _MD_EXTENSIONS = ["fenced_code", "tables", "toc", "sane_lists"]
@@ -125,12 +133,13 @@ def list_docs() -> dict:
 
     Only docs whose file is found under some candidate root are returned, so a
     layout missing the docs tree simply shows fewer entries (README should be
-    present in every layout).
+    present in every layout). Each item carries its kind ("md" rendered inline,
+    "html" opened in a new tab via /api/docs/{id}/raw).
     """
     items = []
-    for doc_id, (title, rel) in _DOCS.items():
+    for doc_id, (title, rel, kind) in _DOCS.items():
         if _resolve(rel) is not None:
-            items.append({"id": doc_id, "title": title, "path": rel})
+            items.append({"id": doc_id, "title": title, "path": rel, "kind": kind})
     if not items:
         # Surface the failure: every layout should at least find the README.
         logger.warning(
@@ -142,11 +151,20 @@ def list_docs() -> dict:
 
 @router.get("/api/docs/{doc_id}")
 def get_doc(doc_id: str) -> dict:
-    """Return one doc rendered to HTML."""
+    """Return one Markdown doc rendered to HTML.
+
+    For "html" docs (complete standalone pages) use /api/docs/{doc_id}/raw
+    instead; this endpoint reports that so the frontend can route correctly.
+    """
     entry = _DOCS.get(doc_id)
     if entry is None:
         raise HTTPException(status_code=404, detail=f"Unknown doc: {doc_id}")
-    title, rel = entry
+    title, rel, kind = entry
+    if kind != "md":
+        raise HTTPException(
+            status_code=400,
+            detail=f"{doc_id} is a standalone page; use /api/docs/{doc_id}/raw",
+        )
     path = _resolve(rel)
     if path is None:
         raise HTTPException(status_code=404, detail=f"Doc not found: {rel}")
@@ -155,3 +173,23 @@ def get_doc(doc_id: str) -> dict:
     except OSError as e:
         raise HTTPException(status_code=500, detail=f"Could not read {rel}: {e}")
     return {"id": doc_id, "title": title, "html": _render(text)}
+
+
+@router.get("/api/docs/{doc_id}/raw", response_class=HTMLResponse)
+def get_doc_raw(doc_id: str) -> HTMLResponse:
+    """Serve a standalone HTML doc verbatim (for the showcase pages).
+
+    These are complete documents with their own styling, so they are served
+    as-is to be opened in a new tab rather than injected into the app shell.
+    """
+    entry = _DOCS.get(doc_id)
+    if entry is None:
+        raise HTTPException(status_code=404, detail=f"Unknown doc: {doc_id}")
+    _title, rel, _kind = entry
+    path = _resolve(rel)
+    if path is None:
+        raise HTTPException(status_code=404, detail=f"Doc not found: {rel}")
+    try:
+        return HTMLResponse(content=path.read_text(encoding="utf-8"))
+    except OSError as e:
+        raise HTTPException(status_code=500, detail=f"Could not read {rel}: {e}")

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -25,9 +25,26 @@ def test_list_docs_includes_readme():
 
 
 def test_listed_docs_all_exist_and_render():
+    # md docs render via /api/docs/{id}; html docs are served raw and 400 on
+    # the markdown endpoint by design (the frontend opens them in a new tab).
     for d in client.get("/api/docs").json()["docs"]:
-        r = client.get(f"/api/docs/{d['id']}")
-        assert r.status_code == 200, d["id"]
+        if d.get("kind") == "html":
+            assert client.get(f"/api/docs/{d['id']}").status_code == 400
+            assert client.get(f"/api/docs/{d['id']}/raw").status_code == 200
+        else:
+            assert client.get(f"/api/docs/{d['id']}").status_code == 200, d["id"]
+
+
+def test_each_listed_doc_has_a_kind():
+    for d in client.get("/api/docs").json()["docs"]:
+        assert d.get("kind") in ("md", "html")
+
+
+def test_showcase_html_served_verbatim():
+    # The standalone showcase pages are served as full HTML documents.
+    r = client.get("/api/docs/overview-page/raw")
+    assert r.status_code == 200
+    assert r.text.lstrip().startswith("<!DOCTYPE")
 
 
 def test_get_readme_renders_html():

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -786,3 +786,9 @@ export async function listDocs(): Promise<{ docs: { id: string; title: string; p
 export async function getDoc(docId: string): Promise<{ id: string; title: string; html: string }> {
   return req<{ id: string; title: string; html: string }>(`/api/docs/${encodeURIComponent(docId)}`);
 }
+
+// URL for a standalone HTML doc, served verbatim (opened in a new tab).
+// Relative so it works behind the reverse proxy regardless of host/port.
+export function docRawUrl(docId: string): string {
+  return `/api/docs/${encodeURIComponent(docId)}/raw`;
+}

--- a/web/frontend/src/screens/DocsView.tsx
+++ b/web/frontend/src/screens/DocsView.tsx
@@ -17,6 +17,7 @@ interface DocMeta {
   id: string;
   title: string;
   path: string;
+  kind?: "md" | "html";
 }
 
 export default function DocsView() {
@@ -26,6 +27,7 @@ export default function DocsView() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const contentRef = useRef<HTMLElement | null>(null);
+  const activeKind = docs.find((d) => d.id === activeId)?.kind ?? "md";
 
   // Load the doc list once, then select the first (README).
   useEffect(() => {
@@ -45,9 +47,13 @@ export default function DocsView() {
     return () => { alive = false; };
   }, []);
 
-  // Fetch the active doc's HTML whenever the selection changes.
+  // Fetch the active doc's HTML whenever the selection changes. Standalone
+  // "html" docs are not fetched here, they open in a new tab via the raw
+  // endpoint, so only "md" docs are rendered inline.
   useEffect(() => {
     if (!activeId) return;
+    const meta = docs.find((d) => d.id === activeId);
+    if (meta?.kind === "html") { setHtml(""); setLoading(false); setError(null); return; }
     let alive = true;
     setLoading(true);
     setError(null);
@@ -55,7 +61,7 @@ export default function DocsView() {
       .then((r) => { if (alive) { setHtml(r.html); setLoading(false); } })
       .catch((e) => { if (alive) { setError(String(e)); setLoading(false); } });
     return () => { alive = false; };
-  }, [activeId]);
+  }, [activeId, docs]);
 
   // After the rendered HTML lands in the DOM, turn any <pre class="mermaid">
   // blocks into diagrams. Mermaid is large and only needed here, so it is
@@ -120,7 +126,22 @@ export default function DocsView() {
         {loading && !error && (
           <div className="animate-pulse text-sm text-slate-400">Loading…</div>
         )}
-        {!loading && !error && (
+        {!loading && !error && activeKind === "html" && (
+          <div className="rounded-2xl border border-slate-200 bg-white p-8">
+            <p className="text-sm text-slate-600">
+              This is a standalone page with its own layout. Open it in a new tab:
+            </p>
+            <a
+              href={activeId ? api.docRawUrl(activeId) : "#"}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="mt-3 inline-flex items-center gap-1.5 rounded-lg bg-slate-900 px-3 py-1.5 text-sm font-medium text-white hover:bg-slate-700"
+            >
+              <BookOpen className="h-3.5 w-3.5" /> Open {docs.find((d) => d.id === activeId)?.title}
+            </a>
+          </div>
+        )}
+        {!loading && !error && activeKind !== "html" && (
           <article
             ref={contentRef}
             className="qallm-doc rounded-2xl border border-slate-200 bg-white p-8"


### PR DESCRIPTION
Two things from the review.

1. CI Docker smoke test. The source CI (install/lint/test) never exercised the built artifact, and the last several bugs only appeared in the packaged image (non-editable install changing __file__ paths, docs/ not copied, a missing frontend library). A new docker-smoke job builds the image, starts the api, and curls the endpoints that depend on packaging being correct: /api/health (online), /api/verification/models (catalogue), /api/docs (non-empty, has readme, the exact "No docs found" bug), and /api/docs/readme (renders to HTML, markdown dep present). Container logs are dumped on failure. Build-only; it never touches the staging VM. The curl assertions were validated against the running app so the greps match real output.

2. Showcase HTML pages in the Docs tab. qallm-overview.html and verification-gap-explainer.html were absent from the Docs tab because the docs router only rendered Markdown; these are complete standalone HTML documents (own <style>/layout). The router now carries a kind per doc ("md" rendered inline, "html" served verbatim via /api/docs/{id}/raw) and lists both showcase pages. The frontend shows an "open in a new tab" card for html docs rather than injecting full-page markup into the app shell; md docs render inline as before. Raw URL is relative, so it works behind the reverse proxy on port 80.

Tests (test_docs_router.py): render test respects kind (html 400s on the md endpoint and 200s on /raw); every listed doc has a kind; showcase HTML served verbatim as a full document.

Suite: 608 passed; ruff clean; frontend builds (project-pinned tsc 5.x).