### PR TITLE
feat(repair): repair logical flaws found by verification, not just fi…

### DIFF
--- a/docs/architecture/verification-repair-reward-design.md
+++ b/docs/architecture/verification-repair-reward-design.md
@@ -89,13 +89,12 @@ graph LR
 
 ## Observation 2: repair on verification failure, not just static findings
 
-### Current behaviour
-Repair currently triggers on static findings, and (now) skips when there are
-zero. But a function can pass static analysis and still fail verification: a
-generated test that fails the ORIGINAL code at round 0 is exactly the
-verification gap, a logical flaw with no static finding. Today such a function
-is detected (it is the gap) but not necessarily routed to repair, because the
-repair trigger is finding-driven, not verification-driven.
+### Status: IMPLEMENTED
+
+### Current behaviour (before this change)
+Repair triggered on static findings only, and skipped when there were zero. A
+function could pass static analysis yet fail verification (a logical flaw), and
+that flaw was never routed to repair because the trigger was finding-driven.
 
 ### Intended behaviour (design)
 A function should be repaired when EITHER it has static findings OR round-0
@@ -114,11 +113,17 @@ graph TD
     Verify --> Judge[Judge vs parent: accept or abandon]
 ```
 
-This makes the gap actionable: the defects QALLM uniquely finds (runtime flaws
-static tools miss) become repair targets, which is the point of the pipeline
-and strengthens the RQ3 verified-fix story. This needs its own PR; the trigger
-lives in the orchestrator's per-unit flow and must thread the failing-test
-evidence into the repair request.
+### Implemented mechanism
+A function is repaired when it has static findings OR the previous round's
+verification found a runtime defect. The orchestrator captures per-function
+runtime failures after each verify (function name, the failing test, a short
+error excerpt) onto the unit track, and passes them into the next round's
+`repair_code_unit`. The repair-skip short-circuit now skips only when there are
+neither findings nor runtime failures. The repair agent's prompt includes the
+failing test as evidence, with an instruction to fix the code (not the test) so
+the test would pass. This needs its own PR; the trigger lives in the
+orchestrator's per-unit flow and threads the failing-test evidence into the
+repair request.
 
 ## Observation 3: per-function vs per-unit coverage and reward
 

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,29 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-09 (later, repair-on-verification-failure)
+
+### Delivered for review
+- **Repair on verification failure (`feature/repair-on-verification-failure`)**:
+  Observation 2. A function with no static finding but a runtime defect (a
+  logical flaw caught by a failing test) is now routed to repair. The
+  orchestrator captures per-function verification failures after each verify
+  and feeds the previous round's failures into the next round's repair;
+  RepairRequest gains a verification_failures field; the repair-skip
+  short-circuit skips only when there are neither findings nor runtime
+  failures; the repair agent prompt includes the failing test as evidence and
+  is told to fix the code, not the test.
+
+### Calibration status (post round-0 fix, from metrics.csv)
+- clean_control: 1 exec_only bug (target 0), one residual false positive.
+- complexity_findings: 0 (correct).
+- reliability_gap: 2 exec_only bugs (target ~5), now UNDER-counting; round-0
+  generated tests catch only 2 of 5 seeded bugs.
+- security_findings: 0 exec_only (static findings present, correct).
+- The gross over-counting is fixed; remaining gaps are round-0 test-generation
+  QUALITY (one false positive, three missed bugs), a precision/recall matter,
+  not a counting bug. Worth a focused look with the run.log next.
+
 ## 2026-06-09 (later, gap-at-round-0)
 
 ### Delivered for review

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -439,6 +439,42 @@ class QALLMOrchestrator:
             halt_reason=self.halt_reason.value if self.halt_reason else None,
         )
 
+    def _verification_failures_from(self, tested_unit) -> list:
+        """Extract per-function runtime failures from a tested unit.
+
+        For each function session whose latest round had a failing test, build
+        a VerificationFailure carrying the function name, the failing test
+        code, and a short error excerpt. These feed the next round's repair so
+        logical flaws with no static finding are still acted on. Best-effort:
+        any malformed session is skipped rather than breaking the run.
+        """
+        from qallm.repair.repair_model import VerificationFailure
+
+        failures: list = []
+        for session in getattr(tested_unit, "sessions", []) or []:
+            rounds = getattr(session, "rounds", None) or []
+            if not rounds:
+                continue
+            last = rounds[-1]
+            execution = getattr(last, "execution", None)
+            if execution is None or getattr(execution, "failed", 0) <= 0:
+                continue
+            gen = getattr(last, "generated_test", None)
+            test_code = getattr(gen, "test_code", "") if gen else ""
+            if not test_code:
+                continue
+            excerpt = ""
+            for d in getattr(execution, "test_details", []) or []:
+                if getattr(d, "status", "") in ("failed", "error"):
+                    excerpt = (getattr(d, "message", "") or "")[:300]
+                    break
+            failures.append(VerificationFailure(
+                function_name=getattr(session, "function_name", "?"),
+                failing_test=test_code,
+                error_excerpt=excerpt,
+            ))
+        return failures
+
     def _identity_repair(self, analysed) -> RepairedCodeUnit:
         """A no-op 'repair' whose output equals the input.
 
@@ -504,7 +540,12 @@ class QALLMOrchestrator:
             repaired = self._identity_repair(analysed)
         else:
             set_context(stage="repair", role="repair")
-            repaired = self.repair_manager.repair_code_unit(analysed)
+            # Pass the previous round's verification failures so logical flaws
+            # with no static finding (the verification gap) get repaired too.
+            repaired = self.repair_manager.repair_code_unit(
+                analysed,
+                verification_failures=track.last_verification_failures,
+            )
 
         # Step 3: verify. round_number=0 tells the stability store this is
         # the baseline round (where tests are generated under the default
@@ -530,6 +571,11 @@ class QALLMOrchestrator:
         self.current_function = None
         self.function_index = 0
         self.function_total = 0
+
+        # Capture this round's runtime failures so the NEXT round's repair can
+        # target logical flaws that have no static finding (the verification
+        # gap made actionable). Stored transiently on the track.
+        track.last_verification_failures = self._verification_failures_from(tested_unit)
 
         # Step 4: build the variant's ProfileVerdict.
         self.current_stage = "judge"

--- a/src/qallm/orchestrator_models.py
+++ b/src/qallm/orchestrator_models.py
@@ -68,6 +68,10 @@ class UnitTrack:
     unit_id: str  # stable identifier: f"{path}::{cell_index}"
     lineage: list[LineageEntry] = field(default_factory=list)
     abandoned: list[AbandonedEntry] = field(default_factory=list)
+    # Transient (not serialised): verification failures from the most recent
+    # round, fed into the NEXT round's repair so logical flaws with no static
+    # finding still get repaired. List of repair_model.VerificationFailure.
+    last_verification_failures: list = field(default_factory=list)
 
     @property
     def current_parent(self) -> Optional[LineageEntry]:

--- a/src/qallm/repair/agents/llm_repair_agent.py
+++ b/src/qallm/repair/agents/llm_repair_agent.py
@@ -17,7 +17,10 @@ BT = chr(96) * 3
 
 SYSTEM_PROMPT = """
 You are a senior Python security and quality engineer.
-Fix the code to address ALL the provided static analysis findings with minimal changes.
+Fix the code to address ALL the provided issues with minimal changes. Issues
+come in two kinds: static analysis findings, and runtime verification failures
+(a generated test that failed when run against the code, evidence of a logical
+flaw that static analysis did not catch). Fix both kinds.
 
 Rules:
 1. Preserve external behavior unless a finding requires changing it for safety.
@@ -28,9 +31,11 @@ Rules:
 5. If a finding is a false positive or cannot be fixed safely, keep the
    original code unchanged and add a # noqa comment on the relevant line.
 6. Keep changes small and localized, fix only the reported issues.
-7. Return the COMPLETE corrected file. No explanations, no markdown fences,
+7. For a runtime failure, make the function behave correctly so the failing
+   test would pass; do not edit the test, fix the code under test.
+8. Return the COMPLETE corrected file. No explanations, no markdown fences,
    no partial snippets. Return the full file from first line to last line.
-8. Ensure all imports needed by your fixes are present at the top of the file.
+9. Ensure all imports needed by your fixes are present at the top of the file.
 """
 
 MAX_RETRIES = 1
@@ -48,12 +53,30 @@ class LLMRepairAgent(RepairAgent):
         findings_text = "\n".join([
             f"  [{f.severity}] {f.rule_id} (line {f.line}): {f.message}"
             for f in request.current_findings
-        ])
+        ]) or "  (none)"
+
+        # Runtime verification failures: a logical flaw with no static finding.
+        # Include the failing test so the agent can see the expected behaviour.
+        runtime_text = ""
+        if request.verification_failures:
+            blocks = []
+            for vf in request.verification_failures:
+                excerpt = (vf.error_excerpt or "").strip()
+                blocks.append(
+                    f"  Function `{vf.function_name}` fails this test:\n"
+                    f"{vf.failing_test}\n"
+                    + (f"  Error: {excerpt}\n" if excerpt else "")
+                )
+            runtime_text = (
+                "\n\nRuntime verification failures (logical flaws found by "
+                "execution, no static finding). Fix the function so the test "
+                "passes:\n" + "\n".join(blocks)
+            )
 
         user_prompt = f"""File: {request.file_path}
 
 Findings to fix:
-{findings_text}
+{findings_text}{runtime_text}
 
 Source Code:
 {request.original_source}

--- a/src/qallm/repair/repair_manager.py
+++ b/src/qallm/repair/repair_manager.py
@@ -34,31 +34,43 @@ class RepairManager:
     def repair_code_unit(
         self,
         analysed_code_unit: AnalysedCodeUnit,
-        persist_dir: Path | None = None
+        persist_dir: Path | None = None,
+        verification_failures: list | None = None,
     ) -> RepairedCodeUnit:
         """Uses Repair agents to repair the supplied code and results in RepairedCodeUnit instance.
-        The repaired code might or might not compile!"""
+        The repaired code might or might not compile!
 
-        logger.info(f"Repairing: ({len(analysed_code_unit.findings)}) findings ["
-                    f"File name: {analysed_code_unit.code_unit.original_path}")
+        ``verification_failures`` carries runtime defects found by execution
+        (logical flaws with no static finding). When present, repair runs even
+        with zero static findings, and the failing tests are passed to the
+        agent as evidence. This makes the verification gap actionable: the
+        runtime flaws QALLM uniquely finds become repair targets.
+        """
+        verification_failures = verification_failures or []
+        n_findings = len(analysed_code_unit.findings)
+        n_runtime = len(verification_failures)
+        logger.info(
+            "Repairing: (%d) findings, (%d) runtime failure(s) [File name: %s]",
+            n_findings, n_runtime, analysed_code_unit.code_unit.original_path,
+        )
 
         code_unit = analysed_code_unit.code_unit
         code_unit_path = str(code_unit.original_path.absolute())
 
-        # Nothing to repair: with zero findings there is no defect for the LLM
-        # to act on, so calling it is wasted budget (and was producing "Repair
-        # completed" lines for files that had no findings at all). Return an
-        # identity result (source unchanged, compiles, empty diff) without any
-        # LLM round-trip.
-        if not analysed_code_unit.findings:
+        # Nothing to repair: no static findings AND no runtime failures. With
+        # neither, there is no defect for the LLM to act on, so calling it is
+        # wasted budget. Return an identity result without any LLM round-trip.
+        # (Previously this skipped on findings alone, which missed logical
+        # flaws that have no static finding but do fail verification.)
+        if not analysed_code_unit.findings and not verification_failures:
             logger.info(
-                "Repair skipped: 0 findings [File name: %s]",
+                "Repair skipped: 0 findings, 0 runtime failures [File name: %s]",
                 code_unit.original_path,
             )
             identity = RepairResult(
                 file_path=code_unit_path,
                 repaired_source=code_unit.source_code,
-                explanation="no findings: repair skipped",
+                explanation="no findings or runtime failures: repair skipped",
                 compiles=True,
                 unified_diff="",
             )
@@ -68,6 +80,7 @@ class RepairManager:
             file_path=code_unit_path,
             original_source=code_unit.source_code,
             current_findings=analysed_code_unit.findings,
+            verification_failures=verification_failures,
         )
 
         repair_result = self.repair_agent.repair(request)

--- a/src/qallm/repair/repair_model.py
+++ b/src/qallm/repair/repair_model.py
@@ -30,6 +30,19 @@ class RepairedCodeUnit():
 
 
 @dataclass
+class VerificationFailure:
+    """Evidence of a runtime defect found by verification, not static analysis.
+
+    A logical flaw can pass every static analyser yet fail at execution. This
+    carries the failing test so repair can target the flaw even when there is
+    no static finding for it, the verification gap made actionable.
+    """
+    function_name: str
+    failing_test: str
+    error_excerpt: str = ""
+
+
+@dataclass
 class RepairRequest:
     """A bundle of findings grouped by the file they target."""
     file_path: str
@@ -37,6 +50,9 @@ class RepairRequest:
     current_findings: List[Finding]
     previous_findings: List[Finding] = field(default_factory=list)
     context_metadata: Dict[str, Any] = field(default_factory=dict)
+    # Runtime defects found by verification (logical flaws with no static
+    # finding). When present, repair acts on these too, not only findings.
+    verification_failures: List["VerificationFailure"] = field(default_factory=list)
 
 @dataclass
 class RepairResult:

--- a/tests/test_orchestrator_loop.py
+++ b/tests/test_orchestrator_loop.py
@@ -171,7 +171,7 @@ def _wire_collaborators(
     # is the same CodeUnit it was asked to repair, so the orchestrator's
     # parent-vs-variant chain stays predictable.
     from qallm.repair.repair_model import RepairedCodeUnit, RepairResult
-    def _fake_repair(analysed):
+    def _fake_repair(analysed, *args, **kwargs):
         repaired_result = RepairResult(
             file_path=str(analysed.code_unit.original_path),
             repaired_source=analysed.code_unit.source_code,

--- a/tests/test_repair_skip_and_log_context.py
+++ b/tests/test_repair_skip_and_log_context.py
@@ -74,3 +74,58 @@ def test_unit_context_shortens_path():
     assert current_unit_label() == "[unit 1/10 deep.py::5] "
     clear_unit_context()
     assert current_unit_label() == ""
+
+
+# ── repair on verification failure (Observation 2) ──
+
+def test_runtime_failure_triggers_repair_with_zero_findings():
+    from qallm.repair.repair_model import VerificationFailure
+    agent = MagicMock()
+    repaired = MagicMock()
+    repaired.repaired_source = "def f():\n    return 2\n"
+    repaired.compiles = True
+    agent.repair.return_value = repaired
+    mgr = RepairManager(repair_agent=agent, analyzer=MagicMock())
+
+    vf = [VerificationFailure(
+        function_name="f", failing_test="def test_f():\n    assert f() == 2",
+        error_excerpt="AssertionError",
+    )]
+    mgr.repair_code_unit(_analysed(findings=[]), verification_failures=vf)
+    # No static findings, but a runtime failure, so repair must run.
+    agent.repair.assert_called_once()
+    # And the request carries the verification failure.
+    req = agent.repair.call_args[0][0]
+    assert len(req.verification_failures) == 1
+    assert req.verification_failures[0].function_name == "f"
+
+
+def test_no_findings_and_no_runtime_still_skips():
+    agent = MagicMock()
+    mgr = RepairManager(repair_agent=agent, analyzer=MagicMock())
+    mgr.repair_code_unit(_analysed(findings=[]), verification_failures=[])
+    agent.repair.assert_not_called()
+
+
+def test_repair_prompt_includes_failing_test():
+    from qallm.repair.agents.llm_repair_agent import LLMRepairAgent
+    from qallm.repair.repair_model import RepairRequest, VerificationFailure
+
+    llm = MagicMock()
+    resp = MagicMock()
+    resp.content = "def f():\n    return 2\n"
+    resp.model = "stub"
+    llm.chat.return_value = resp
+    agent = LLMRepairAgent(llm=llm, tracker=MagicMock())
+    req = RepairRequest(
+        file_path="x.py", original_source="def f():\n    return 1\n",
+        current_findings=[],
+        verification_failures=[VerificationFailure(
+            "f", "def test_f():\n    assert f() == 2", "AssertionError: 1 != 2",
+        )],
+    )
+    agent.repair(req)
+    user_prompt = llm.chat.call_args[0][1]
+    assert "def test_f" in user_prompt
+    assert "Runtime verification failures" in user_prompt
+    assert "AssertionError" in user_prompt


### PR DESCRIPTION
…ndings

Observation 2: the verification gap made actionable. A function can pass every static analyser yet fail at execution (a logical flaw). Previously repair was finding-driven, so such flaws were detected (they are the gap) but never routed to repair. Now they are.

Mechanism:
- RepairRequest gains a verification_failures field (VerificationFailure: function name, the failing test, a short error excerpt).
- The orchestrator captures per-function runtime failures after each verify (_verification_failures_from) onto the unit track, and passes the previous round's failures into the next round's repair_code_unit.
- repair_code_unit's skip short-circuit now skips only when there are NEITHER static findings NOR runtime failures (was findings-only, which missed logical flaws); when runtime failures are present it repairs even with zero findings.
- The repair agent prompt includes the failing test as evidence and instructs the model to fix the code so the test passes, not edit the test.

This strengthens the RQ3 verified-fix story: the runtime flaws QALLM uniquely finds become repair targets.

Tests (+3): runtime failure triggers repair with zero findings and the request carries the failure; no findings and no runtime still skips; the repair prompt includes the failing test and error. Updated the orchestrator-loop fake repair stub to accept the new kwarg.

Docs: design doc marks Observation 2 implemented; session log updated, incl. the post-round-0 calibration status (gross over-counting fixed; residual round-0 test-generation precision/recall to look at next).

Suite: 629 passed; ruff clean.