### PR TITLE
feat(runner): configurable parallel file processing (--workers)

### DIFF
--- a/docs/experiments/oracle-variance-and-consensus.md
+++ b/docs/experiments/oracle-variance-and-consensus.md
@@ -119,6 +119,45 @@ is prevented (a repeated assertion counts once per sample); pytest.approx is
 normalised; raises and inequalities are not voted on. This removes the cryptic
 false positive while preserving the 5/5 reliability recall.
 
+## Update 2: voting rarely triggers, because samples test different inputs
+
+With consensus genuinely running (`--samples 5`), the lab result was:
+clean_control 2 (worse than single-sample 1), complexity_findings 1,
+reliability_gap 5. The run.log shows the reason: **zero votes were cast across
+the entire run.** Majority voting only prunes when several samples assert
+different expected values for the SAME call, but the LLM samples pick DIFFERENT
+test inputs each time (one tests `add(2, 3)`, another `add(-1, 1)`, etc.), so
+there is almost never a shared call to vote on. Union then accumulates every
+sample's tests, including any one-off wrong assertion on a unique input, which
+is why clean_control got worse: more samples means more chances for a stray
+wrong assertion on an input no other sample tested.
+
+So consensus-by-union plus call-keyed voting does not help precision here, and
+hurts it on clean code. The mechanism is sound but mis-targeted: it assumes
+samples will collide on inputs, and they do not.
+
+### The real fix: fix the inputs, then vote on outputs
+Voting needs shared calls. The way to get them is to decouple input selection
+from output prediction:
+1. Generate candidate INPUTS once (or take the union of inputs across samples).
+2. For each fixed input, ask K samples only for the EXPECTED OUTPUT.
+3. Keep the input with its majority expected output; drop inputs with no
+   majority (the spec is too ambiguous for that input, exactly the cryptic and
+   safe_mean cases).
+
+This makes voting actually bind: every sample answers the same questions, so a
+one-off wrong answer is outvoted, and an input nobody agrees on is dropped
+rather than fired as a false positive. It also bounds the suite size (K answers
+per input, not K independent suites).
+
+This is a larger change (a new generation shape: propose-inputs then
+vote-outputs) and should be its own design + PR. For now, the honest
+calibration position is: single-sample correctness oracle gives 5/5 reliability
+recall with 1 to 2 false positives on clean/ambiguous functions; consensus as
+currently built does not improve precision and should be left at samples=1 until
+the fixed-input voting is implemented. The reliability recall (5/5) does not
+depend on consensus.
+
 ## What is NOT changing
 
 - The crash oracle stays as is; it is correct for crash-class defects and does

--- a/docs/guides/documentation-style-guide.md
+++ b/docs/guides/documentation-style-guide.md
@@ -92,6 +92,36 @@ clearly so a reader never implements a proposal as if it were current:
   "confirm/refute", "verified fix" as the standard vocabulary; do not introduce
   synonyms for established terms.
 
+## Logging conventions
+
+Logging is documentation for operators, so it follows the same discipline. The
+levels mean specific things:
+
+- **INFO**: milestones an operator watching a run wants to see, one per
+  meaningful step, not one per iteration. "Verifying f [3/12] in round 2",
+  "Gap experiment: 289 inputs, 0 done", "Consensus merge for f: 5/5 valid".
+  A reader skimming INFO should see the run progress, not a firehose.
+- **DEBUG**: the per-iteration and per-item detail useful when diagnosing a
+  specific failure: each generated test's validation result, per-sample timing,
+  intermediate token counts. Off by default; on when chasing a bug.
+- **WARNING**: something recovered from but worth knowing: a sample was
+  invalid, a test was dropped, a fixture was missing. Not for normal flow.
+- **ERROR**: the operation failed and the run is affected.
+
+Rules of thumb:
+- If a line fires once per function-per-round (or more often), it is almost
+  certainly DEBUG, not INFO. Per-round test-execution detail is DEBUG; the
+  round's verdict is INFO.
+- Method and event names in log messages start with a verb and read uniformly
+  ("Generating ...", "Verifying ...", "Repairing ...", "Dropped ..."), so a
+  grep on the verb finds the whole class of events.
+- One idea per line; do not pack several facts into one message. Structured
+  fields (key=value) are easier to grep than prose.
+- Never log secrets (API keys, tokens) at any level.
+
+When in doubt, ask: would an operator running ENVRI over hundreds of notebooks
+want this line every time? If not, it is DEBUG.
+
 ## The docs index
 
 `docs/README.md` lists every doc with a one-line description, grouped by

