### PR TITLE
feat(oracle): add a correctness oracle for reliability (wrong-value) …

### DIFF
--- a/docs/experiments/reliability-oracle-findings.md
+++ b/docs/experiments/reliability-oracle-findings.md
@@ -1,0 +1,102 @@
+# Why the reliability bugs are missed: an oracle-type mismatch
+
+From the lab calibration artifacts (session 20260609_220309, reliability_gap.py).
+This is the most important finding since the round-0 fix. Dashes avoided per
+convention.
+
+## The numbers
+
+reliability_gap.py has 5 seeded bugs, one per function, all lint-clean and
+non-crashing (wrong values, not exceptions). Round-0 verification result:
+
+| Function | Seeded bug | round-0 failed |
+| --- | --- | --- |
+| inclusive_range_count | off-by-one (`end - start`, should be `+1`) | 0 |
+| normalise_unit | divides by max only, not (max - min) | 0 |
+| accumulate | mutable default argument | 0 |
+| safe_divide | guards `b is None` instead of `b == 0` | 0 |
+| first_even | uses `n % 2 == 1`, returns first ODD | 1 |
+
+Only 1 of 5 bugs caught. clean_control is now 0 (good), but reliability_gap is
+badly under-detecting.
+
+## Root cause: the crash oracle cannot catch wrong-value bugs
+
+The generated tests assert the wrong thing. Examples from the artifacts:
+
+- `inclusive_range_count`: every test is `assert isinstance(result, int)`. The
+  function returns 10 for (0,10) when it should return 11, but the test only
+  checks the TYPE, not the value, so it passes on buggy code.
+- `safe_divide`: the test is `with pytest.raises(ZeroDivisionError):
+  safe_divide(5, 0)`. The docstring says it should RETURN 0 on a zero divisor;
+  the buggy code crashes; the test asserts the crash is correct. The test
+  encodes the bug as expected behaviour.
+
+Two compounding causes:
+
+1. **Oracle-type mismatch.** The default oracle is `crash`, whose prompt
+   literally says "test whether the function handles edge cases without raising
+   unhandled exceptions." That is a robustness oracle. The reliability bugs are
+   wrong VALUES from functions that do not crash, so a crash oracle
+   structurally cannot catch them. This is not a prompt typo; it is the oracle
+   doing exactly what it is designed to do.
+
+2. **Implementation-biased generation.** The prompt shows the function SOURCE
+   and asks the LLM to test it. The model reads the (buggy) implementation and
+   asserts what the code DOES, not what the docstring SAYS it should do. That
+   is why `safe_divide`'s test expects the crash: the model saw the code crash
+   and encoded that as the expectation.
+
+`first_even` was caught only incidentally: one of its value assertions happened
+to contradict the buggy behaviour.
+
+## Why this matters for the thesis
+
+The verification gap claim is "execution finds defects static analysis misses."
+For that to hold on RELIABILITY defects (the most common real-world class),
+QALLM needs an oracle that checks CORRECTNESS, not just crash-freedom. Right
+now, on the very dataset built to demonstrate the gap, QALLM misses 4 of 5
+reliability bugs because the default oracle and the implementation-biased prompt
+both steer away from value correctness. An examiner running the lab set would
+see this immediately. It must be fixed before the ENVRI headline.
+
+## The fix (design)
+
+Two changes, the first is the substantive one.
+
+### 1. A specification-based correctness oracle
+Add a `correctness` oracle (or strengthen the crash-oracle prompt) that:
+- Derives expected outputs from the DOCSTRING and the function's stated intent,
+  NOT from the implementation. The prompt should present the docstring as the
+  source of truth and explicitly warn: "the implementation may be wrong; assert
+  what the docstring promises, not what the code does."
+- Requires exact-value assertions for concrete inputs (`assert f(0, 10) == 11`),
+  not type/shape checks.
+- Optionally withholds or de-emphasises the implementation so the model is not
+  anchored on buggy behaviour. (Showing the signature + docstring + a few
+  argument examples may be enough; the body biases the oracle.)
+
+### 2. Make it the default for the gap experiment
+The reliability gap is a correctness question, so the gap experiment should run
+the correctness oracle (or a crash+correctness combination), not crash alone.
+The crash oracle remains valuable for the crash-class defects; this is about
+matching the oracle to the defect class under study.
+
+### Regression gate
+Re-run lab calibration with the correctness oracle:
+- reliability_gap -> ~5 (the seeded bugs caught by value assertions)
+- clean_control -> 0 (correct code passes value assertions)
+- complexity_findings -> 0 (structural, no runtime defect)
+- security_findings -> static findings confirmed where executable
+
+That is the instrument working: high recall on real reliability bugs, no false
+positives on clean code.
+
+## Honest framing
+
+The round-0 counting fix was necessary and correct, but it exposed that the
+DETECTION itself was weak for reliability defects, previously masked by the
+over-counting noise. This is good: the calibration set has now isolated the real
+problem (oracle quality for wrong-value bugs), which is a precise, fixable
+target and a genuinely interesting thesis point (oracle design determines which
+defect classes the verification gap can surface).

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,32 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-09 (later, correctness oracle)
+
+### Diagnosis (from the pipeline artifacts)
+Calibration after the round-0 fix: clean_control 0 (good), but reliability_gap
+fell to 1 of 5 seeded bugs. The artifacts show why: the default CRASH oracle
+only checks "does not raise", but the reliability bugs are WRONG VALUES from
+non-crashing functions. The generated tests asserted isinstance(result, int)
+(type, not value) and even encoded the bug as expected (safe_divide test
+asserted ZeroDivisionError, which the docstring says should be a returned 0).
+Two causes: oracle-type mismatch (crash cannot catch wrong values) and
+implementation-biased generation (LLM asserts what the buggy code does).
+Full write-up: docs/experiments/reliability-oracle-findings.md.
+
+### Delivered for review
+- **Correctness oracle (`feature/correctness-oracle`)**: a new oracle type
+  whose prompt treats the DOCSTRING as the source of truth, warns the
+  implementation may be buggy, and demands exact-value assertions (not
+  isinstance/type checks). Wired into OracleType, the generator dispatch, and
+  all --oracle CLI choices. Crash oracle unchanged (still right for crash-class
+  defects).
+
+### Regression gate (re-run needed)
+Re-run lab calibration with --oracle correctness: expect reliability_gap -> ~5,
+clean_control -> 0, complexity_findings -> 0. This is the recall test for
+reliability defects.
+
 ## 2026-06-09 (later, repair-on-verification-failure)
 
 ### Delivered for review

