### PR TITLE
feat(experiments): persist run logs to disk for both runners

### DIFF
--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -62,10 +62,23 @@ def main() -> None:
                              "since it reads per-round artefacts from disk.")
     parser.add_argument("--log-level", default="INFO",
                         choices=["DEBUG", "INFO", "WARNING", "ERROR"])
+    parser.add_argument("--log-file", default=None,
+                        help="Also write logs to this file (in addition to the "
+                             "console). Useful under screen/tmux where console "
+                             "scrollback is lost; tail -f it from another shell. "
+                             "Defaults to <output>/run.log when omitted.")
     args = parser.parse_args()
 
+    # Always persist a log to disk so a long run under screen/tmux can be
+    # inspected later and tailed live, not just watched in a console that
+    # scrolls away. Defaults to <output>/run.log.
+    log_path = Path(args.log_file) if args.log_file else Path(args.output) / "run.log"
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    handlers = [logging.StreamHandler(), logging.FileHandler(log_path, encoding="utf-8")]
     logging.basicConfig(level=getattr(logging, args.log_level),
-                        format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+                        format="%(asctime)s %(levelname)s %(name)s: %(message)s",
+                        handlers=handlers)
+    logging.getLogger(__name__).info("Logging to %s", log_path)
 
     config = GapExperimentConfig(
         dataset_dir=Path(args.dataset),

--- a/scripts/run_humaneval.py
+++ b/scripts/run_humaneval.py
@@ -86,10 +86,17 @@ def main() -> int:
     )
     args = parser.parse_args()
 
+    # Persist a log to disk (<output>/run.log) so a long run under screen/tmux
+    # can be tailed live and inspected later, not lost to console scrollback.
+    from pathlib import Path as _Path
+    _log_path = _Path(args.output) / "run.log"
+    _log_path.parent.mkdir(parents=True, exist_ok=True)
     logging.basicConfig(
         level=getattr(logging, args.log_level),
         format="%(asctime)s [%(levelname)s] %(name)s: %(message)s",
+        handlers=[logging.StreamHandler(), logging.FileHandler(_log_path, encoding="utf-8")],
     )
+    logging.getLogger(__name__).info("Logging to %s", _log_path)
 
     from qallm.experiments.humaneval_runner import (
         ExperimentConfig, run_experiment,


### PR DESCRIPTION
Under screen/tmux the console scrolls away and the logs are lost, making a long run impossible to inspect after the fact. Both runners now always write a run.log to the output directory (gap runner also accepts --log-file to override), in addition to the console, via a FileHandler. The path is logged at startup so it is easy to tail -f from another shell.

This directly addresses the "I cannot see proper logs" problem: tail -f runs/<name>/run.log gives live, scrollable, greppable logs independent of the screen session.

ruff clean; both runners parse.