### PR TITLE
docs: sync to current state; FedLLM as default; add session log

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,8 +215,9 @@ If you enable the optional Ollama profile to run local LLMs, add:
 
 ### LLM API keys
 
-QALLM can use OpenAI, Anthropic, or Ollama (local). You need at least one configured. For OpenAI and Anthropic, obtain an API key from the provider's console:
+QALLM uses FedLLM by default (`fedllm:gpt-oss-120b`, hosted on EGI, free for VO users); it can also use OpenAI, Anthropic, or Ollama (local). You need at least one configured.
 
+* FedLLM (default): set `FEDLLM_API_KEY`. Hosted at <https://llm.ai.egi.eu>; free for VO users.
 * OpenAI: <https://platform.openai.com/api-keys>
 * Anthropic: <https://console.anthropic.com/>
 
@@ -230,7 +231,7 @@ The repository ships a multi-stage Dockerfile and a Compose file that build the 
 git clone https://github.com/assaban/qallm-uva.git
 cd qallm-uva
 
-# Configure API keys (at minimum one of OPENAI_API_KEY, ANTHROPIC_API_KEY).
+# Configure API keys (FEDLLM_API_KEY by default; or OPENAI_API_KEY / ANTHROPIC_API_KEY).
 cp .env.example .env
 $EDITOR .env
 
@@ -267,16 +268,16 @@ git clone https://github.com/assaban/qallm-uva.git
 cd qallm-uva
 pip install -e .
 
-export OPENAI_API_KEY=sk-...   # or ANTHROPIC_API_KEY
+export FEDLLM_API_KEY=...   # default provider; or OPENAI_API_KEY / ANTHROPIC_API_KEY
 
 # Static analysis only, on a notebook
 qallm notebooks/analysis.ipynb --strategy hypothesis
 
-# One-shot LLM verification
-qallm notebooks/analysis.ipynb --strategy oneshot --llm openai
+# One-shot LLM verification (FedLLM is the default provider)
+qallm notebooks/analysis.ipynb --strategy oneshot --llm fedllm
 
-# Full iterative-feedback verification, 5 rounds
-qallm notebooks/analysis.ipynb --strategy feedback --rounds 5 --llm openai
+# Full iterative-feedback verification, 5 rounds (FedLLM is the default)
+qallm notebooks/analysis.ipynb --strategy feedback --rounds 5 --llm fedllm
 ```
 
 Inputs may be a single `.py` or `.ipynb` file, a directory, a `.zip` archive, or a GitHub URL.

--- a/docs/README.md
+++ b/docs/README.md
@@ -41,6 +41,7 @@ The mechanics and design record.
 - [`thesis/thesis-draft-scaffold.md`](thesis/thesis-draft-scaffold.md): the thesis structure and metric definitions.
 - [`thesis/methodology-decisions.md`](thesis/methodology-decisions.md): the dated, append-only record of methodology decisions (MD-001, MD-002, ...).
 - [`thesis/roadmap.md`](thesis/roadmap.md): priorities and rationale.
+- [`thesis/session-log.md`](thesis/session-log.md): append-only, dated record of what changed each session and what is outstanding (for cross-session continuity).
 
 ## showcase/ — shareable, self-contained pages
 

--- a/docs/architecture/workflow-design.md
+++ b/docs/architecture/workflow-design.md
@@ -87,10 +87,10 @@ The diagram below traces a single QALLM session in detail: how each unit moves t
 
 ```mermaid
 flowchart TD
-    Start([CLI: qallm SOURCE --strategy rl --judge-strategy lexicographic]) --> Init[Construct orchestrator:<br/>BudgetCaps, TestStabilityConfig,<br/>VerificationManager, Judge]
+    Start([CLI: qallm SOURCE --strategy feedback --llm fedllm --judge-strategy lexicographic]) --> Init[Construct orchestrator:<br/>BudgetCaps, TestStabilityConfig,<br/>VerificationManager, Judge]
     Init --> Ingest[Ingestion: collect CodeUnits]
     Ingest --> Tracks[Initialise UnitTrack per unit:<br/>empty lineage, empty abandoned]
-    Tracks --> Baseline[Round 0 baseline:<br/>static analysis only<br/>round_00_baseline/]
+    Tracks --> Baseline[Round 0 baseline:<br/>analyse + execution-based verify<br/>round_00_baseline/]
 
     Baseline --> LoopHead[For each round r = 1..max_rounds]
     LoopHead --> BudgetStart[BudgetState.mark_round_start]

