### PR TITLE
feat(oracle): correctness oracle withholds the implementation body

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -10,6 +10,7 @@ The reasoning the thesis rests on.
 
 - [`concepts/surpassing-static-analysers.md`](concepts/surpassing-static-analysers.md): the static-versus-execution argument (the verification gap, confirm/refute, verified fixes).
 - [`concepts/oracles.md`](concepts/oracles.md): the verification oracles (crash, property, metamorphic).
+- [`concepts/oracles-and-defect-classes.md`](concepts/oracles-and-defect-classes.md): which oracle catches which defect class, and why the correctness oracle withholds the implementation (illustrated).
 
 ## guides/ — how to run and operate QALLM
 

--- a/docs/architecture/verification-repair-reward-design.md
+++ b/docs/architecture/verification-repair-reward-design.md
@@ -2,8 +2,7 @@
 
 Status: design analysis and source of truth, written 2026-06-09 in response to
 five observations from the lab calibration run. Some sections describe current
-behaviour, some describe the fix being made. Each is marked. Dashes avoided per
-convention.
+behaviour, some describe the fix being made. Each is marked.
 
 ## The five observations and how they connect
 

--- a/docs/concepts/oracles-and-defect-classes.md
+++ b/docs/concepts/oracles-and-defect-classes.md
@@ -1,0 +1,79 @@
+# Oracles and defect classes
+
+QALLM's central idea is that execution finds defects static analysis misses
+(the verification gap). Which defects it finds depends on the ORACLE, the rule
+that decides whether an execution outcome counts as a defect. Different defect
+classes need different oracles; matching them is what makes the gap measurable.
+
+## The defect classes and the oracle that catches each
+
+```mermaid
+graph TD
+    Code[Code unit under test] --> Static[Static analysis]
+    Static -->|finds| SecComplexity[Security and complexity findings]
+    Static -.misses.-> Crash[Crash defects:<br/>unhandled exceptions on some input]
+    Static -.misses.-> Reliability[Reliability defects:<br/>wrong VALUE, no exception]
+
+    Crash --> CrashOracle[Crash oracle:<br/>test runs many inputs,<br/>a defect = an unhandled exception]
+    Reliability --> CorrOracle[Correctness oracle:<br/>test asserts the SPEC value,<br/>a defect = wrong returned value]
+
+    CrashOracle --> Gap[Verification gap:<br/>execution found what static missed]
+    CorrOracle --> Gap
+```
+
+- **Crash defects** (a function raises on some input it should handle) are
+  caught by the **crash oracle**: generate inputs, treat an unhandled exception
+  as the defect signal. Value correctness is not checked.
+- **Reliability defects** (a function returns the WRONG value but does not
+  crash, off-by-one, wrong operator, mutable-default state) are invisible to
+  the crash oracle, because nothing raises. They need the **correctness
+  oracle**: assert the value the specification promises, and a mismatch is the
+  defect.
+
+This is why the lab `reliability_gap.py` set was almost entirely missed under
+the crash oracle: every bug there is a wrong value, not a crash.
+
+## Why the correctness oracle withholds the implementation
+
+A correctness test is only as good as its expected value. If that value is
+derived from the (possibly buggy) code, the test just confirms the bug. We saw
+this directly: given the buggy body, the model generated
+
+```python
+assert inclusive_range_count(1, 5) == 5 - 1   # 4, the buggy answer
+```
+
+even though the docstring says the count is inclusive (5 values, not 4). The
+implementation was too strong an anchor, warnings did not overcome it.
+
+```mermaid
+graph LR
+    subgraph Anchored [Body shown: anchored on the bug]
+        Body[Buggy body:<br/>return end - start] --> WrongAssert[assert == end - start<br/>passes on buggy code]
+    end
+    subgraph SpecOnly [Body withheld: forced to the spec]
+        Sig[Signature + docstring:<br/>'count inclusive'] --> RightAssert[assert == 11 for 0..10<br/>fails on buggy code = gap found]
+    end
+```
+
+So the correctness oracle is shown only the **signature and docstring**, never
+the body. With nothing to copy, the model must compute the expected value from
+the specification, which is exactly the independent oracle a correctness check
+requires.
+
+## Choosing the oracle for an experiment
+
+- Studying reliability defects (the common real-world class, and the lab
+  reliability set): use `correctness`.
+- Studying crash robustness: use `crash`.
+- A run can target the class under study; the gap rate is then "gap for THIS
+  defect class", which is a sharper and more honest claim than a single blended
+  number.
+
+## Cross-call (stateful) defects
+
+Some reliability defects only appear across multiple calls (a mutable default
+argument that accumulates state, a cache that goes stale). A single call cannot
+reveal them. The correctness oracle prompt instructs the model to write
+multi-call tests when the spec describes cross-call behaviour, so this class is
+covered too.

