### PR TITLE
fix(orchestrator): unique run_id so parallel workers do not collide

### DIFF
--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,36 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-10 (parallel session-id collision, fixed)
+
+### Bug (data corruption)
+With --workers 4, all workers started in the same second and the orchestrator's
+fallback run_id was a bare %Y%m%d_%H%M%S, so all four got the SAME id, shared one
+report directory, and cross-contaminated metrics. lab_cal_voted_4 showed all
+four sessions with identical exec_only=7, gap=0.7 (impossible for four different
+files), the corruption signature. The tmp run happened to show truer per-file
+numbers (clean_control 1, complexity 1, reliability 5, security 0), matching the
+known single-sample result, but it still shared one id.
+
+### Fix
+The orchestrator fallback run_id now appends a uuid8 suffix (matching the
+reporter's own scheme), so runs are unique even at identical timestamps.
+
+### Delivered for review
+- **Run-id uniqueness (`fix/parallel-session-id-collision`)**: uuid suffix on
+  the fallback run_id; tests that four orchestrators in the same frozen second
+  get unique ids and that an explicit run_id is still respected.
+
+### Note on the two runs
+tmp is the trustworthy one: reliability 5/5, security 0, two false positives on
+clean_control(safe_mean) and complexity(cryptic), consistent with the
+single-sample correctness oracle. lab_cal_voted_4 is collision-corrupted and
+should be discarded.
+
+### Still open (Observation 5)
+Sessions still land in outputs/quality_reporter, not under the run output dir.
+Placing them under runs/<name>/sessions/ would improve traceability; separate PR.
+
 ## 2026-06-10 (parallel workers were silent, fixed)
 
 ### Bug

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -46,6 +46,7 @@ from datetime import datetime
 import json
 import logging
 import time
+import uuid
 from typing import Literal, Optional
 
 from qallm.analysis.normalizer import LifecycleStage
@@ -174,7 +175,15 @@ class QALLMOrchestrator:
         if reporter is not None:
             self.reporter = reporter
         else:
-            effective_run_id = run_id or datetime.now().strftime("%Y%m%d_%H%M%S")
+            # A bare second-resolution timestamp collides when several
+            # orchestrators start in the same second (parallel --workers runs),
+            # which made workers share one report directory and cross-contaminate
+            # each other's metrics. Append a short uuid so each run is unique
+            # even at identical timestamps (matches the reporter's own scheme).
+            effective_run_id = run_id or (
+                datetime.now().strftime("%Y%m%d_%H%M%S")
+                + "_" + uuid.uuid4().hex[:8]
+            )
             self.reporter = QualityReporter(
                 "outputs/quality_reporter", effective_run_id,
                 artefact_retention=artefact_retention,

--- a/tests/test_run_id_uniqueness.py
+++ b/tests/test_run_id_uniqueness.py
@@ -1,0 +1,38 @@
+"""Run IDs must be unique even when orchestrators start in the same second.
+
+Regression: parallel --workers runs created several orchestrators within one
+second; a bare %Y%m%d_%H%M%S run_id collided, so workers shared one report
+directory and cross-contaminated each other's metrics (all sessions showed
+identical numbers). The fallback run_id now carries a uuid suffix.
+"""
+
+from unittest.mock import patch
+from qallm.orchestrator import QALLMOrchestrator
+
+
+def _make(**kw):
+    # Build with rule-based judge and a stub LLM type that does not connect;
+    # we only need __init__ to set up the reporter run_id.
+    return QALLMOrchestrator(
+        strategy="feedback", llm_type="fedllm", rounds=1,
+        judge_strategy="lexicographic", **kw,
+    )
+
+
+def test_fallback_run_id_is_unique_within_a_second():
+    fixed = "20260610_134007"
+    ids = set()
+    # Freeze the timestamp so all four share the same second; the uuid suffix
+    # must still make them unique.
+    with patch("qallm.orchestrator.datetime") as dt:
+        dt.now.return_value.strftime.return_value = fixed
+        for _ in range(4):
+            orch = _make()
+            ids.add(orch.reporter.run_id)
+    assert len(ids) == 4, f"run_ids collided: {ids}"
+    assert all(rid.startswith(fixed + "_") for rid in ids)
+
+
+def test_explicit_run_id_is_respected():
+    orch = _make(run_id="my-fixed-run")
+    assert orch.reporter.run_id == "my-fixed-run"


### PR DESCRIPTION
With --workers N, the workers start within the same second, and the orchestrator's fallback run_id was a bare %Y%m%d_%H%M%S timestamp. So all workers generated the SAME run_id, shared one report directory, and cross-contaminated each other's metrics. The lab_cal_voted_4 run showed the signature clearly: all four sessions reported identical execution_only=7 and gap=0.7, impossible for four different files. (The tmp run happened to show truer per-file numbers, reliability 5/5, but still shared one id.)

Fix: the fallback run_id now appends uuid4().hex[:8] (matching the reporter's own naming), so runs are unique even at identical second-resolution timestamps. An explicit caller-supplied run_id is still used verbatim.

Tests (+2): four orchestrators built under a frozen identical timestamp get four unique run_ids; an explicit run_id is respected. Existing run_id shape tests still pass.

Note: sessions still live under outputs/quality_reporter rather than the run output dir; placing them under runs/<name>/sessions/ (Observation 5) is a separate traceability improvement, not needed to fix this corruption.

Suite: 658 passed; ruff clean.