--- a/docs/guides/jupyter-magic.md
+++ b/docs/guides/jupyter-magic.md
@@ -66,7 +66,7 @@ The magic accepts a subset of the `qallm` CLI options:
 | Option | Default | Meaning |
 |---|---|---|
 | `--strategy` | `feedback` | `hypothesis`, `oneshot`, or `feedback` |
-| `--llm` | `openai` | `openai`, `anthropic`, or `ollama` |
+| `--llm` | `fedllm` | `fedllm`, `openai`, `anthropic`, or `ollama` |
 | `--model` | (provider default) | specific model name |
 | `--rounds` | `3` | iterative feedback rounds |
 | `--oracle` | `crash` | `crash`, `property`, or `metamorphic` |
@@ -104,9 +104,10 @@ Sessions tab.
 
 ## Notes
 
-- The magic needs the LLM credentials the pipeline normally needs
-  (e.g. `OPENAI_API_KEY`), set in the environment before launching the
-  notebook.
+- The magic needs whatever credentials the configured provider requires,
+  set in the environment before launching the notebook. For the default
+  FedLLM provider this is `FEDLLM_API_KEY`; for OpenAI it is `OPENAI_API_KEY`,
+  and so on.
 - Results render as inline HTML in the notebook, with a plain-text
   fallback where rich display is unavailable.
 

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -1,0 +1,83 @@
+# QALLM session log
+
+An append-only, dated record of what changed each working session and what is
+outstanding. Purpose: preserve context across chat sessions so a new session
+can pick up without re-deriving state. Newest entries at the top. This is a
+log, not a plan; for priorities see `roadmap.md`, for design rationale see
+`methodology-decisions.md`.
+
+Conventions: each entry lists MERGED work (what landed), OPEN items (what is
+left, with enough detail to resume), and any DECISIONS worth remembering.
+
+---
+
+## 2026-06-09
+
+### Merged this session (PRs in order)
+- Fetcher: never prompt for git credentials; per-clone timeout (private/removed
+  repos no longer hang the ENVRI crawl).
+- Experiment file logging: both runners write `run.log` to the output dir, so
+  `tail -f runs/<name>/run.log` gives live logs independent of screen/tmux.
+- Gap-report Finding-object fix: `build_gap_report` accepted dicts but the
+  in-memory metrics_only path passes `Finding` objects; crashed on any unit
+  with static findings. Now normalises both. (Unblocked ENVRI: real notebooks
+  almost all have static findings.)
+- Observability + efficiency: per-unit progress prefix on every log line
+  (`[unit 3/47 file.ipynb::7]` via contextvar + logging filter); repair skips
+  the LLM when there are zero findings (saves credits); ingestion excludes
+  `.ipynb_checkpoints` (both the gap-runner rglob and the directory scanner).
+
+### Delivered for review (this session, pending merge confirmation)
+- **Bug 2 baseline gate (`fix/baseline-gate-oracle-quality`)**: the
+  oracle-quality fix. In repair rounds (round >= 1) a freshly generated test
+  that fails against the original baseline is stripped (not a valid
+  bug-detector). Does NOT run at round 0 (round 0 is the gap-detection pass;
+  gating it would erase the bugs we measure). This targets the inflated gap
+  rate (1.0 with clean-control false positives) and 0% HumanEval detection.
+- **Docs sync (`docs/sync-state-fedllm-default`)**: FedLLM as the documented
+  default everywhere; jupyter magic default changed from `openai` to `fedllm`
+  (code + doc + test); README LLM section and CLI examples lead with FedLLM;
+  workflow-design diagram fixed (round 0 is analyse+verify, not static-only;
+  `--strategy feedback --llm fedllm`). Added this session log.
+
+### Experiment findings to date (from runs the user shared)
+- Lab calibration (pre-Bug-2): gap rate pegged at 1.0; clean_control reported
+  11-16 false-positive "bugs"; reliability_gap over-reported (24 vs 5 seeded).
+  Diagnosis: generated tests over-fire on correct code. Bug 2 is the fix.
+- HumanEvalFix: 0% detection across all strategies, but 25 "bugs reported" per
+  problem at 100% coverage; tests fail canonical solutions too. Same cause.
+- The run.log (after file-logging shipped) was the key diagnostic: round 0
+  clean functions `failed=0` (correct), round 1 `failed=2` on unchanged correct
+  code (the over-counting), plus a 60s test timeout on a clean function.
+
+### OPEN items (resume here)
+1. **Re-run lab calibration after Bug 2 merges** (the regression gate):
+   expect clean_control -> ~0, complexity_findings -> ~0, reliability_gap -> ~5.
+   This is what makes the gap rate trustworthy. Command:
+   `python scripts/run_gap_experiment.py --dataset datasets/lab
+   --output runs/lab_calibration --pattern "*.py" --llm fedllm --rounds 5 --confirm`
+2. **ENVRI headline run** once calibration is clean: full corpus, tmux,
+   resumable, metrics_only retention, `--pattern "*.ipynb"`. Report gap rate
+   with its 95% CI.
+3. **RQ2/RQ3 confirm path** still produced 0 confirmed/0 refuted on the lab set
+   even with `--confirm`. Investigate after Bug 2; the security findings should
+   confirm. (Confirmed != 0 was null in output, so the path may not populate.)
+4. **Verify the execution sandbox can import heavy ML deps** (tensorflow/torch)
+   for ENVRI notebooks, or run a dependency-light subset; otherwise they ERROR.
+5. **VM locale warning** (cosmetic): `echo 'export LANG=C.UTF-8' >> ~/.bashrc`
+   on the VM is the zero-sudo fix.
+6. **Credits**: user may hit FedLLM credit limits; resets ~2h. The repair-skip
+   and checkpoint-exclusion changes reduce waste.
+
+### Decisions worth remembering
+- The baseline gate is round-aware by design: round 0 keeps gap-detecting
+  tests, round >= 1 strips tests that regress against the baseline. Under the
+  default FROZEN+REPLAY_ONLY policy (generate once at round 0, replay after),
+  the gate mainly guards the GROW policies, which is where over-firing appeared.
+- FedLLM (`fedllm:gpt-oss-120b`) is the project default everywhere; cost $0.00
+  is correct (free for VO users), not a bug.
+
+### Deferred / future (not blocking the thesis)
+- In-app live metrics page; conference one-pager; per-round verified-fix
+  tracking (PhD tier); wiring the fixed TruffleHog into a security defect-class
+  study; multi-model HumanEval run for external validity.

