### PR TITLE
fix(gap): measure the verification gap at round 0, not the final round

### DIFF
--- a/docs/architecture/verification-repair-reward-design.md
+++ b/docs/architecture/verification-repair-reward-design.md
@@ -1,0 +1,243 @@
+# Verification, repair, and reward: architecture and the gap-measurement fix
+
+Status: design analysis and source of truth, written 2026-06-09 in response to
+five observations from the lab calibration run. Some sections describe current
+behaviour, some describe the fix being made. Each is marked. Dashes avoided per
+convention.
+
+## The five observations and how they connect
+
+1. Repair is correctly skipped for code units with zero static findings (done).
+2. Code can fail verification (logical flaws) even with zero static findings;
+   such functions should still be repairable. Needs design + fix.
+3. Functions are verified independently of the code unit they belong to;
+   coverage and reward may not aggregate to the unit. Needs design.
+4. The progress label reads "unit 1/1" because the runner processes one file
+   at a time and a `.py` file is a single code unit. Needs a sequence fix.
+5. One run over a 4-file dataset yields 4 separate sessions; tracing across the
+   experiment files and the pipeline output is hard. Needs a structural answer.
+
+Four of these (2, 3, 4, 5) share one root: **QALLM's unit of work is the
+function, but the unit of meaning is sometimes the code unit (file or cell) and
+sometimes the whole run.** The calibration false positives (observation behind
+all of this) come from a related conflation in time: **the verification gap is
+a round-0 property of the original code, but the metric was reading the final
+round.** That is the first thing to fix.
+
+## The data model (current, correct)
+
+```mermaid
+graph TD
+    Dataset[Dataset dir: N files] --> File[File: .py or .ipynb]
+    File -->|.py| U1[1 CodeUnit cell_index 0]
+    File -->|.ipynb| UN[M CodeUnits one per cell]
+    U1 --> Fns[Functions in the unit]
+    UN --> Fns
+    Fns --> Fn[Function: the verification target]
+    Fn --> Rounds[Rounds 0..R: tests generated, executed, scored]
+```
+
+- A **dataset** has N files.
+- A **file** ingests to one CodeUnit (`.py`) or many (`.ipynb`, one per cell).
+- A **CodeUnit** contains zero or more functions.
+- A **function** is what verification actually targets: tests are generated for
+  it, executed against it, scored, and repaired.
+- Each function has **rounds** 0..R. Round 0 is the baseline (original code).
+
+## Bug A (the calibration false positives): gap read the wrong round
+
+### Symptom
+On `clean_control.py` (correct by construction) the gap reported 12 execution
+only bugs. The run.log shows why, for `add` (`return a + b`):
+
+```
+round 0: failed=0   round 1: failed=0   ...   round 4: failed=1   round 5: failed=3
+```
+
+Round 0 is correct (gap = 0). Later rounds accumulate GROW tests, some of which
+are flaky or wrong, and they fail. Since `add` has zero findings, repair is now
+skipped, so the code is identical across rounds; the failures are test noise,
+not defects.
+
+### Root cause
+`_executions_from_verification` reads `rounds[-1]` (the final round) and counts
+`bugs = failed`. The verification gap, by definition, asks: *does the ORIGINAL
+code have a runtime defect that static analysis missed?* That is a round-0
+question. Reading the last round conflates the gap with repair-round test noise.
+
+### Fix (being made)
+The gap metric reads **round 0** execution, not `rounds[-1]`. Round 0 is the
+baseline pass over the original code, exactly the code whose gap we are
+measuring. Repair rounds remain relevant to RQ3 (verified-fix rate) but must
+not feed the round-0 gap count.
+
+Regression gate: after the fix, on the lab set, `clean_control.py` and
+`complexity_findings.py` report ~0 execution-only bugs, `reliability_gap.py`
+reports ~5 (its seeded bugs are present in the original, so they show at round
+0, which is correct).
+
+```mermaid
+graph LR
+    subgraph Before [Before: reads final round]
+        R0b[round 0: failed=0] --> Rlast_b[round 5: failed=3] --> Cb[gap = 3 WRONG]
+    end
+    subgraph After [After: reads round 0]
+        R0a[round 0: failed=0] --> Ca[gap = 0 CORRECT]
+        Rlast_a[round 5: noise] -.ignored for gap.-> Ca
+    end
+```
+
+## Observation 2: repair on verification failure, not just static findings
+
+### Current behaviour
+Repair currently triggers on static findings, and (now) skips when there are
+zero. But a function can pass static analysis and still fail verification: a
+generated test that fails the ORIGINAL code at round 0 is exactly the
+verification gap, a logical flaw with no static finding. Today such a function
+is detected (it is the gap) but not necessarily routed to repair, because the
+repair trigger is finding-driven, not verification-driven.
+
+### Intended behaviour (design)
+A function should be repaired when EITHER it has static findings OR round-0
+verification found a runtime defect (a test that ran and failed against the
+original code). The repair input in the second case is the failing test and its
+output, the evidence of the logical flaw, not a static finding.
+
+```mermaid
+graph TD
+    Fn[Function] --> A{static findings?}
+    A -->|yes| Repair[Repair: fix the findings]
+    A -->|no| V{round-0 verification<br/>found a runtime defect?}
+    V -->|yes, logical flaw| Repair
+    V -->|no| Skip[No repair: genuinely clean]
+    Repair --> Verify[Re-verify the repaired variant]
+    Verify --> Judge[Judge vs parent: accept or abandon]
+```
+
+This makes the gap actionable: the defects QALLM uniquely finds (runtime flaws
+static tools miss) become repair targets, which is the point of the pipeline
+and strengthens the RQ3 verified-fix story. This needs its own PR; the trigger
+lives in the orchestrator's per-unit flow and must thread the failing-test
+evidence into the repair request.
+
+## Observation 3: per-function vs per-unit coverage and reward
+
+### Current behaviour
+Verification targets one function at a time. Coverage
+(`execution.coverage_percent`) is measured for that function's tests, and the
+reward uses that per-function coverage. There is no aggregation of coverage or
+reward to the owning code unit.
+
+### Why this can mislead
+If a code unit has several functions, per-function coverage answers "how well
+is THIS function tested", not "how well is the UNIT tested". For the thesis
+metrics that is actually the correct granularity: the verification gap and the
+confirmation/fix rates are per-function properties, and aggregating coverage
+across functions in a unit would blur which function carries the gap. So the
+per-function measurement is right for the RESULTS.
+
+The reward is a different matter. The reward drives the RL/feedback loop's
+decision to keep generating tests for a function; it is intentionally
+per-function, because the loop optimises one function's test suite at a time.
+Aggregating reward to the unit would couple unrelated functions' loops and is
+not wanted.
+
+### Decision (source of truth)
+- Coverage and bug/gap metrics stay **per function**; this is the correct
+  granularity for RQ1/RQ2/RQ3 and for the reward loop.
+- Aggregation to the **code unit** and to the **run** happens only at REPORTING
+  time (counts and rates summed across functions), never inside the loop.
+- If a unit-level coverage figure is ever wanted for presentation, it is a
+  reporting-time union of the functions' covered lines, computed from the
+  persisted per-function data, not a change to the loop.
+
+This keeps the loop's incentives clean and the results at the granularity the
+research questions ask about. No loop change is needed; the clarification is
+the deliverable.
+
+```mermaid
+graph TD
+    subgraph Loop [In the loop: per function]
+        Fa[func A: coverage, reward] 
+        Fb[func B: coverage, reward]
+    end
+    subgraph Report [At reporting time only]
+        Fa --> Unit[Code-unit summary:<br/>sum bugs, sum findings]
+        Fb --> Unit
+        Unit --> Run[Run aggregate:<br/>gap rate + CI across functions]
+    end
+```
+
+## Observation 4: "unit 1/1" progress label
+
+### Cause
+The progress label was set per code unit, and the gap-runner processes one file
+per orchestrator run. A `.py` file is one code unit, so the label is always
+"unit 1/1". The sequence that matters to the user is the **file's position in
+the dataset** (file 7 of 289), and within a notebook, the **cell/function
+position**.
+
+### Fix (being made)
+The label gains the function sequence within the unit (`fn 2/4`) which the
+verification manager already tracks, and the runner contributes the file's
+position in the dataset (`file 7/289`) to the context. So a line reads:
+
+```
+[file 7/289 prediction.ipynb | unit 2/5 | fn 3/4 normalise] ...
+```
+
+The orchestrator already sets unit/function context; the runner needs to set
+the file-level part of the label before each `_run_one`.
+
+## Observation 5: one session per file; traceability
+
+### Current behaviour
+The gap-runner runs one orchestrator per file, producing one session directory
+per file, named `{timestamp}_{uuid8}`. For a 4-file dataset that is 4 session
+dirs, with no obvious link between them or to the experiment output.
+
+### Why it is structured this way (and is mostly correct)
+Per-file sessions are the right isolation boundary: each file is an independent
+input, resumable on its own, and one file failing does not corrupt another. The
+problem is not the per-file split; it is **discoverability**, the sessions are
+not visibly tied to the run that produced them.
+
+### Decision (source of truth) and fix
+Keep one session per file (the isolation is valuable), but make the run the
+parent of its sessions:
+- The runner writes a `manifest.json` (it already does) listing every session
+  id and its input file, so the run-to-session mapping is explicit.
+- Session directories for a run are placed under the run's output directory
+  (e.g. `runs/lab_calibration/sessions/{file_stem}_{uuid8}`), so they live with
+  the `aggregate.json`, `metrics.csv`, and `run.log` rather than in a global
+  session store. This is the "related directories" the observation asks for.
+- The session id incorporates the input file stem so a directory name is
+  self-describing (`clean_control_a1b2c3d4`), not an opaque uuid.
+
+```mermaid
+graph TD
+    Run[runs/lab_calibration/] --> Agg[aggregate.json]
+    Run --> Csv[metrics.csv]
+    Run --> Log[run.log]
+    Run --> Man[manifest.json: session-to-file map]
+    Run --> Sess[sessions/]
+    Sess --> S1[clean_control_a1b2c3d4/]
+    Sess --> S2[reliability_gap_e5f6g7h8/]
+    S1 --> L1[lineage/ abandoned/ summary.json]
+```
+
+## Implementation order
+
+1. **Bug A (round-0 gap):** highest priority, it is what makes the lab
+   calibration correct. Small, well-scoped change to `_executions_from_verification`
+   and the disk-path round selection, with the lab set as the regression gate.
+   (This PR.)
+2. **Observation 4 (progress label):** small, independent. Add file/function
+   sequence to the context. (This PR or the next.)
+3. **Observation 2 (repair on verification failure):** medium, its own PR;
+   changes the repair trigger and threads failing-test evidence.
+4. **Observation 5 (session layout):** medium, its own PR; a persistence-path
+   change, needs care so confirm/verify and the web UI still find sessions.
+5. **Observation 3:** no loop change; this document is the deliverable. A
+   reporting-time unit-coverage union can be added later if presentation needs it.
+```

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,7 +11,48 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
-## 2026-06-09
+## 2026-06-09 (later, gap-at-round-0)
+
+### Delivered for review
+- **Gap measured at round 0 (`fix/gap-measured-at-round-0`)**: the lab
+  calibration after Bug 2 still showed clean_control with 12 false bugs. Root
+  cause: the gap metric read the FINAL round (and summed execution_only across
+  ALL rounds), folding in GROW test noise from repair rounds. The gap is a
+  round-0 property of the ORIGINAL code. Fixed both paths:
+  `_executions_from_verification` reads the baseline (lowest round_number) round;
+  `build_session_metrics` takes execution_only from the round-0 gap report only,
+  not summed. Verified on the calibration shape: clean_control -> 0,
+  reliability_gap -> 5.
+- **Design doc** `docs/architecture/verification-repair-reward-design.md`:
+  source-of-truth analysis with diagrams for all five observations (repair on
+  verification failure, per-function vs per-unit coverage/reward, the unit-1/1
+  label, per-file sessions/traceability), and the round-0 gap fix.
+
+### OPEN items added this session (from the five observations)
+- **Repair on verification failure** (observation 2): a function with no static
+  findings but a round-0 runtime defect (logical flaw) should be routed to
+  repair using the failing test as evidence. Designed, not yet implemented; own
+  PR. Trigger lives in the orchestrator per-unit flow.
+- **Progress label** (observation 4): add file position in dataset (file 7/289)
+  and function position (fn 2/4) to the context; "unit 1/1" alone is
+  uninformative for single-unit .py files. Small, own PR.
+- **Session layout** (observation 5): keep one session per file (isolation is
+  valuable) but place session dirs under the run output
+  (runs/<name>/sessions/<file_stem>_<uuid>) and name them by file stem, so the
+  run-to-session link is visible. Persistence-path change; own PR; must keep
+  confirm/verify and the web UI working.
+- **Per-function vs per-unit (observation 3)**: DECISION recorded, no loop
+  change. Coverage/bugs stay per-function (correct granularity for RQ1/2/3 and
+  the reward loop); aggregation to unit/run happens only at reporting time.
+
+### Re-run after this merges
+Lab calibration is again the gate: clean_control -> ~0, complexity_findings ->
+~0, reliability_gap -> ~5. If those hold, the gap rate is trustworthy and ENVRI
+can run for the headline.
+
+---
+
+
 
 ### Merged this session (PRs in order)
 - Fetcher: never prompt for git credentials; per-clone timeout (private/removed

--- a/src/qallm/analysis/gap_analysis.py
+++ b/src/qallm/analysis/gap_analysis.py
@@ -161,11 +161,19 @@ def _function_for_line(spans: list[FunctionSpan], line: int) -> str | None:
 
 
 def _executions_from_verification(verification: list | None) -> dict[str, FunctionExecution]:
-    """Map function name -> execution outcome from a round's verification.json.
+    """Map function name -> execution outcome for the gap measurement.
 
-    Reads the last round of each function's session (the final state that
-    round), counting tests that ran (passed/failed) vs errored, mirroring
-    the bug-detail summary used elsewhere.
+    The verification gap is a property of the ORIGINAL code: does it have a
+    runtime defect that static analysis missed? That is a round-0 question. So
+    this reads the BASELINE round (the lowest round_number, the original code
+    before any repair), not the final round.
+
+    Reading the final round was wrong: under the GROW policy, later rounds
+    accumulate generated tests, some flaky or incorrect, whose failures against
+    a repaired variant were being counted as gap bugs. On a clean function
+    (identical code across rounds, since repair is skipped with no findings)
+    that produced false positives, the lab clean_control reporting bugs it
+    does not have.
     """
     out: dict[str, FunctionExecution] = {}
     if not verification:
@@ -174,7 +182,13 @@ def _executions_from_verification(verification: list | None) -> dict[str, Functi
         rounds = session.get("rounds") or []
         if not rounds:
             continue
-        execution = (rounds[-1].get("execution") or {})
+        # Select the baseline round: the lowest round_number, falling back to
+        # the first element if round_number is absent.
+        baseline = min(
+            rounds,
+            key=lambda r: r.get("round_number", 0) if isinstance(r, dict) else 0,
+        )
+        execution = (baseline.get("execution") or {})
         name = session.get("function") or session.get("function_name") or "?"
         passed = int(execution.get("passed", 0) or 0)
         failed = int(execution.get("failed", 0) or 0)

--- a/src/qallm/metrics_export.py
+++ b/src/qallm/metrics_export.py
@@ -116,13 +116,28 @@ def build_session_metrics(
         tokens=int(cost.get("total_tokens", 0) or 0),
     )
 
-    # Verification gap, aggregated across rounds (matches the UI card).
-    exec_only = sum(int(r.get("summary", {}).get("execution_only", 0) or 0)
-                    for r in gap_rounds)
-    confirmed_findings = sum(
-        int(r.get("summary", {}).get("confirmed", 0) or 0) for r in gap_rounds
-    )
-    findings = sum(len(r.get("findings", []) or []) for r in gap_rounds)
+    # Verification gap: a property of the ORIGINAL code (round 0). Use the
+    # round-0 gap report only, not a sum across rounds. Summing double-counted
+    # the same functions and folded in repair-round test noise, which on clean
+    # code produced false-positive "bugs" (the lab clean_control case). Round 0
+    # is the baseline pass over the original code, exactly what the gap asks
+    # about; repair rounds inform RQ3 (verified fixes), not the gap count.
+    def _round_no(r: dict) -> int:
+        return int(r.get("round", r.get("round_number", 0)) or 0)
+
+    baseline_round = None
+    if gap_rounds:
+        baseline_round = min(gap_rounds, key=_round_no)
+    if baseline_round is not None:
+        exec_only = int(baseline_round.get("summary", {}).get("execution_only", 0) or 0)
+        confirmed_findings = int(
+            baseline_round.get("summary", {}).get("confirmed", 0) or 0
+        )
+        findings = len(baseline_round.get("findings", []) or [])
+    else:
+        exec_only = 0
+        confirmed_findings = 0
+        findings = 0
     m.static_findings = findings
     m.confirmed_findings = confirmed_findings
     m.execution_only_bugs = exec_only

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -103,3 +103,36 @@ def test_csv_has_stable_header_and_rows():
 def test_to_dict_keys_match_csv_columns():
     s1 = SessionMetrics("s1")
     assert set(s1.to_dict().keys()) == set(CSV_COLUMNS)
+
+
+def test_gap_measured_at_round_0_not_summed():
+    """The verification gap is a round-0 property. Later rounds (GROW test
+    noise, repair-round failures) must not be summed into the gap count.
+    Regression: clean code reported false bugs from accumulated round-N tests.
+    """
+    gap_rounds = [
+        # Round 0: the original code is clean (the true gap is 0).
+        {"round": 0, "findings": [],
+         "summary": {"execution_only": 0, "confirmed": 0}},
+        # Later rounds: accumulated flaky tests "fail" on the (unchanged) code.
+        {"round": 3, "findings": [],
+         "summary": {"execution_only": 2, "confirmed": 0}},
+        {"round": 5, "findings": [],
+         "summary": {"execution_only": 3, "confirmed": 0}},
+    ]
+    m = build_session_metrics("clean", _summary(), gap_rounds)
+    assert m.execution_only_bugs == 0   # round 0 only, not 0+2+3=5
+    assert m.verification_gap_rate is None  # no bugs, no findings -> no gap
+
+
+def test_gap_round_0_seeded_bugs_preserved():
+    """A genuinely buggy original (bugs present at round 0) is still counted;
+    the round-0 selection does not suppress real gap detection."""
+    gap_rounds = [
+        {"round": 0, "findings": [],
+         "summary": {"execution_only": 5, "confirmed": 0}},
+        {"round": 2, "findings": [],
+         "summary": {"execution_only": 8, "confirmed": 0}},
+    ]
+    m = build_session_metrics("reliability", _summary(), gap_rounds)
+    assert m.execution_only_bugs == 5   # the seeded bugs at round 0, not 5+8


### PR DESCRIPTION
After Bug 2 merged, the lab calibration still reported clean_control with 12 execution-only "bugs". Root cause, in two places:

1. _executions_from_verification read rounds[-1] (the final round) and counted failed tests as bugs.
2. build_session_metrics summed execution_only across ALL rounds.

The verification gap is, by definition, a property of the ORIGINAL code: does it have a runtime defect static analysis missed? That is a round-0 question. Under the GROW policy, later rounds accumulate generated tests, some flaky or wrong; on a clean function (identical code across rounds, repair skipped with no findings) those test failures were miscounted as gap bugs.

Fix: the gap is now measured at round 0 only.
- _executions_from_verification selects the baseline round (lowest round_number) of each function's session.
- build_session_metrics takes execution_only / confirmed / findings from the round-0 gap report only, not summed across rounds.

Repair rounds still inform RQ3 (verified-fix rate); they no longer feed the round-0 gap count.

Verified on the calibration shape: a session whose round 0 is clean but whose round 5 has accumulated-test failures reports 0 gap bugs (was summing to >0); a session with 5 seeded bugs at round 0 reports 5 (was summing round0+roundN).

Also adds docs/architecture/verification-repair-reward-design.md: a source-of-truth design analysis with diagrams covering this fix and four related observations (repair on verification failure, per-function vs per-unit coverage/reward, the unit-1/1 progress label, per-file session traceability), with an implementation order. Session log updated.

Tests (test_metrics_export.py, +2): gap measured at round 0 not summed; round-0 seeded bugs preserved.

Regression gate: re-run lab calibration; clean_control and complexity_findings should report ~0 execution-only bugs, reliability_gap ~5.

Suite: 626 passed; ruff clean.