### PR TITLE
fix(runner): exclude backups and cruft from input discovery

### DIFF
--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -11,6 +11,15 @@ left, with enough detail to resume), and any DECISIONS worth remembering.
 
 ---
 
+## 2026-06-10 (input discovery hardened against backups)
+
+### Delivered for review
+- **Backup/cruft exclusion (`fix/discovery-exclude-backups`)**: input discovery
+  now skips not just .ipynb_checkpoints dirs but also loose *-checkpoint.ipynb,
+  macOS ._ sidecars, and editor backups (~, .bak, .orig, .tmp, .swp). Prevents
+  double-counting and junk inputs on a real dataset, so the ENVRI run uses only
+  canonical files. Done to support the live experiment.
+
 ## 2026-06-10 (test-quality metric surfaced)
 
 ### Delivered for review

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -87,18 +87,39 @@ class GapExperimentResult:
     errors: list[dict] = field(default_factory=list)
 
 
+def _is_backup_or_cruft(path: Path) -> bool:
+    """True for files that are not real dataset inputs.
+
+    rglob over a real-world dataset catches more than the intended notebooks:
+    Jupyter autosave copies (under .ipynb_checkpoints, or named
+    *-checkpoint.ipynb), editor backups (foo.ipynb~, foo.py.bak, foo.py.orig),
+    and macOS AppleDouble sidecars (._foo.ipynb). Processing these
+    double-counts the same code or feeds junk to the pipeline, wasting budget
+    and skewing the gap rate. Exclude them so a run uses only canonical inputs.
+    """
+    name = path.name
+    if ".ipynb_checkpoints" in path.parts:
+        return True
+    if name.startswith("._"):  # macOS AppleDouble sidecar
+        return True
+    if name.endswith((".ipynb~", ".py~", ".bak", ".orig", ".tmp", ".swp")):
+        return True
+    if name.endswith("-checkpoint.ipynb"):  # Jupyter checkpoint outside the dir
+        return True
+    return False
+
+
 def _discover_inputs(dataset_dir: Path, pattern: str) -> list[Path]:
-    """Every file under dataset_dir matching the pattern, sorted for
+    """Every canonical file under dataset_dir matching the pattern, sorted for
     determinism.
 
-    Jupyter autosave backups under .ipynb_checkpoints are excluded: they are
-    "-checkpoint.ipynb" duplicates of real notebooks, and rglob("*.ipynb")
-    matches them, which double-processes the same code and wastes budget (the
-    ENVRI run was burning rounds on checkpoint copies).
+    Backups and editor/Jupyter/OS cruft are excluded (see
+    _is_backup_or_cruft): they are duplicates or junk that rglob would
+    otherwise feed to the pipeline, double-processing code and wasting budget.
     """
     return sorted(
         p for p in dataset_dir.rglob(pattern)
-        if ".ipynb_checkpoints" not in p.parts
+        if not _is_backup_or_cruft(p)
     )
 
 

--- a/tests/test_gap_runner_parallel.py
+++ b/tests/test_gap_runner_parallel.py
@@ -106,3 +106,20 @@ def test_worker_logging_initializer_configures_file_handler(tmp_path):
             root._qallm_worker_configured = saved_flag
         elif hasattr(root, "_qallm_worker_configured"):
             delattr(root, "_qallm_worker_configured")
+
+
+def test_discovery_excludes_backups_and_cruft(tmp_path):
+    """Input discovery must skip backups/checkpoints/OS cruft so a run uses only
+    canonical inputs (no double-counting, no junk)."""
+    from qallm.experiments.gap_runner import _discover_inputs
+    ds = tmp_path / "ds"
+    (ds / ".ipynb_checkpoints").mkdir(parents=True)
+    (ds / "real.ipynb").write_text("{}")
+    (ds / "sub").mkdir()
+    (ds / "sub" / "also_real.ipynb").write_text("{}")
+    (ds / ".ipynb_checkpoints" / "real-checkpoint.ipynb").write_text("{}")
+    (ds / "loose-checkpoint.ipynb").write_text("{}")
+    (ds / "._real.ipynb").write_text("{}")
+    (ds / "real.ipynb~").write_text("{}")
+    found = {p.name for p in _discover_inputs(ds, "*.ipynb")}
+    assert found == {"real.ipynb", "also_real.ipynb"}


### PR DESCRIPTION
rglob over a real dataset catches more than the intended inputs: loose *-checkpoint.ipynb copies (not just those under .ipynb_checkpoints), macOS AppleDouble sidecars (._foo.ipynb), and editor backups (foo.ipynb~, foo.py.bak, .orig, .tmp, .swp). Processing these double-counts the same code or feeds junk to the pipeline, wasting budget and skewing the gap rate. _discover_inputs now filters them via _is_backup_or_cruft, so a run uses only canonical inputs. This directly supports the live ENVRI run (the user asked to avoid backup files).

Tests (+1): discovery excludes checkpoints, loose checkpoints, ._ sidecars, and ~ backups, keeping only the real notebooks. The existing checkpoint-exclusion test still passes.

Suite: 663 passed; ruff clean.