--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -43,7 +43,7 @@ def main() -> None:
                         choices=["feedback", "rl", "oneshot", "hypothesis"])
     parser.add_argument("--rounds", type=int, default=5)
     parser.add_argument("--oracle", default="crash",
-                        choices=["crash", "property", "metamorphic"])
+                        choices=["crash", "correctness", "property", "metamorphic"])
     parser.add_argument("--judge-strategy", default="lexicographic",
                         choices=["strict", "lexicographic", "model"])
     parser.add_argument("--stage", default="implementation",

--- a/scripts/run_humaneval.py
+++ b/scripts/run_humaneval.py
@@ -71,7 +71,7 @@ def main() -> int:
         help="QALLM rounds per run (default 5).",
     )
     parser.add_argument(
-        "--oracle", default="crash", choices=["crash", "property", "metamorphic"],
+        "--oracle", default="crash", choices=["crash", "correctness", "property", "metamorphic"],
         help="Test oracle (default crash).",
     )
     parser.add_argument(

--- a/src/qallm/experiment.py
+++ b/src/qallm/experiment.py
@@ -229,7 +229,7 @@ def main():
     parser.add_argument("--input", required=True, help="Path to notebooks/source files")
     parser.add_argument("--models", default="gpt-4o-mini", help="Comma-separated model names")
     parser.add_argument("--rounds", type=int, default=5, help="RL feedback rounds")
-    parser.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])
+    parser.add_argument("--oracle", default="crash", choices=["crash", "correctness", "property", "metamorphic"])
     parser.add_argument("--output", default="outputs/experiments", help="Output directory")
     parser.add_argument("-v", "--verbose", action="store_true")
     args = parser.parse_args()

