### PR TITLE
fix(runner): parallel workers log to run.log (were silent)

### DIFF
--- a/docs/guides/running-experiments.md
+++ b/docs/guides/running-experiments.md
@@ -66,6 +66,12 @@ not CPU: for FedLLM, start at 4 and watch for rate-limit warnings before going
 higher. With `metrics_only` retention this gives a near-linear speedup on large
 datasets.
 
+Under `--workers N`, each worker logs to the same `run.log` (and stderr) with a
+`[pid NNNN]` prefix, so a parallel run is observable live (`tail -f run.log`)
+and interleaved lines stay attributable to their worker. Control verbosity with
+`--log-level` (DEBUG for per-step detail, WARNING to quieten); it applies to the
+workers too.
+
 By default a batch gap run uses `--retention metrics_only`: it keeps the gap
 data in `summary.json` and skips the per-unit round directories, which is far
 less disk on a large dataset (those directories are one folder per code unit

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,27 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-10 (parallel workers were silent, fixed)
+
+### Bug
+Running with --workers 4 produced no logs during processing: run.log had only
+the start lines, then nothing until completion. Cause: ProcessPoolExecutor
+workers are fresh interpreters (spawn) and do NOT inherit the main process's
+logging config, so all per-file work logged to nowhere. The user could not
+observe a parallel run.
+
+### Delivered for review
+- **Worker logging (`fix/parallel-worker-logging`)**: a pool initializer
+  configures logging in each worker to the SAME run.log (and stderr) with a
+  [pid NNNN] prefix so interleaved lines are attributable; idempotent. log_level
+  added to the config and threaded so workers honour --log-level. Now a parallel
+  run is observable live (tail -f run.log).
+
+### Note to user
+Re the earlier "what to do next": option 1 (run ENVRI now at samples=1,
+--workers 4) was THE recommendation; options 2 (fixed-input voting) and 3
+(logging normalisation pass) were optional offers, not required steps.
+
 ## 2026-06-10 (parallel runner + consensus-voting finding)
 
 ### Finding: voting rarely triggers (samples test different inputs)

--- a/scripts/run_gap_experiment.py
+++ b/scripts/run_gap_experiment.py
@@ -93,6 +93,7 @@ def main() -> None:
         rounds=args.rounds,
         samples=args.samples,
         workers=args.workers,
+        log_level=args.log_level,
         oracle=args.oracle,
         judge_strategy=args.judge_strategy,
         stage=args.stage,

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -58,6 +58,10 @@ class GapExperimentConfig:
     # in separate processes; each file is an independent orchestrator/session,
     # so this is safe. Bound by LLM-API concurrency limits in practice.
     workers: int = 1
+    # Log level workers configure for themselves (they do not inherit the main
+    # process's logging config under the spawn start method). The log file is
+    # output_dir/run.log, matching the main process.
+    log_level: str = "INFO"
 
     def to_manifest(self) -> dict:
         return {
@@ -201,7 +205,12 @@ def run_gap_experiment(
             # complete (order may differ from input order; the aggregate is
             # order-independent and each row carries its own input path).
             from concurrent.futures import ProcessPoolExecutor, as_completed
-            with ProcessPoolExecutor(max_workers=config.workers) as pool:
+            log_path = config.output_dir / "run.log"
+            with ProcessPoolExecutor(
+                max_workers=config.workers,
+                initializer=_init_worker_logging,
+                initargs=(str(log_path), config.log_level),
+            ) as pool:
                 futures = {
                     pool.submit(_run_one, p, config, orchestrator_factory): p
                     for p in pending
@@ -231,6 +240,38 @@ def run_gap_experiment(
                 "Aggregate verification_gap_rate=%s",
                 len(metrics), len(errors), aggregate.get("verification_gap_rate"))
     return GapExperimentResult(aggregate=aggregate, per_session=per_session, errors=errors)
+
+
+def _init_worker_logging(log_path: str, log_level: str) -> None:
+    """Configure logging inside a pool worker process.
+
+    ProcessPoolExecutor workers are fresh interpreters (spawn start method on
+    macOS and Windows) and do NOT inherit the main process's logging config, so
+    without this a parallel run is silent: all per-file work happens in workers
+    that log to nowhere, and the main log only shows start/finish. Each worker
+    attaches its own handlers to the SAME run.log (FileHandler appends, so
+    workers interleave into one file) plus stderr, and prefixes each line with
+    the worker pid so interleaved lines are attributable.
+    """
+    import logging as _logging
+    import os
+
+    root = _logging.getLogger()
+    # Guard against double-configuration if the initializer runs more than once.
+    if getattr(root, "_qallm_worker_configured", False):
+        return
+    level = getattr(_logging, log_level, _logging.INFO)
+    fmt = _logging.Formatter(
+        f"%(asctime)s %(levelname)s [pid {os.getpid()}] %(name)s: %(message)s"
+    )
+    file_h = _logging.FileHandler(log_path, encoding="utf-8")
+    file_h.setFormatter(fmt)
+    stream_h = _logging.StreamHandler()
+    stream_h.setFormatter(fmt)
+    root.setLevel(level)
+    root.addHandler(file_h)
+    root.addHandler(stream_h)
+    root._qallm_worker_configured = True
 
 
 def _run_one(

--- a/tests/test_gap_runner_parallel.py
+++ b/tests/test_gap_runner_parallel.py
@@ -76,3 +76,33 @@ def test_parallel_resume_skips_completed(tmp_path):
     # f0 appears once (the pre-seeded row), f1 and f2 added once each.
     assert inputs.count("f0.py") == 1
     assert "f1.py" in inputs and "f2.py" in inputs
+
+
+def test_worker_logging_initializer_configures_file_handler(tmp_path):
+    """Workers must configure their own logging (they do not inherit the main
+    process config under spawn). The initializer attaches a FileHandler to the
+    given run.log so a parallel run is not silent."""
+    import logging
+    from qallm.experiments.gap_runner import _init_worker_logging
+
+    log_path = tmp_path / "run.log"
+    root = logging.getLogger()
+    # Snapshot and restore handlers so this test does not leak global state.
+    saved = root.handlers[:]
+    saved_flag = getattr(root, "_qallm_worker_configured", False)
+    try:
+        root.handlers = []
+        if hasattr(root, "_qallm_worker_configured"):
+            delattr(root, "_qallm_worker_configured")
+        _init_worker_logging(str(log_path), "INFO")
+        assert any(isinstance(h, logging.FileHandler) for h in root.handlers)
+        # Idempotent: a second call does not double-add.
+        n = len(root.handlers)
+        _init_worker_logging(str(log_path), "INFO")
+        assert len(root.handlers) == n
+    finally:
+        root.handlers = saved
+        if saved_flag:
+            root._qallm_worker_configured = saved_flag
+        elif hasattr(root, "_qallm_worker_configured"):
+            delattr(root, "_qallm_worker_configured")


### PR DESCRIPTION
Running with --workers N produced no logs during processing: run.log had only the main process's start/finish lines, and the console went quiet for the whole run. Cause: ProcessPoolExecutor workers are fresh interpreters (spawn start method on macOS) and do NOT inherit the main process's logging configuration, so every per-file orchestrator/verification log call in the workers went to a logger with no handlers.

Fix: a pool initializer (_init_worker_logging) configures logging inside each worker, attaching handlers to the SAME run.log (FileHandler appends, so workers interleave into one file) plus stderr, with a [pid NNNN] prefix so interleaved lines are attributable to their worker. The initializer is idempotent (guarded against double-configuration on worker reuse). log_level is added to GapExperimentConfig and threaded from --log-level, so workers honour the chosen verbosity (DEBUG for detail, WARNING to quieten).

Now a parallel run is observable live (tail -f run.log) at an acceptable verbosity, instead of going dark until completion.

Docs: running-experiments.md documents the pid-prefixed worker logging and --log-level; session log updated.

Tests (+1): the initializer attaches a FileHandler and is idempotent.

Suite: 656 passed; ruff clean.