### PR TITLE
feat: per-unit progress in logs; skip no-op repair; exclude checkpoints

### DIFF
--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -77,8 +77,17 @@ class GapExperimentResult:
 
 def _discover_inputs(dataset_dir: Path, pattern: str) -> list[Path]:
     """Every file under dataset_dir matching the pattern, sorted for
-    determinism."""
-    return sorted(dataset_dir.rglob(pattern))
+    determinism.
+
+    Jupyter autosave backups under .ipynb_checkpoints are excluded: they are
+    "-checkpoint.ipynb" duplicates of real notebooks, and rglob("*.ipynb")
+    matches them, which double-processes the same code and wastes budget (the
+    ENVRI run was burning rounds on checkpoint copies).
+    """
+    return sorted(
+        p for p in dataset_dir.rglob(pattern)
+        if ".ipynb_checkpoints" not in p.parts
+    )
 
 
 def _effective_retention(config: GapExperimentConfig) -> str:

--- a/src/qallm/ingestion/ingestion_manager.py
+++ b/src/qallm/ingestion/ingestion_manager.py
@@ -79,7 +79,13 @@ class IngestionManager:
 
     def _scan_directory(self, directory: Path) -> List[CodeUnit]:
         units = []
-        for root, _, files in os.walk(directory):
+        for root, dirs, files in os.walk(directory):
+            # Skip Jupyter autosave backups: .ipynb_checkpoints holds
+            # "-checkpoint.ipynb" duplicates of real notebooks. Including them
+            # double-processes the same code, wastes budget, and pollutes the
+            # results (the ENVRI run was spending rounds on checkpoint copies).
+            # Pruning dirs in-place stops os.walk descending into them.
+            dirs[:] = [d for d in dirs if d != ".ipynb_checkpoints"]
             for file in files:
                 fpath = Path(root) / file
                 if fpath.suffix == '.ipynb':

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -78,6 +78,11 @@ from qallm.llm.transcript import (
 )
 from qallm.profiles import IMPLEMENTATION_DEFAULT, QualityProfile
 from qallm.utils.reporter import QualityReporter
+from qallm.utils.log_context import (
+    clear_unit_context,
+    install_unit_context_filter,
+    set_unit_context,
+)
 from qallm.verification.models import OracleType, TestedCodeUnit
 from qallm.verification.test_persistence import TestStabilityConfig
 from qallm.verification.verification_manager import VerificationManager
@@ -297,6 +302,10 @@ class QALLMOrchestrator:
         """
         logger.info(f"Starting QALLM operation for {source_path}...")
 
+        # Ensure the unit-context filter is attached so per-unit progress
+        # labels appear on every log line during this run. Idempotent.
+        install_unit_context_filter()
+
         # Activate prompt/response capture for the duration of this run.
         # reset_context clears any stale thread-local context from a prior
         # run on the same worker thread.
@@ -332,6 +341,12 @@ class QALLMOrchestrator:
         # Initialise per-unit tracking before the first round runs.
         for unit in units:
             self.tracks[_unit_id(unit)] = UnitTrack(unit_id=_unit_id(unit))
+
+        # Stable 1-based sequence number per unit, in collection order, for
+        # progress logging ("unit 3/47"). Lets every log line locate itself in
+        # the run instead of just naming a function with no sense of how far
+        # along we are.
+        self._unit_sequence = {_unit_id(u): i + 1 for i, u in enumerate(units)}
 
         # One unified loop. Round 0 is the baseline (analyse + verify the
         # original, no repair, always accepted, no budget round consumed).