--- a/docs/experiments/reliability-oracle-findings.md
+++ b/docs/experiments/reliability-oracle-findings.md
@@ -1,8 +1,7 @@
 # Why the reliability bugs are missed: an oracle-type mismatch
 
 From the lab calibration artifacts (session 20260609_220309, reliability_gap.py).
-This is the most important finding since the round-0 fix. Dashes avoided per
-convention.
+This is the most important finding since the round-0 fix.
 
 ## The numbers
 
@@ -91,6 +90,40 @@ Re-run lab calibration with the correctness oracle:
 
 That is the instrument working: high recall on real reliability bugs, no false
 positives on clean code.
+
+## Update (after the first correctness-oracle run): the body anchors the model
+
+Adding the correctness oracle improved recall (reliability_gap 1 -> 2 of 5,
+clean_control held at 0), but three bugs were still missed. The artifacts show
+why: even with the docstring presented as the source of truth and an explicit
+"the implementation may be wrong" warning, the model still derived expected
+values from the code. The clearest evidence, the generated test for
+inclusive_range_count contained:
+
+```python
+assert result == end - start  # expected buggy behavior
+```
+
+The model read the buggy body, computed `end - start`, and even labelled it
+"expected buggy behavior". Two more:
+- safe_divide: asserted `pytest.raises(ZeroDivisionError)` for b=0, mirroring
+  the buggy crash, when the docstring says it should return 0.
+- accumulate: the mutable-default bug only surfaces across MULTIPLE calls; every
+  generated test passed a fresh bucket and called once, so it never triggered.
+
+### Fix: withhold the implementation body
+The correctness oracle now shows only the SIGNATURE and docstring, never the
+body. With no code to anchor on, the model must compute expected values from
+the spec. The prompt also adds explicit guidance for stateful/cross-call
+behaviour (the accumulate class) and clarifies that an edge input the spec says
+should RETURN a value must be asserted as a return, not a raise (the safe_divide
+class).
+
+### Regression gate
+Re-run lab calibration with --oracle correctness; expect reliability_gap -> ~5
+(all seeded bugs caught), clean_control -> 0. If a bug is still missed, its
+artifact shows whether the model mis-derived the expected value from the spec,
+which is a prompt-refinement signal, not a structural one.
 
 ## Honest framing
 

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,32 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-10 (correctness oracle, withhold body)
+
+### Diagnosis (from artifacts 20260610_010643)
+First correctness-oracle run: reliability_gap 1 -> 2 of 5, clean_control held at
+0. Three bugs still missed. The artifacts show the model still derived expected
+values from the buggy body despite the warning: the inclusive_range_count test
+literally asserted `result == end - start  # expected buggy behavior`.
+safe_divide asserted a raise (mirroring the crash) when the spec says return 0;
+accumulate's mutable-default bug needs multiple calls but every test called once.
+
+### Delivered for review
+- **Withhold body in correctness oracle (`feature/correctness-oracle-signature-only`)**:
+  the correctness prompt now shows only the SIGNATURE + docstring, never the
+  body, so the model must compute expected values from the spec. Adds explicit
+  guidance for cross-call/stateful defects (accumulate class) and for
+  return-not-raise edge behaviour (safe_divide class).
+- New illustrated doc `concepts/oracles-and-defect-classes.md` (which oracle
+  catches which defect class; why the body is withheld), linked in the index.
+- Removed the "Dashes avoided per convention" lines from docs (convention now
+  applied silently).
+
+### Regression gate (re-run needed)
+Re-run lab calibration `--oracle correctness`: expect reliability_gap -> ~5,
+clean_control -> 0, complexity_findings -> 0. That is the recall gate before the
+ENVRI headline.
+
 ## 2026-06-09 (later, correctness oracle)
 
 ### Diagnosis (from the pipeline artifacts)

