### PR TITLE
feat(jupyter): show the verification gap inline in the %%qallm magic

### DIFF
--- a/docs/guides/jupyter-magic.md
+++ b/docs/guides/jupyter-magic.md
@@ -109,3 +109,13 @@ Sessions tab.
   notebook.
 - Results render as inline HTML in the notebook, with a plain-text
   fallback where rich display is unavailable.
+
+## The verification gap, inline
+
+When a run finds a runtime defect in a function that static analysis passed,
+the inline summary shows a "Verification gap found" block with the actual
+generated test that fails against that function. This is the point of QALLM
+made tangible in the notebook: the researcher sees not just a bug count but
+the concrete, runnable test that proves their code is wrong even though the
+linter was happy. Clean functions produce no such block, so the gap section
+only appears when there is a real gap to show.

--- a/src/qallm/jupyter.py
+++ b/src/qallm/jupyter.py
@@ -95,6 +95,23 @@ def _make_arg_parser():
     return p
 
 
+def _failing_test_for_session(session: dict) -> str | None:
+    """The test code from the first round whose execution had a failure.
+
+    This is the concrete proof of a verification-gap bug: a test that ran and
+    failed against code that static analysis passed. Surfacing it inline is
+    the point, the researcher sees exactly what breaks, in their own notebook.
+    """
+    for rnd in session.get("rounds", []) or []:
+        execution = rnd.get("execution") or {}
+        if (execution.get("failed") or 0) > 0:
+            gen = rnd.get("generated_test") or {}
+            code = gen.get("test_code")
+            if code:
+                return code
+    return None
+
+
 def _summary_html(summary: dict) -> str:
     """Render a compact, readable HTML summary of a run for the notebook."""
     cost = summary.get("cost", {}) or {}
@@ -115,8 +132,9 @@ def _summary_html(summary: dict) -> str:
         for k, v in rows
     )
     # Per-function coverage / bugs, if present.
+    sessions = summary.get("sessions", []) or []
     fn_rows = ""
-    for s in summary.get("sessions", []) or []:
+    for s in sessions:
         name = html.escape(str(s.get("function_name", "?")))
         cov = s.get("final_coverage")
         bugs = s.get("final_bugs")
@@ -132,11 +150,41 @@ def _summary_html(summary: dict) -> str:
         f"<table style='font-size:13px;margin-top:4px'>{fn_rows}</table></div>"
         if fn_rows else ""
     )
+
+    # The verification gap, made tangible: for each function with a bug, show
+    # the failing test that proves it. This is the exciting part for a
+    # notebook user, static analysis passed this code, execution did not.
+    gap_block = ""
+    gap_items = ""
+    for s in sessions:
+        if not (s.get("final_bugs") or 0):
+            continue
+        test_code = _failing_test_for_session(s)
+        if not test_code:
+            continue
+        name = html.escape(str(s.get("function_name", "?")))
+        gap_items += (
+            f"<div style='margin-top:10px'>"
+            f"<div style='font-size:13px;color:#0f172a'>"
+            f"<span style='font-family:monospace;font-weight:600'>{name}</span> "
+            f"passed static analysis but a generated test fails at runtime:</div>"
+            f"<pre style='margin:6px 0 0;padding:10px 12px;background:#0f172a;color:#e2e8f0;"
+            f"border-radius:8px;font-size:12px;overflow-x:auto'>{html.escape(test_code.strip())}</pre>"
+            f"</div>"
+        )
+    if gap_items:
+        gap_block = (
+            "<div style='margin-top:12px;border-top:1px solid #e2e8f0;padding-top:10px'>"
+            "<div style='font-size:12px;color:#b91c1c;text-transform:uppercase;"
+            "letter-spacing:.05em;font-weight:600'>Verification gap found</div>"
+            f"{gap_items}</div>"
+        )
+
     return (
         "<div style='border:1px solid #e2e8f0;border-radius:12px;padding:14px 16px;"
         "font-family:system-ui,-apple-system,sans-serif;max-width:560px'>"
         "<div style='font-weight:700;color:#4f46e5;margin-bottom:8px'>QALLM run complete</div>"
-        f"<table style='font-size:13px'>{body}</table>{fn_block}"
+        f"<table style='font-size:13px'>{body}</table>{fn_block}{gap_block}"
         "<div style='margin-top:8px;font-size:11px;color:#94a3b8'>"
         "Bugs found by execution, not static analysis. Full artefacts saved to the session directory.</div>"
         "</div>"

--- a/tests/test_jupyter_magic.py
+++ b/tests/test_jupyter_magic.py
@@ -81,3 +81,43 @@ def test_load_extension_registers_magic():
         J.load_ipython_extension(fake_ipython)
     assert "fn" in captured
     assert "_qallm_magic" in fake_ipython.user_ns
+
+
+def test_failing_test_extracted_from_first_failing_round():
+    from qallm.jupyter import _failing_test_for_session
+    session = {
+        "function_name": "divide",
+        "rounds": [
+            {"execution": {"failed": 0, "passed": 1}, "generated_test": {"test_code": "ok"}},
+            {"execution": {"failed": 1, "passed": 0}, "generated_test": {"test_code": "def test_x(): assert divide(1,0)==0"}},
+        ],
+    }
+    code = _failing_test_for_session(session)
+    assert code is not None
+    assert "divide(1,0)" in code
+
+
+def test_no_failing_test_when_all_pass():
+    from qallm.jupyter import _failing_test_for_session
+    session = {"rounds": [{"execution": {"failed": 0, "passed": 2}, "generated_test": {"test_code": "ok"}}]}
+    assert _failing_test_for_session(session) is None
+
+
+def test_summary_html_shows_verification_gap_with_failing_test():
+    from qallm.jupyter import _summary_html
+    summary = {
+        "source": "cell.py", "strategy": "feedback", "model": "stub",
+        "sessions": [{
+            "function_name": "divide", "final_bugs": 1, "final_coverage": 100.0,
+            "rounds": [{"execution": {"failed": 1}, "generated_test": {"test_code": "def test_divide(): assert divide(1,0)==0"}}],
+        }],
+    }
+    html_out = _summary_html(summary)
+    assert "Verification gap found" in html_out
+    assert "test_divide" in html_out
+
+
+def test_summary_html_no_gap_block_when_clean():
+    from qallm.jupyter import _summary_html
+    summary = {"sessions": [{"function_name": "add", "final_bugs": 0, "rounds": []}]}
+    assert "Verification gap found" not in _summary_html(summary)


### PR DESCRIPTION
The %%qallm notebook magic (FEAT-10) already exists and works: cell/line magic, inline HTML summary, same orchestrator as CLI and web UI, with the [jupyter] extra and tests. What it lacked was the moment that makes a researcher care: seeing, in their own notebook, the concrete proof that code their linter passed is actually broken.

The inline summary now renders a "Verification gap found" block for each function with a runtime defect, showing the generated test that fails against it (pulled from the first round whose execution had a failure). A bug count becomes a runnable demonstration: "divide passed static analysis but this test fails at runtime", with the test shown. Clean functions add no block, so the section appears only when there is a real gap.

This is purely a presentation enrichment of data already in the summary (sessions -> rounds -> generated_test/execution); no pipeline change.

Tests (test_jupyter_magic.py, +4): failing test extracted from the first failing round; none when all pass; summary HTML shows the gap block with the failing test; no gap block for clean functions. Doc updated.

Suite: 612 passed; ruff clean.