@@ -467,6 +482,14 @@ class QALLMOrchestrator:
         """
         is_baseline = self.current_round == 0
         self.current_unit_id = unit_id
+        # Prefix every log line emitted while this unit is processed with its
+        # sequence position, so the log shows how far the run has progressed
+        # ("unit 3/47") rather than only naming a function.
+        set_unit_context(
+            index=self._unit_sequence.get(unit_id, 0),
+            total=self.units_total,
+            unit_id=unit_id,
+        )
         set_context(round_number=self.current_round, unit_id=unit_id,
                     function=None, oracle=None)
 
@@ -623,6 +646,7 @@ class QALLMOrchestrator:
         for unit_id, unit in inputs.items():
             track = self.tracks[unit_id]
             next_inputs[unit_id] = self._process_unit(unit_id, unit, track)
+            clear_unit_context()
         logger.info("Round %d (%s) completed.", self.current_round, label)
         return next_inputs
 

--- a/src/qallm/repair/repair_manager.py
+++ b/src/qallm/repair/repair_manager.py
@@ -45,6 +45,25 @@ class RepairManager:
         code_unit = analysed_code_unit.code_unit
         code_unit_path = str(code_unit.original_path.absolute())
 
+        # Nothing to repair: with zero findings there is no defect for the LLM
+        # to act on, so calling it is wasted budget (and was producing "Repair
+        # completed" lines for files that had no findings at all). Return an
+        # identity result (source unchanged, compiles, empty diff) without any
+        # LLM round-trip.
+        if not analysed_code_unit.findings:
+            logger.info(
+                "Repair skipped: 0 findings [File name: %s]",
+                code_unit.original_path,
+            )
+            identity = RepairResult(
+                file_path=code_unit_path,
+                repaired_source=code_unit.source_code,
+                explanation="no findings: repair skipped",
+                compiles=True,
+                unified_diff="",
+            )
+            return RepairedCodeUnit(analysed_code_unit, identity)
+
         request = RepairRequest(
             file_path=code_unit_path,
             original_source=code_unit.source_code,

--- a/src/qallm/utils/log_context.py
+++ b/src/qallm/utils/log_context.py
@@ -1,0 +1,107 @@
+"""Per-unit logging context.
+
+Across a run, many components log independently (orchestrator, analysis,
+repair, verification manager/generator/executor/sandbox). Their messages name
+the function under test but not *where in the run* it sits, so from a single
+line you cannot tell whether you are on the first code unit or the last. That
+makes a long run feel unobservable.
+
+This module carries a small progress label in a ``contextvar`` that the
+orchestrator sets once per code unit (e.g. ``unit 3/47 prediction.ipynb::7``).
+A logging ``Filter`` then prefixes that label onto every record emitted while
+the context is active, regardless of which component logged it. Components do
+not need to thread any parameter through their call sites; they just log as
+usual and inherit the context.
+
+Usage (orchestrator):
+
+    from qallm.utils.log_context import set_unit_context, clear_unit_context
+    set_unit_context(index=i, total=n, unit_id="file.py::3")
+    ...                     # all logs here are prefixed
+    clear_unit_context()    # or use the unit_context() context manager
+
+Install the filter once at logging setup:
+
+    from qallm.utils.log_context import install_unit_context_filter
+    install_unit_context_filter()
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+from contextvars import ContextVar
+
+# Holds the current prefix, e.g. "[unit 3/47 file.py::3]". Empty when no unit
+# is being processed (setup, ingestion, teardown), in which case nothing is
+# prefixed.
+_unit_label: ContextVar[str] = ContextVar("qallm_unit_label", default="")
+
+
+def set_unit_context(*, index: int, total: int, unit_id: str) -> None:
+    """Set the progress label for the unit currently being processed.
+
+    ``index`` is 1-based. ``unit_id`` is the stable ``path::cell`` identifier;
+    the path is shortened to its basename to keep lines readable.
+    """
+    short = unit_id
+    if "::" in unit_id:
+        path, _, cell = unit_id.rpartition("::")
+        base = path.rsplit("/", 1)[-1]
+        short = f"{base}::{cell}"
+    else:
+        short = unit_id.rsplit("/", 1)[-1]
+    _unit_label.set(f"[unit {index}/{total} {short}] ")
+
+
+def clear_unit_context() -> None:
+    """Clear the progress label (no prefix until the next set)."""
+    _unit_label.set("")
+
+
+@contextlib.contextmanager
+def unit_context(*, index: int, total: int, unit_id: str):
+    """Scope a unit's progress label to a ``with`` block."""
+    token = _unit_label.set("")
+    set_unit_context(index=index, total=total, unit_id=unit_id)
+    try:
+        yield
+    finally:
+        _unit_label.reset(token)
+
+
+def current_unit_label() -> str:
+    """The current prefix, or empty string when no unit context is set."""
+    return _unit_label.get()
+
+
+class _UnitContextFilter(logging.Filter):
+    """Prefix the active unit label onto every record's message.
+
+    A Filter (not a Formatter) is used so the prefix appears regardless of the
+    handler's format string, and so it is a no-op when no context is set.
+    """
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        label = _unit_label.get()
+        if label and not getattr(record, "_unit_ctx_applied", False):
+            record.msg = f"{label}{record.msg}"
+            record._unit_ctx_applied = True
+        return True
+
+
+_FILTER_SINGLETON = _UnitContextFilter()
+
+
+def install_unit_context_filter() -> None:
+    """Attach the unit-context filter to the root logger (idempotent).
+
+    Filters on the root logger do not propagate to child loggers' own
+    handlers, so the filter is attached to the root *handlers*. When logging
+    is configured with basicConfig (one root handler), this covers everything
+    that propagates to root, which is the whole pipeline.
+    """
+    root = logging.getLogger()
+    for handler in root.handlers:
+        if _FILTER_SINGLETON not in handler.filters:
+            handler.addFilter(_FILTER_SINGLETON)

--- a/tests/test_gap_runner.py
+++ b/tests/test_gap_runner.py
@@ -156,3 +156,20 @@ def test_default_orchestrator_factory_constructs(tmp_path):
     assert orch is not None
     # The rounds value should have been accepted and applied.
     assert orch.rounds == 3
+
+
+def test_discover_inputs_excludes_ipynb_checkpoints(tmp_path):
+    """Jupyter autosave backups must not be processed as real notebooks."""
+    from qallm.experiments.gap_runner import _discover_inputs
+
+    (tmp_path / "real.ipynb").write_text("{}")
+    sub = tmp_path / "sub"
+    sub.mkdir()
+    (sub / "nb.ipynb").write_text("{}")
+    ckpt = sub / ".ipynb_checkpoints"
+    ckpt.mkdir()
+    (ckpt / "nb-checkpoint.ipynb").write_text("{}")
+
+    found = sorted(p.name for p in _discover_inputs(tmp_path, "*.ipynb"))
+    assert found == ["nb.ipynb", "real.ipynb"]
+    assert "nb-checkpoint.ipynb" not in found