--- a/src/qallm/jupyter.py
+++ b/src/qallm/jupyter.py
@@ -84,7 +84,7 @@ def _make_arg_parser():
                    help="Path for the line magic; omitted for the cell magic.")
     p.add_argument("--strategy", default="feedback",
                    choices=["hypothesis", "oneshot", "feedback"])
-    p.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama", "fedllm"])
+    p.add_argument("--llm", default="fedllm", choices=["openai", "anthropic", "ollama", "fedllm"])
     p.add_argument("--model", default=None)
     p.add_argument("--rounds", type=int, default=3)
     p.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])

--- a/tests/test_jupyter_magic.py
+++ b/tests/test_jupyter_magic.py
@@ -29,6 +29,7 @@ def test_arg_parser_defaults_and_overrides():
     p = J._make_arg_parser()
     a = p.parse_args([])
     assert a.strategy == "feedback" and a.rounds == 3 and a.source is None
+    assert a.llm == "fedllm"  # FedLLM is QALLM's default provider
     b = p.parse_args(["file.py", "--strategy", "oneshot", "--rounds", "5"])
     assert b.source == "file.py" and b.strategy == "oneshot" and b.rounds == 5
 


### PR DESCRIPTION
Keeps the docs honest against the code and standardises FedLLM as the default provider everywhere.

- jupyter magic: default --llm changed from openai to fedllm (matches the rest of QALLM, where gap-runner and MODEL_CATALOG already default to FedLLM). Doc table and credentials note updated; a test asserts the fedllm default.
- README: LLM-keys section and CLI examples now lead with FedLLM (fedllm:gpt-oss-120b, free for VO users) while still listing OpenAI/Anthropic/ Ollama as options.
- workflow-design.md: fixed two stale bits in the diagram, round 0 is analyse + execution-based verify (not static-only, per MD-001), and the CLI label uses --strategy feedback --llm fedllm (not the old rl).
- Added docs/thesis/session-log.md: an append-only, dated record of what changed each session and what is outstanding, so a new chat session can resume without re-deriving state. Linked from the docs index.

Suite: 619 passed; ruff clean.