--- a/src/qallm/verification/prompts.py
+++ b/src/qallm/verification/prompts.py
@@ -40,6 +40,29 @@ input (e.g. result of f(1000) must not be compared to expected(100)).
 """
 
 
+def _signature_only(func: "FunctionInfo") -> str:
+    """The function's def line(s) up to the colon, without the body.
+
+    The correctness oracle must reason from the SPEC, not the implementation.
+    Showing the body anchors the model on what the (possibly buggy) code does,
+    even when told not to, observed on the lab set where a test asserted
+    `result == end - start  # expected buggy behavior`. Withholding the body
+    forces the model to derive expected values from the docstring. Falls back
+    to a bare `def name(...)` if the header cannot be parsed.
+    """
+    src = func.source or ""
+    header_lines = []
+    for line in src.splitlines():
+        header_lines.append(line)
+        if ":" in line.split("#")[0]:
+            break
+    header = "\n".join(header_lines).strip()
+    if not header.startswith(("def ", "async def ")):
+        arglist = ", ".join(name for name, _ in (func.args or []))
+        header = f"def {func.name}({arglist}):"
+    return header
+
+
 def build_correctness_oracle_prompt(func: FunctionInfo) -> str:
     """Build a user prompt for the correctness oracle.
 
@@ -47,21 +70,24 @@ def build_correctness_oracle_prompt(func: FunctionInfo) -> str:
     crash but return WRONG values. These are missed by the crash oracle (which
     only checks for unhandled exceptions). The key design choices:
 