--- a/tests/test_repair_skip_and_log_context.py
+++ b/tests/test_repair_skip_and_log_context.py
@@ -1,0 +1,76 @@
+"""Tests for the zero-findings repair short-circuit and unit log context."""
+
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from qallm.analysis.analysis_model import AnalysedCodeUnit
+from qallm.common.model import CodeUnit
+from qallm.repair.repair_manager import RepairManager
+
+
+def _analysed(findings):
+    unit = CodeUnit(source_code="def f():\n    return 1\n", cell_index=0,
+                    original_path=Path("example.py"))
+    return AnalysedCodeUnit(code_unit=unit, findings=findings, raw_tool_results={})
+
+
+def test_repair_skips_llm_when_no_findings():
+    # With zero findings there is nothing to repair, so the repair agent (an
+    # LLM call) must not be invoked: that was wasted budget.
+    agent = MagicMock()
+    analyzer = MagicMock()
+    mgr = RepairManager(repair_agent=agent, analyzer=analyzer)
+
+    result = mgr.repair_code_unit(_analysed(findings=[]))
+
+    agent.repair.assert_not_called()
+    # Identity result: source unchanged, compiles, empty diff.
+    assert result.repaired_result.repaired_source == "def f():\n    return 1\n"
+    assert result.repaired_result.compiles is True
+    assert result.repaired_result.unified_diff == ""
+
+
+def test_repair_calls_llm_when_findings_present():
+    # With findings, the agent IS called (guard against over-eager skipping).
+    agent = MagicMock()
+    repaired = MagicMock()
+    repaired.repaired_source = "def f():\n    return 2\n"
+    repaired.compiles = True
+    agent.repair.return_value = repaired
+    mgr = RepairManager(repair_agent=agent, analyzer=MagicMock())
+
+    mgr.repair_code_unit(_analysed(findings=[MagicMock()]))
+
+    agent.repair.assert_called_once()
+
+
+# ── unit log context ──
+
+def test_unit_context_prefixes_log_records(caplog):
+    from qallm.utils.log_context import (
+        install_unit_context_filter, set_unit_context, clear_unit_context,
+    )
+    # caplog uses its own handler; attach the filter to it so the prefix shows.
+    from qallm.utils.log_context import _FILTER_SINGLETON
+    caplog.handler.addFilter(_FILTER_SINGLETON)
+    install_unit_context_filter()
+
+    log = logging.getLogger("qallm.verification.generator")
+    with caplog.at_level(logging.INFO):
+        set_unit_context(index=3, total=47, unit_id="datasets/lab/clean_control.py::2")
+        log.info("Generating tests for add")
+        clear_unit_context()
+        log.info("no context here")
+
+    messages = [r.getMessage() for r in caplog.records]
+    assert any("[unit 3/47 clean_control.py::2] Generating tests for add" in m for m in messages)
+    assert any(m == "no context here" for m in messages)
+
+
+def test_unit_context_shortens_path():
+    from qallm.utils.log_context import set_unit_context, current_unit_label, clear_unit_context
+    set_unit_context(index=1, total=10, unit_id="a/b/c/deep.py::5")
+    assert current_unit_label() == "[unit 1/10 deep.py::5] "
+    clear_unit_context()
+    assert current_unit_label() == ""


### PR DESCRIPTION
Three observability/efficiency improvements driven by the ENVRI run log.

1. Per-unit progress context in every log line. Components (orchestrator, analysis, repair, verification manager/generator/executor/sandbox) named the function under test but not where in the run it sat, so a line could be the first unit or the last with no way to tell. A contextvar carries a progress label that the orchestrator sets once per unit (e.g. "[unit 3/47 prediction.ipynb::7]"), and a logging Filter prefixes it onto every record emitted while that unit is processed, no per-call-site threading. New module qallm.utils.log_context; orchestrator assigns a stable 1-based sequence per unit and sets/clears the context around each unit.

2. Repair skips the LLM when there are zero findings. With nothing to repair, calling the repair agent was wasted budget and produced misleading "Repair completed" lines for findings-free files. repair_code_unit now returns an identity result (source unchanged, compiles, empty diff) without any LLM round-trip when findings is empty.

3. Exclude .ipynb_checkpoints from ingestion. Jupyter autosave backups ("-checkpoint.ipynb") are duplicates of real notebooks; rglob("*.ipynb") matched them, so the ENVRI run was burning rounds on checkpoint copies. Both the gap-runner discovery (rglob) and the directory scanner (os.walk) now skip the .ipynb_checkpoints directory.

Tests (+5): repair skips LLM on 0 findings and still calls it when findings exist; unit context prefixes records and clears; path shortening; checkpoint files excluded from discovery.

Suite: 619 passed; ruff clean.