--- a/docs/guides/running-experiments.md
+++ b/docs/guides/running-experiments.md
@@ -51,7 +51,20 @@ python scripts/run_gap_experiment.py \
 python scripts/run_gap_experiment.py \
     --dataset data/li_notebooks --output runs/gap_full \
     --llm fedllm --rounds 5 --confirm
+
+# parallel: each file is an independent session, so files can run concurrently
+python scripts/run_gap_experiment.py \
+    --dataset data/li_notebooks --output runs/gap_full \
+    --llm fedllm --rounds 5 --confirm --workers 4
 ```
+
+`--workers N` (default 1, sequential) processes N files concurrently in
+separate processes. Each file is its own orchestrator and session, so this is
+safe; the run stays resumable (completed files are skipped) and the aggregate
+is order-independent. The practical ceiling is the LLM API's concurrency limit,
+not CPU: for FedLLM, start at 4 and watch for rate-limit warnings before going
+higher. With `metrics_only` retention this gives a near-linear speedup on large
+datasets.
 
 By default a batch gap run uses `--retention metrics_only`: it keeps the gap
 data in `summary.json` and skips the per-unit round directories, which is far

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,38 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-10 (parallel runner + consensus-voting finding)
+
+### Finding: voting rarely triggers (samples test different inputs)
+With consensus genuinely running (--samples 5), lab gave clean_control 2 (worse
+than single-sample), complexity 1, reliability 5. run.log: ZERO votes cast all
+run. Call-keyed voting only prunes when samples disagree on the SAME call, but
+samples pick DIFFERENT inputs, so there is nothing to vote on; union then
+accumulates every stray wrong assertion, hurting clean code. Honest position:
+reliability recall 5/5 does NOT depend on consensus; consensus-by-union does not
+improve precision and should stay at samples=1 until fixed-input voting (propose
+inputs once, vote on outputs per input) is implemented. Documented as the real
+fix in oracle-variance-and-consensus.md (its own future PR).
+
+### Delivered for review
+- **Parallel runner (`feature/parallel-gap-runner`)**: --workers N (default 1 =
+  sequential, unchanged). >1 processes files concurrently via
+  ProcessPoolExecutor; each file is an independent orchestrator/session so it is
+  safe; resumable (completed files skipped); aggregate is order-independent.
+  Threaded CLI -> config -> manifest. Tests cover all-files-processed, manifest,
+  sequential default, and parallel resume.
+- Logging conventions added to the documentation style guide (INFO = milestones,
+  DEBUG = per-iteration detail; per-round test-exec is DEBUG, round verdict is
+  INFO; uniform verb-first messages; no secrets). Supports the logging
+  normalization started in executor.py and verification_manager.py.
+- running-experiments.md documents --workers.
+
+### Next
+- Re-run ENVRI can now use --workers 4 for a near-linear speedup.
+- Fixed-input voting is the real consensus fix (own PR); until then samples=1.
+- ENVRI RQ1 headline remains the priority (--oracle correctness, samples=1,
+  tmux, metrics_only, --workers 4, report gap rate with 95% CI).
+
 ## 2026-06-10 (consensus was silently disabled, fixed)
 
 ### Finding

--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -42,6 +42,8 @@ def main() -> None:
     parser.add_argument("--strategy", default="feedback",
                         choices=["feedback", "rl", "oneshot", "hypothesis"])
     parser.add_argument("--rounds", type=int, default=5)
+    parser.add_argument("--workers", type=int, default=1,
+                        help="Parallel workers for processing files (1 = sequential; >1 runs that many files concurrently in separate processes).")
     parser.add_argument("--samples", type=int, default=1,
                         help="Consensus samples for the correctness oracle (>1 merges several generations to reduce variance; 1 = single-shot).")
     parser.add_argument("--oracle", default="crash",
@@ -90,6 +92,7 @@ def main() -> None:
         strategy=args.strategy,
         rounds=args.rounds,
         samples=args.samples,
+        workers=args.workers,
         oracle=args.oracle,
         judge_strategy=args.judge_strategy,
         stage=args.stage,

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -53,6 +53,11 @@ class GapExperimentConfig:
     # (thousands of small files across a dataset) and keep the gap data in
     # summary.json. Pass "full" to retain every variant's provenance.
     artefact_retention: str = "metrics_only"
+    # Parallel workers for processing files. 1 = sequential (default, identical
+    # to the historical behaviour). >1 processes that many files concurrently
+    # in separate processes; each file is an independent orchestrator/session,
+    # so this is safe. Bound by LLM-API concurrency limits in practice.
+    workers: int = 1
 
     def to_manifest(self) -> dict:
         return {
@@ -67,6 +72,7 @@ class GapExperimentConfig:
             "stage": self.stage,
             "pattern": self.pattern,
             "confirm": self.confirm,
+            "workers": self.workers,
         }
 
 
@@ -176,18 +182,42 @@ def run_gap_experiment(
         elif row.get("metrics"):
             metrics.append(_metrics_from_dict(row["metrics"]))
 
+    pending = [p for p in inputs if str(p) not in already]
+
+    def _handle_row(row: dict) -> None:
+        out.write(json.dumps(row) + "\n")
+        out.flush()
+        if row.get("error"):
+            errors.append(row)
+        elif row.get("metrics"):
+            metrics.append(_metrics_from_dict(row["metrics"]))
+
     with open(results_path, "a", encoding="utf-8") as out:
-        for input_path in inputs:
-            key = str(input_path)
-            if key in already:
-                continue
-            row = _run_one(input_path, config, orchestrator_factory)
-            out.write(json.dumps(row) + "\n")
-            out.flush()
-            if row.get("error"):
-                errors.append(row)
-            elif row.get("metrics"):
-                metrics.append(_metrics_from_dict(row["metrics"]))
+        if config.workers and config.workers > 1 and len(pending) > 1:
+            logger.info("Processing %d file(s) with %d parallel worker(s).",
+                        len(pending), config.workers)
+            # Each file is an independent orchestrator/session, so files run
+            # in separate processes safely. Results are written as they
+            # complete (order may differ from input order; the aggregate is
+            # order-independent and each row carries its own input path).
+            from concurrent.futures import ProcessPoolExecutor, as_completed
+            with ProcessPoolExecutor(max_workers=config.workers) as pool:
+                futures = {
+                    pool.submit(_run_one, p, config, orchestrator_factory): p
+                    for p in pending
+                }
+                for fut in as_completed(futures):
+                    input_path = futures[fut]
+                    try:
+                        row = fut.result()
+                    except Exception as exc:  # a worker crashed; record it
+                        logger.exception("Worker failed for %s", input_path)
+                        row = {"input": str(input_path), "error": repr(exc)}
+                    _handle_row(row)
+        else:
+            for input_path in pending:
+                row = _run_one(input_path, config, orchestrator_factory)
+                _handle_row(row)
 
     aggregate = aggregate_sessions(metrics).to_dict()
     per_session = [m.to_dict() for m in metrics]

--- a/tests/test_gap_runner_parallel.py
+++ b/tests/test_gap_runner_parallel.py
@@ -1,0 +1,78 @@
+"""Tests for parallel file processing in the gap runner."""
+
+import json
+from pathlib import Path
+
+from qallm.experiments.gap_runner import (
+    run_gap_experiment,
+    GapExperimentConfig,
+)
+
+
+# Module-level factory so ProcessPoolExecutor can pickle it. Returns a stub
+# orchestrator-like object is not needed; _run_one builds the orchestrator via
+# this factory, so we make it produce a deterministic fake result by raising a
+# sentinel the runner records as an error row (no LLM needed).
+def _fake_factory(config):
+    raise RuntimeError("stub-no-llm")
+
+
+def _make_dataset(tmp_path: Path, n: int) -> Path:
+    ds = tmp_path / "ds"
+    ds.mkdir()
+    for i in range(n):
+        (ds / f"f{i}.py").write_text(f"def g{i}(x):\n    return x\n")
+    return ds
+
+
+def test_parallel_processes_all_files(tmp_path):
+    ds = _make_dataset(tmp_path, 4)
+    cfg = GapExperimentConfig(
+        dataset_dir=ds, output_dir=tmp_path / "out", pattern="*.py",
+        rounds=1, workers=3,
+    )
+    run_gap_experiment(cfg, orchestrator_factory=_fake_factory)
+    rows = (tmp_path / "out" / "results.jsonl").read_text().strip().splitlines()
+    inputs = sorted(json.loads(r)["input"].split("/")[-1] for r in rows)
+    assert inputs == ["f0.py", "f1.py", "f2.py", "f3.py"]
+
+
+def test_workers_in_manifest(tmp_path):
+    ds = _make_dataset(tmp_path, 1)
+    cfg = GapExperimentConfig(
+        dataset_dir=ds, output_dir=tmp_path / "out", pattern="*.py",
+        rounds=1, workers=2,
+    )
+    run_gap_experiment(cfg, orchestrator_factory=_fake_factory)
+    manifest = json.loads((tmp_path / "out" / "manifest.json").read_text())
+    assert manifest["workers"] == 2
+
+
+def test_sequential_default_still_works(tmp_path):
+    ds = _make_dataset(tmp_path, 2)
+    cfg = GapExperimentConfig(
+        dataset_dir=ds, output_dir=tmp_path / "out", pattern="*.py",
+        rounds=1, workers=1,
+    )
+    run_gap_experiment(cfg, orchestrator_factory=_fake_factory)
+    rows = (tmp_path / "out" / "results.jsonl").read_text().strip().splitlines()
+    assert len(rows) == 2
+
+
+def test_parallel_resume_skips_completed(tmp_path):
+    ds = _make_dataset(tmp_path, 3)
+    out = tmp_path / "out"
+    out.mkdir()
+    # Pre-seed one completed result; the runner should not reprocess it.
+    (out / "results.jsonl").write_text(
+        json.dumps({"input": str(ds / "f0.py"), "metrics": None}) + "\n"
+    )
+    cfg = GapExperimentConfig(
+        dataset_dir=ds, output_dir=out, pattern="*.py", rounds=1, workers=2,
+    )
+    run_gap_experiment(cfg, orchestrator_factory=_fake_factory)
+    rows = (out / "results.jsonl").read_text().strip().splitlines()
+    inputs = [json.loads(r)["input"].split("/")[-1] for r in rows]
+    # f0 appears once (the pre-seeded row), f1 and f2 added once each.
+    assert inputs.count("f0.py") == 1
+    assert "f1.py" in inputs and "f2.py" in inputs


### PR DESCRIPTION
The gap runner processed files strictly sequentially, but each file is an independent orchestrator/session, so files can run concurrently. Adds --workers N (default 1 = sequential, behaviour unchanged). With N > 1 the runner uses a ProcessPoolExecutor to process N files at a time; results are written as they complete (order may differ, the aggregate is order-independent and each row carries its own input path), the run stays resumable (completed files skipped), and a crashed worker is recorded as an error row rather than killing the run. The practical ceiling is the LLM API concurrency limit, not CPU. Threaded CLI -> GapExperimentConfig -> manifest.

Also includes the consensus finding from the latest run: with consensus genuinely running (samples=5), ZERO votes were cast all run, because samples pick different test inputs, so call-keyed voting never has a shared call to prune. Union then accumulates stray wrong assertions and hurts clean code (clean_control 2). Honest position recorded in
oracle-variance-and-consensus.md: reliability recall 5/5 does NOT depend on consensus; the real fix is fixed-input voting (propose inputs once, vote on the expected output per input), which is its own future PR. Until then samples=1.

Docs: logging conventions added to the documentation style guide (INFO = milestones, DEBUG = per-iteration detail, uniform verb-first messages, no secrets), supporting the logging normalisation started in executor.py and verification_manager.py; running-experiments.md documents --workers; session log updated.

Tests (+4): parallel processes all files; workers in manifest; sequential default still works; parallel resume skips completed files.

Suite: 655 passed; ruff clean.