--- a/src/qallm/jupyter.py
+++ b/src/qallm/jupyter.py
@@ -87,7 +87,7 @@ def _make_arg_parser():
     p.add_argument("--llm", default="fedllm", choices=["openai", "anthropic", "ollama", "fedllm"])
     p.add_argument("--model", default=None)
     p.add_argument("--rounds", type=int, default=3)
-    p.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])
+    p.add_argument("--oracle", default="crash", choices=["crash", "correctness", "property", "metamorphic"])
     p.add_argument("--stage", default="implementation",
                    choices=["draft", "implementation", "publication"])
     p.add_argument("--max-tokens", type=int, default=None, dest="max_tokens")

--- a/src/qallm/run_qallm.py
+++ b/src/qallm/run_qallm.py
@@ -23,7 +23,7 @@ def main():
     parser.add_argument("--llm", default="openai", choices=["openai", "anthropic", "ollama", "fedllm"])
     parser.add_argument("--model", default=None, help="Specific model name (e.g. gpt-4o-mini)")
     parser.add_argument("--rounds", type=int, default=5, help="Iterative feedback rounds (default: 5)")
-    parser.add_argument("--oracle", default="crash", choices=["crash", "property", "metamorphic"])
+    parser.add_argument("--oracle", default="crash", choices=["crash", "correctness", "property", "metamorphic"])
     parser.add_argument("--stage", default="implementation",
                         choices=["initialization", "implementation", "publication"])
     parser.add_argument(

--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -14,6 +14,7 @@ from qallm.llm.base import LLMModel, TokenTracker
 from qallm.verification.models import FunctionInfo, GeneratedTest, OracleType, TestGenerationSession
 from qallm.verification.prompts import (
     SYSTEM_PROMPT,
+    build_correctness_oracle_prompt,
     build_crash_oracle_prompt,
     build_metamorphic_oracle_prompt,
     build_property_oracle_prompt,
@@ -29,6 +30,7 @@ logger = logging.getLogger(__name__)
 
 PROMPT_BUILDERS = {
     "crash": build_crash_oracle_prompt,
+    "correctness": build_correctness_oracle_prompt,
     "property": build_property_oracle_prompt,
     "metamorphic": build_metamorphic_oracle_prompt,
 }

--- a/src/qallm/verification/models.py
+++ b/src/qallm/verification/models.py
@@ -42,7 +42,7 @@ class FunctionInfo:
     filepath: str
 
 
-OracleType = Literal["crash", "property", "metamorphic"]
+OracleType = Literal["crash", "correctness", "property", "metamorphic"]
 
 
 @dataclass

--- a/src/qallm/verification/prompts.py
+++ b/src/qallm/verification/prompts.py
@@ -40,6 +40,62 @@ input (e.g. result of f(1000) must not be compared to expected(100)).
 """
 
 
+def build_correctness_oracle_prompt(func: FunctionInfo) -> str:
+    """Build a user prompt for the correctness oracle.
+
+    The correctness oracle targets reliability defects: functions that do not
+    crash but return WRONG values. These are missed by the crash oracle (which
+    only checks for unhandled exceptions). The key design choices:
+
+    - Expected outputs are derived from the DOCSTRING / stated intent, never
+      from the implementation. The implementation may be buggy; asserting what
+      the code does would encode the bug as expected behaviour (the failure
+      mode seen on the lab set, e.g. a test asserting safe_divide(5, 0) raises,
+      when the docstring says it should return 0).
+    - Assertions must check exact VALUES for concrete inputs, not just types or
+      shapes (`assert f(0, 10) == 11`, not `assert isinstance(f(0, 10), int)`).
+    """
+    parts = [
+        "## Function under test\n",
+        f"```python\n{func.source}\n```\n",
+    ]
+
+    if func.docstring:
+        parts.append(f"## Specification (docstring, the SOURCE OF TRUTH)\n{func.docstring}\n")
+
+    if func.args:
+        arg_lines = []
+        for name, annotation in func.args:
+            arg_lines.append(
+                f"  {name}: {annotation}" if annotation
+                else f"  {name}: (no type annotation)"
+            )
+        parts.append("## Arguments\n" + "\n".join(arg_lines) + "\n")
+
+    parts.append(
+        "## Task\n"
+        "Generate pytest tests that check the function returns the CORRECT "
+        "VALUE according to the specification (docstring) above.\n\n"
+        "CRITICAL:\n"
+        "  - The implementation shown MAY BE WRONG. Derive every expected "
+        "value from the docstring / stated intent, NOT from what the code "
+        "appears to do. If the code contradicts the docstring, your test must "
+        "follow the docstring and therefore FAIL on the code.\n"
+        "  - Assert exact values for concrete inputs "
+        "(e.g. `assert f(0, 10) == 11`). Do NOT use `isinstance` or type/shape "
+        "checks as the only assertion; those pass on wrong values.\n"
+        "  - Pick inputs whose correct output you can determine from the "
+        "docstring and state that output explicitly in the assert.\n\n"
+        "Cover normal cases, boundaries, and any behaviour the docstring "
+        "promises for edge inputs (empty, zero, None). Use pytest.raises only "
+        "when the docstring explicitly says an exception is the correct "
+        "behaviour.\n\n"
+        "Return ONLY the complete test file. Start with imports."
+    )
+
+    return "\n".join(parts)
+
+
 def build_crash_oracle_prompt(func: FunctionInfo) -> str:
     """Build a user prompt for crash oracle test generation.
 

--- a/tests/test_prompts_correctness.py
+++ b/tests/test_prompts_correctness.py
@@ -1,0 +1,31 @@
+"""Tests for the correctness oracle prompt (reliability-bug detection)."""
+
+from qallm.verification.extractor import FunctionInfo
+from qallm.verification.prompts import build_correctness_oracle_prompt
+from qallm.verification.generator import PROMPT_BUILDERS
+
+
+def _fi():
+    return FunctionInfo(
+        name="inclusive_range_count",
+        source="def inclusive_range_count(start, end):\n    return end - start",
+        docstring="Count integers from start to end inclusive.",
+        args=[("start", None), ("end", None)],
+        lineno=1, filepath="x.py",
+    )
+
+
+def test_correctness_oracle_registered():
+    assert "correctness" in PROMPT_BUILDERS
+
+
+def test_correctness_prompt_treats_docstring_as_truth():
+    p = build_correctness_oracle_prompt(_fi())
+    assert "SOURCE OF TRUTH" in p
+    assert "MAY BE WRONG" in p  # implementation may be buggy
+
+
+def test_correctness_prompt_demands_value_assertions():
+    p = build_correctness_oracle_prompt(_fi())
+    assert "exact value" in p.lower()
+    assert "isinstance" in p  # explicitly discouraged


### PR DESCRIPTION
…defects

Diagnosis from the lab calibration artifacts: after the round-0 fix, reliability_gap caught only 1 of 5 seeded bugs. The artifacts show why, the default CRASH oracle only asks "does the function avoid unhandled exceptions", but the reliability bugs are WRONG VALUES from functions that do not crash. The generated tests asserted isinstance(result, int) (type, not value) and in one case encoded the bug as expected (safe_divide test asserting ZeroDivisionError, when the docstring says it should return 0). Two causes: an oracle-type mismatch (crash structurally cannot catch wrong values) and implementation-biased generation (the LLM asserts what the buggy code does).

Fix: a new "correctness" oracle. Its prompt presents the DOCSTRING as the source of truth, explicitly warns that the implementation may be wrong (assert what the docstring promises, not what the code does), and requires exact-value assertions rather than type/shape checks. Wired into OracleType, the generator PROMPT_BUILDERS dispatch, and every --oracle CLI choice. The crash oracle is unchanged; it remains correct for crash-class defects. Matching the oracle to the defect class under study is the point.

Docs: docs/experiments/reliability-oracle-findings.md (full analysis with the per-function evidence); session log updated.

Tests (+3): correctness oracle registered; prompt treats the docstring as truth and warns the implementation may be wrong; prompt demands value assertions and discourages isinstance.

Regression gate: re-run lab calibration with --oracle correctness; expect reliability_gap ~5, clean_control 0, complexity_findings 0.

Suite: 632 passed; ruff clean.