### PR TITLE
fix(verification): baseline gate (repair rounds), drop tests failing …

### DIFF
--- a/src/qallm/verification/test_validator.py
+++ b/src/qallm/verification/test_validator.py
@@ -328,3 +328,40 @@ def strip_incoherent_oracle_tests(code: str, fut_name: str) -> tuple[str, list[s
     except Exception:  # noqa: BLE001 - unparse should not fail, but be safe
         return code, []
     return rewritten, sorted(to_remove)
+
+
+def strip_tests_by_name(code: str, names: set[str]) -> tuple[str, list[str]]:
+    """Remove the named top-level test functions, keeping everything else.
+
+    Used by the baseline gate: tests that fail against the original (known
+    reference) code are not valid bug-detectors and are stripped before the
+    suite is allowed to indict a variant. Returns the rewritten code and the
+    sorted list of removed names; returns the code unchanged on parse failure
+    or when ``names`` is empty.
+    """
+    if not names:
+        return code, []
+    try:
+        tree = ast.parse(code)
+    except SyntaxError:
+        return code, []
+
+    before = {
+        node.name for node in tree.body
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+        and node.name in names
+    }
+    if not before:
+        return code, []
+    tree.body = [
+        node for node in tree.body
+        if not (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name in names
+        )
+    ]
+    try:
+        rewritten = ast.unparse(tree)
+    except Exception:  # noqa: BLE001 - unparse should not fail, but be safe
+        return code, []
+    return rewritten, sorted(before)

--- a/src/qallm/verification/verification_manager.py
+++ b/src/qallm/verification/verification_manager.py
@@ -16,6 +16,7 @@ import dataclasses
 import json
 import logging
 import time
+import ast as _ast
 from dataclasses import asdict
 from pathlib import Path
 from typing import Callable, Optional
@@ -25,6 +26,7 @@ from qallm.repair.repair_model import RepairedCodeUnit
 from .extractor import extract_functions_from_source
 from .generator import TestGenerator
 from .executor import run_tests
+from .test_validator import strip_tests_by_name
 from .models import TestGenerationSession, RoundResult, TestedCodeUnit
 from .reward import compute_reward
 from .test_persistence import (
@@ -36,6 +38,19 @@ from .test_persistence import (
 )
 
 logger = logging.getLogger(__name__)
+
+
+def _has_test_function(code: str) -> bool:
+    """True if the code parses and defines at least one top-level test_*."""
+    try:
+        tree = _ast.parse(code)
+    except SyntaxError:
+        return False
+    return any(
+        isinstance(n, (_ast.FunctionDef, _ast.AsyncFunctionDef))
+        and n.name.startswith("test")
+        for n in tree.body
+    )
 
 
 def _concatenate_test_codes(stored: list[StoredTest]) -> str:
@@ -230,6 +245,47 @@ class VerificationManager:
                     f", discarded={len(generated.discarded_tests)}" if generated.discarded_tests else "",
                     f", error={generated.generation_error}" if generated.generation_error else "",
                 )
+                # Baseline gate (Bug 2 fix): in REPAIR rounds (round >= 1), a
+                # freshly generated test that fails against the ORIGINAL
+                # baseline code is not a valid bug-detector, the baseline is
+                # the reference the repair must not regress against, so a
+                # failure there is the test being wrong, not a defect. Counting
+                # such failures inflated the gap rate (clean functions failing
+                # in round 1) and caused 0% HumanEval detection.
+                #
+                # CRITICAL: this must NOT run at round 0. Round 0 is the
+                # verification-gap pass itself, where a generated test that
+                # fails the original IS the signal being measured (static-clean
+                # but runtime-broken). Gating at round 0 would strip exactly the
+                # bugs the experiment exists to find.
+                if (
+                    round_number >= 1
+                    and generated is not None
+                    and generated.is_valid
+                    and generated.test_code
+                ):
+                    gate = run_tests(
+                        original_source, generated.test_code,
+                        f"{module_name}.py", path,
+                    )
+                    bad = {
+                        d.name for d in gate.test_details
+                        if d.status in ("failed", "error")
+                    }
+                    if bad:
+                        kept, removed = strip_tests_by_name(generated.test_code, bad)
+                        logger.info(
+                            "  [%s] baseline-gate: dropped %d test(s) that fail on "
+                            "the original code (not bug-detectors): %s",
+                            func.name, len(removed), ", ".join(removed),
+                        )
+                        generated.test_code = kept
+                        if not _has_test_function(kept):
+                            generated.is_valid = False
+                            generated.generation_error = (
+                                "All generated tests failed against the original "
+                                "code (baseline gate); none are valid bug-detectors."
+                            )
                 # Record only valid tests in the store under FROZEN modes;
                 # under PER_ROUND we still record so artefacts are tracked.
                 if self.store.carries_tests() or self.stability_config.policy is GenerationPolicy.GROW:

--- a/tests/test_test_validator.py
+++ b/tests/test_test_validator.py
@@ -132,3 +132,35 @@ def test_two(foo, bar):
 '''
     problems = find_unsatisfied_fixtures(code)
     assert set(problems["test_two"]) == {"foo", "bar"}
+
+
+# ── strip_tests_by_name (baseline gate helper) ──
+
+def test_strip_tests_by_name_removes_only_named():
+    from qallm.verification.test_validator import strip_tests_by_name
+    code = (
+        "def test_good():\n    assert add(1, 2) == 3\n\n"
+        "def test_bad():\n    assert add(1, 1) == 3\n\n"
+        "def helper():\n    return 1\n"
+    )
+    kept, removed = strip_tests_by_name(code, {"test_bad"})
+    assert removed == ["test_bad"]
+    assert "def test_good" in kept
+    assert "def test_bad" not in kept
+    assert "def helper" in kept  # non-test top-level statements preserved
+
+
+def test_strip_tests_by_name_empty_names_is_noop():
+    from qallm.verification.test_validator import strip_tests_by_name
+    code = "def test_a():\n    assert True\n"
+    kept, removed = strip_tests_by_name(code, set())
+    assert removed == []
+    assert kept == code
+
+
+def test_strip_tests_by_name_unknown_name_is_noop():
+    from qallm.verification.test_validator import strip_tests_by_name
+    code = "def test_a():\n    assert True\n"
+    kept, removed = strip_tests_by_name(code, {"test_nonexistent"})
+    assert removed == []
+    assert "def test_a" in kept

--- a/tests/test_verification_function_filter.py
+++ b/tests/test_verification_function_filter.py
@@ -309,3 +309,102 @@ class TestSessionSourceRefresh:
             assert session_after_r2 is session_after_r1
             assert "ast.literal_eval(x)" in session_after_r2.source_code
             assert "return eval(x)" not in session_after_r2.source_code
+
+
+class TestBaselineGate:
+    """The baseline gate (Bug 2): a generated test that fails on the ORIGINAL
+    code is stripped, since the original is the reference, the test is wrong,
+    not the code. Prevents false bugs on correct functions and the 0% HumanEval
+    detection signature."""
+
+    def test_test_failing_on_original_is_stripped(self, tmp_path, caplog):
+        from qallm.verification.models import TestDetail
+
+        original_source = "def add(a, b):\n    return a + b\n"
+        unit = _build_repaired_unit(
+            original_source, original_source, tmp_path / "demo.py",
+        )
+        vm = _make_verification_manager()
+        # GROW so freshly generated tests are run (gate is on generation path).
+        vm.stability_config = TestStabilityConfig(
+            stability=TestStability.FROZEN, policy=GenerationPolicy.GROW,
+        )
+
+        gen = MagicMock(
+            test_code=(
+                "def test_ok():\n    assert add(1, 2) == 3\n\n"
+                "def test_wrong():\n    assert add(1, 1) == 3\n"
+            ),
+            is_valid=True, generation_error=None, oracle="crash",
+            model="stub", provider="stub", discarded_tests=[],
+            input_tokens=0, output_tokens=0,
+        )
+
+        def fake_run(source, test_code, *a, **k):
+            # The gate runs against original_source: test_wrong fails there.
+            if "test_wrong" in test_code and source == original_source:
+                return MagicMock(
+                    test_details=[
+                        TestDetail(name="test_ok", status="passed"),
+                        TestDetail(name="test_wrong", status="failed"),
+                    ],
+                    passed=1, failed=1, errors=0, coverage_percent=100.0,
+                    execution_error=None,
+                )
+            # Subsequent runs (variant) see only the surviving test.
+            return MagicMock(
+                test_details=[TestDetail(name="test_ok", status="passed")],
+                passed=1, failed=0, errors=0, coverage_percent=100.0,
+                execution_error=None,
+            )
+
+        with patch.object(vm.generator, "generate", return_value=gen), \
+             patch("qallm.verification.verification_manager.run_tests", side_effect=fake_run):
+            with caplog.at_level(logging.INFO):
+                vm.verify(unit, round_number=1)
+
+        # test_wrong (fails on the original) was stripped; test_ok survives.
+        assert "test_wrong" not in gen.test_code
+        assert "def test_ok" in gen.test_code
+        assert any("baseline-gate" in r.getMessage() for r in caplog.records)
+
+
+    def test_gate_does_not_run_at_round_0(self, tmp_path, caplog):
+        """Round 0 is the gap-detection pass: a test that fails the original
+        is the signal, not noise, and must NOT be stripped. Gating round 0
+        would erase exactly the bugs the experiment measures."""
+        from qallm.verification.models import TestDetail
+
+        # Original code is buggy here (the round-0 case for reliability_gap).
+        original_source = "def add(a, b):\n    return a - b  # BUG\n"
+        unit = _build_repaired_unit(
+            original_source, original_source, tmp_path / "demo.py",
+        )
+        vm = _make_verification_manager()
+
+        gen = MagicMock(
+            test_code="def test_add():\n    assert add(1, 2) == 3\n",
+            is_valid=True, generation_error=None, oracle="crash",
+            model="stub", provider="stub", discarded_tests=[],
+            input_tokens=0, output_tokens=0,
+        )
+
+        run_calls = []
+
+        def fake_run(source, test_code, *a, **k):
+            run_calls.append(test_code)
+            # The (buggy) original fails this correct test, that is the gap.
+            return MagicMock(
+                test_details=[TestDetail(name="test_add", status="failed")],
+                passed=0, failed=1, errors=0, coverage_percent=100.0,
+                execution_error=None,
+            )
+
+        with patch.object(vm.generator, "generate", return_value=gen), \
+             patch("qallm.verification.verification_manager.run_tests", side_effect=fake_run):
+            with caplog.at_level(logging.INFO):
+                vm.verify(unit, round_number=0)
+
+        # The bug-catching test survives (not stripped) and no gate ran.
+        assert "def test_add" in gen.test_code
+        assert not any("baseline-gate" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
…on original

Bug 2, the oracle-quality problem behind the inflated gap rate and 0% HumanEval detection. In REPAIR rounds (round >= 1), a freshly generated test that fails against the ORIGINAL baseline code is not a valid bug-detector: the baseline is the reference the repair must not regress against, so a failure there is the test being wrong, not a defect. Previously such tests were stored and run against the variant, counting as execution-only bugs. This is why clean functions "failed" in round 1 (add/clamp/word_count) and why HumanEval detection was 0 (tests failed canonical solutions too).

CRITICAL design point: the gate does NOT run at round 0. Round 0 is the verification-gap pass itself, where a generated test that fails the original IS the signal being measured (static-clean but runtime-broken). Gating round 0 would strip exactly the bugs the experiment exists to find. The guard is round_number >= 1; a regression test asserts a bug-catching test survives at round 0 and no gate runs.

Fix: in VerificationManager.verify, for round >= 1, after a fresh test is generated and before it is stored or run against the variant, run it against original_source and strip any test that fails or errors there (strip_tests_by_name, new in test_validator). If nothing survives, the suite is marked invalid with a clear reason. A test timing out on the original errors there too, so it is stripped (addresses the 60s hang on a clean function).

Complements the static incoherent-oracle filter (constant-vs-constant only) with a dynamic check that catches any wrong oracle.

Tests: strip_tests_by_name units; baseline-gate integration test (round 1 strips a test that fails the original, keeps the valid one, logs it); round-0 guard test (bug-catching test survives, no gate runs).

Regression gate for the real run: on the lab set, clean_control.py and complexity_findings.py should report ~0 execution-only bugs and reliability_gap.py ~5. Re-run lab calibration to confirm before ENVRI.

Suite: 624 passed; ruff clean.