### PR TITLE
fix(gap): build_gap_report crashed on units with static findings

### DIFF
--- a/src/qallm/analysis/gap_analysis.py
+++ b/src/qallm/analysis/gap_analysis.py
@@ -203,6 +203,19 @@ def build_gap_report(
 
     functions_with_finding: set[str] = set()
     for f in findings:
+        # findings may arrive as dicts (disk path: parsed from static.json) or
+        # as Finding dataclass objects (in-memory metrics_only path, which
+        # passes analysed.findings directly). Normalise to dict access so both
+        # work; previously the object path raised "'Finding' object has no
+        # attribute 'get'" on any unit that had static findings.
+        if not isinstance(f, dict):
+            f = {
+                "line": getattr(f, "line", 0),
+                "tool": getattr(f, "tool", "?"),
+                "severity": getattr(f, "severity", "?"),
+                "message": getattr(f, "message", ""),
+                "rule_id": getattr(f, "rule_id", ""),
+            }
         line = int(f.get("line", 0) or 0)
         fn = _function_for_line(spans, line)
         if fn:

--- a/tests/test_gap_analysis.py
+++ b/tests/test_gap_analysis.py
@@ -115,3 +115,36 @@ def test_syntax_error_source_no_crash():
     rep = build_gap_report(0, "def broken(:\n  pass", [], None)
     assert rep.findings == []
     assert rep.execution_only_functions == []
+
+
+def test_build_gap_report_accepts_finding_objects():
+    """findings may be Finding dataclass objects, not just dicts.
+
+    Regression: the in-memory metrics_only path passes analysed.findings (a
+    list of Finding objects) straight to build_gap_report, which previously
+    called f.get(...) and raised "'Finding' object has no attribute 'get'" on
+    any unit that had static findings. Both dict and object inputs must work.
+    """
+    from qallm.analysis.analysis_model import Finding
+
+    finding = Finding(
+        tool="bandit", type="security", severity="HIGH", file="x.py",
+        line=2, message="eval use", rule_id="B307", code_snippet="", extra={},
+    )
+    rep = build_gap_report(0, SOURCE, [finding], [])
+    assert len(rep.findings) == 1
+    assert rep.findings[0].tool == "bandit"
+    assert rep.findings[0].severity == "HIGH"
+
+
+def test_build_gap_report_dict_and_object_agree():
+    """A dict finding and the equivalent Finding object yield the same fields."""
+    from qallm.analysis.analysis_model import Finding
+
+    obj = Finding(tool="ruff", type="style", severity="LOW", file="x.py",
+                  line=2, message="m", rule_id="E501", code_snippet="", extra={})
+    as_dict = {"tool": "ruff", "severity": "LOW", "line": 2, "message": "m", "rule_id": "E501"}
+    r_obj = build_gap_report(0, SOURCE, [obj], [])
+    r_dict = build_gap_report(0, SOURCE, [as_dict], [])
+    assert r_obj.findings[0].tool == r_dict.findings[0].tool
+    assert r_obj.findings[0].line == r_dict.findings[0].line


### PR DESCRIPTION
The run.log from the lab run showed every unit that HAS static findings (complexity_findings.py, security_findings.py) failing with "'Finding' object has no attribute 'get'", while units with zero static findings (clean_control, reliability_gap) ran fine. Cause: build_gap_report calls f.get(...) expecting finding dicts, but the in-memory metrics_only path passes analysed.findings, which are Finding dataclass objects. The disk path reads static.json (dicts) so it never hit this; the object path was never exercised.

This matters for the real run: every ENVRI notebook with any static finding would have errored under the default metrics_only retention.

Fix: build_gap_report now normalises non-dict findings (Finding objects) to dict access, so both call paths work.

Tests (test_gap_analysis.py, +2): build_gap_report accepts Finding objects and preserves their fields; a dict finding and the equivalent object yield the same result. Same "test the real thing" lesson as the gap-runner kwarg and the TruffleHog bugs, the object path was only ever shadowed by the dict path.

Suite: 614 passed; ruff clean.