-    - Expected outputs are derived from the DOCSTRING / stated intent, never
-      from the implementation. The implementation may be buggy; asserting what
-      the code does would encode the bug as expected behaviour (the failure
-      mode seen on the lab set, e.g. a test asserting safe_divide(5, 0) raises,
-      when the docstring says it should return 0).
-    - Assertions must check exact VALUES for concrete inputs, not just types or
-      shapes (`assert f(0, 10) == 11`, not `assert isinstance(f(0, 10), int)`).
+    - Only the SIGNATURE and docstring are shown, never the body. Showing the
+      implementation anchors the model on the buggy behaviour even when warned
+      against it.
+    - Expected outputs are derived from the DOCSTRING / stated intent.
+    - Assertions must check exact VALUES for concrete inputs, not types/shapes.
     """
     parts = [
-        "## Function under test\n",
-        f"```python\n{func.source}\n```\n",
+        "## Function to test (signature only, the body is withheld on purpose)\n",
+        f"```python\n{_signature_only(func)}\n    ...\n```\n",
     ]
 
     if func.docstring:
         parts.append(f"## Specification (docstring, the SOURCE OF TRUTH)\n{func.docstring}\n")
+    else:
+        parts.append(
+            "## Specification\nNo docstring is available. Infer the intended "
+            "behaviour from the function name and arguments, and test that.\n"
+        )
 
     if func.args:
         arg_lines = []
@@ -74,24 +100,30 @@ def build_correctness_oracle_prompt(func: FunctionInfo) -> str:
 
     parts.append(
         "## Task\n"
-        "Generate pytest tests that check the function returns the CORRECT "
-        "VALUE according to the specification (docstring) above.\n\n"
+        "You are given only the signature and the specification, NOT the "
+        "implementation. Write pytest tests that check the function returns "
+        "the CORRECT VALUE according to the specification.\n\n"
         "CRITICAL:\n"
-        "  - The implementation shown MAY BE WRONG. Derive every expected "
-        "value from the docstring / stated intent, NOT from what the code "
-        "appears to do. If the code contradicts the docstring, your test must "
-        "follow the docstring and therefore FAIL on the code.\n"
-        "  - Assert exact values for concrete inputs "
-        "(e.g. `assert f(0, 10) == 11`). Do NOT use `isinstance` or type/shape "
-        "checks as the only assertion; those pass on wrong values.\n"
-        "  - Pick inputs whose correct output you can determine from the "
-        "docstring and state that output explicitly in the assert.\n\n"
-        "Cover normal cases, boundaries, and any behaviour the docstring "
-        "promises for edge inputs (empty, zero, None). Use pytest.raises only "
-        "when the docstring explicitly says an exception is the correct "
-        "behaviour.\n\n"
+        "  - Derive every expected value from the specification. Compute by "
+        "hand what the function SHOULD return for each input, and assert that "
+        "exact value (e.g. `assert f(0, 10) == 11`). Do NOT use `isinstance` "
+        "or type/shape checks as the only assertion; those pass on wrong "
+        "values.\n"
+        "  - If the docstring describes behaviour that only appears across "
+        "MULTIPLE calls (state retained between calls, accumulation, caching, "
+        "default-argument reuse), write a test that calls the function several "
+        "times and asserts the specified cross-call behaviour. A single call "
+        "will miss such defects.\n"
+        "  - For error handling, use pytest.raises ONLY when the spec says an "
+        "exception is the correct behaviour. If the spec says the function "
+        "should RETURN a value for an edge input (e.g. return 0 on a zero "
+        "divisor), assert that returned value, do not assert it raises.\n\n"
+        "Cover normal cases, boundaries, and the edge behaviours the spec "
+        "promises.\n\n"
         "Return ONLY the complete test file. Start with imports."
     )
+
+    return "\n".join(parts)
 
     return "\n".join(parts)
 

--- a/tests/test_prompts_correctness.py
+++ b/tests/test_prompts_correctness.py
@@ -22,10 +22,41 @@ def test_correctness_oracle_registered():
 def test_correctness_prompt_treats_docstring_as_truth():
     p = build_correctness_oracle_prompt(_fi())
     assert "SOURCE OF TRUTH" in p
-    assert "MAY BE WRONG" in p  # implementation may be buggy
+    assert "body is withheld" in p  # implementation not shown, so no anchoring
 
 
 def test_correctness_prompt_demands_value_assertions():
     p = build_correctness_oracle_prompt(_fi())
     assert "exact value" in p.lower()
     assert "isinstance" in p  # explicitly discouraged
+
+
+def test_correctness_prompt_withholds_implementation_body():
+    # The body must NOT appear (it anchors the model on buggy behaviour); the
+    # signature must.
+    fi = FunctionInfo(
+        name="inclusive_range_count",
+        source="def inclusive_range_count(start, end):\n    return end - start",
+        docstring="Count integers from start to end inclusive.",
+        args=[("start", None), ("end", None)], lineno=1, filepath="x.py",
+    )
+    p = build_correctness_oracle_prompt(fi)
+    assert "return end - start" not in p          # body withheld
+    assert "def inclusive_range_count(start, end)" in p  # signature shown
+
+
+def test_correctness_prompt_has_stateful_and_return_guidance():
+    fi = FunctionInfo(
+        name="f", source="def f(x):\n    return x", docstring="d",
+        args=[("x", None)], lineno=1, filepath="x.py",
+    )
+    p = build_correctness_oracle_prompt(fi)
+    assert "MULTIPLE calls" in p          # cross-call defects (accumulate class)
+    assert "do not assert it raises" in p  # return-not-raise (safe_divide class)
+
+
+def test_signature_only_falls_back_when_unparseable():
+    from qallm.verification.prompts import _signature_only
+    fi = FunctionInfo(name="g", source="", docstring="", args=[("a", None)],
+                      lineno=1, filepath="x.py")
+    assert _signature_only(fi) == "def g(a):"


### PR DESCRIPTION
Diagnosis from the latest artifacts: the first correctness oracle lifted reliability_gap from 1 to 2 of 5 (clean_control stayed at 0), but three bugs were still missed because the model kept deriving expected values from the buggy body despite an explicit "implementation may be wrong" warning. The clearest evidence, the generated inclusive_range_count test asserted `result == end - start  # expected buggy behavior`. safe_divide asserted a ZeroDivisionError (mirroring the buggy crash) when the docstring says it should return 0; accumulate's mutable-default bug only shows across multiple calls but every generated test called once.

Fix: the correctness oracle now shows only the SIGNATURE and docstring, never the body. With no code to anchor on, the model must compute expected values from the specification, which is the independent oracle a correctness check requires. The prompt also adds explicit guidance for cross-call/stateful defects (write multi-call tests) and clarifies that an edge input the spec says should RETURN a value must be asserted as a return, not a raise. A _signature_only helper extracts the def header (with a safe fallback).

Docs: new illustrated concepts/oracles-and-defect-classes.md (which oracle catches which defect class; why the body is withheld), linked in the index; reliability-oracle-findings.md updated with the body-anchoring evidence; session log updated. Removed the "Dashes avoided per convention" notes from docs (applied silently now).

Tests (+3): body withheld but signature shown; stateful and return-not-raise guidance present; signature-only fallback when source is unparseable. Updated one prior assertion (the prompt withholds the body rather than warning about it).

Regression gate: re-run lab calibration --oracle correctness; expect reliability_gap ~5, clean_control 0.

Suite: 635 passed; ruff clean.