### PR TITLE
fix(metrics): surface confirm inconclusive / not-testable (RQ2 legibi…

### DIFF
--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -4,6 +4,33 @@ Newest first. Append-only.
 
 ---
 
+## 2026-06-15 (RQ2 diagnosis: findings confirm but land inconclusive, now legible)
+
+### Diagnosis from lab_calibration_06151708 (the run with diagnostics)
+The confirm path is NOT broken in plumbing: it found baseline units and findings
+(security: 4 SECURITY findings; complexity: 1 COMPLEXITY finding), and 3 of the 4
+security findings map to functions (line 10 is module-level import, correctly
+unmapped). So confirm_findings ran on 3 testable SECURITY findings. The reason
+RQ2 read 0 confirmed / 0 refuted: every targeted security test came back
+INCONCLUSIVE (the exploit test errors or cannot demonstrate the unsafe effect in
+the sandbox), and inconclusive was never surfaced. The aggregate only exposed
+confirmed/refuted, so "all inconclusive" looked identical to "nothing to
+confirm". That was a legibility bug, not a confirmation bug.
+
+### Delivered for review (`fix/surface-confirm-inconclusive`)
+- SessionMetrics + aggregate now carry inconclusive and not_execution_testable
+  (in summary.json, metrics.csv, aggregate.json). RQ2 is now legible: confirmed
+  / refuted / inconclusive / not-testable are all visible.
+- confirm_verify logs the verdict breakdown per session.
+
+### Real RQ2 finding (for the thesis, not a bug)
+Security findings on the lab set are reachable-but-not-trivially-demonstrable by
+a generated exploit under the sandbox, so they land inconclusive. This is itself
+a result: execution can strongly adjudicate RELIABILITY (wrong-value) findings,
+but SECURITY confirmation via generated exploit is weaker and often inconclusive.
+Worth stating in RQ2 and threats-to-validity. The reliability path (the headline)
+is unaffected.
+
 ## 2026-06-15 (lab full-run analysis: two fixes + confirm diagnostics)
 
 ### Analysis of lab_full_rq1553

--- a/src/qallm/experiments/confirm_verify.py
+++ b/src/qallm/experiments/confirm_verify.py
@@ -185,6 +185,11 @@ def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None) -> d
         "not_execution_testable": not_testable,
         "confirmation_rate": (confirmed / denom) if denom else None,
     }
+    logger.info(
+        "Confirm/verify verdicts: confirmed=%d refuted=%d inconclusive=%d "
+        "not_execution_testable=%d", confirmed, refuted, inconclusive,
+        not_testable,
+    )
 
     # Verify fixes: re-run each confirmed finding's reproducing test against
     # the final (repaired) source for its unit.

--- a/src/qallm/metrics_export.py
+++ b/src/qallm/metrics_export.py
@@ -47,6 +47,14 @@ class SessionMetrics:
     confirmed: int | None = None
     refuted: int | None = None
     confirmation_rate: float | None = None
+    # Confirm/refute outcomes that are neither confirmed nor refuted, surfaced
+    # so RQ2 is legible: an "inconclusive" (the targeted test errored or was
+    # invalid) or "not_execution_testable" (a non-runtime finding type, e.g.
+    # complexity) is not the same as "no findings". Without these, a run where
+    # every finding came back inconclusive looks identical to a run with nothing
+    # to confirm, which is misleading.
+    inconclusive: int | None = None
+    not_execution_testable: int | None = None
     # Verified-fix (only if verify-fixes was run and recorded).
     verified_fixed: int | None = None
     not_fixed: int | None = None
@@ -70,6 +78,8 @@ class SessionMetrics:
             "confirmed": self.confirmed,
             "refuted": self.refuted,
             "confirmation_rate": self.confirmation_rate,
+            "inconclusive": self.inconclusive,
+            "not_execution_testable": self.not_execution_testable,
             "verified_fixed": self.verified_fixed,
             "not_fixed": self.not_fixed,
             "verified_fix_rate": self.verified_fix_rate,
@@ -83,6 +93,7 @@ CSV_COLUMNS: list[str] = [
     "incoherent_oracles_dropped",
     "static_findings", "execution_only_bugs", "verification_gap_rate",
     "confirmed", "refuted", "confirmation_rate",
+    "inconclusive", "not_execution_testable",
     "verified_fixed", "not_fixed", "verified_fix_rate",
 ]
 
@@ -153,6 +164,10 @@ def build_session_metrics(
         m.confirmed = int(confirm_summary.get("confirmed", 0) or 0)
         m.refuted = int(confirm_summary.get("refuted", 0) or 0)
         m.confirmation_rate = confirm_summary.get("confirmation_rate")
+        m.inconclusive = int(confirm_summary.get("inconclusive", 0) or 0)
+        m.not_execution_testable = int(
+            confirm_summary.get("not_execution_testable", 0) or 0
+        )
 
     if verify_summary:
         m.verified_fixed = int(verify_summary.get("verified_fixed", 0) or 0)
@@ -173,6 +188,8 @@ class AggregateMetrics:
     total_execution_only_bugs: int = 0
     total_confirmed: int = 0
     total_refuted: int = 0
+    total_inconclusive: int = 0
+    total_not_execution_testable: int = 0
     total_verified_fixed: int = 0
     total_not_fixed: int = 0
     total_cost_usd: float = 0.0
@@ -232,6 +249,8 @@ class AggregateMetrics:
             "verification_gap_rate": self.verification_gap_rate,
             "total_confirmed": self.total_confirmed,
             "total_refuted": self.total_refuted,
+            "total_inconclusive": self.total_inconclusive,
+            "total_not_execution_testable": self.total_not_execution_testable,
             "confirmation_rate": self.confirmation_rate,
             "total_verified_fixed": self.total_verified_fixed,
             "total_not_fixed": self.total_not_fixed,
@@ -251,6 +270,8 @@ def aggregate_sessions(sessions: list[SessionMetrics]) -> AggregateMetrics:
         agg.total_execution_only_bugs += s.execution_only_bugs
         agg.total_confirmed += (s.confirmed or 0)
         agg.total_refuted += (s.refuted or 0)
+        agg.total_inconclusive += (s.inconclusive or 0)
+        agg.total_not_execution_testable += (s.not_execution_testable or 0)
         agg.total_verified_fixed += (s.verified_fixed or 0)
         agg.total_not_fixed += (s.not_fixed or 0)
         agg.total_cost_usd += s.cost_usd

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -136,3 +136,25 @@ def test_gap_round_0_seeded_bugs_preserved():
     ]
     m = build_session_metrics("reliability", _summary(), gap_rounds)
     assert m.execution_only_bugs == 5   # the seeded bugs at round 0, not 5+8
+
+
+def test_confirm_inconclusive_and_not_testable_surfaced():
+    """RQ2 must distinguish 'nothing to confirm' from 'all inconclusive'."""
+    from qallm.metrics_export import build_session_metrics, aggregate_sessions
+    cs = {"confirmed": 0, "refuted": 0, "inconclusive": 3,
+          "not_execution_testable": 1, "confirmation_rate": None}
+    m = build_session_metrics("s", {"model": "m", "oracle": "correctness"},
+                              [], cs)
+    assert m.inconclusive == 3
+    assert m.not_execution_testable == 1
+    d = m.to_dict()
+    assert d["inconclusive"] == 3 and d["not_execution_testable"] == 1
+    agg = aggregate_sessions([m]).to_dict()
+    assert agg["total_inconclusive"] == 3
+    assert agg["total_not_execution_testable"] == 1
+
+
+def test_confirm_columns_present():
+    from qallm.metrics_export import CSV_COLUMNS
+    assert "inconclusive" in CSV_COLUMNS
+    assert "not_execution_testable" in CSV_COLUMNS


### PR DESCRIPTION
…lity)

The lab diagnostics run pinpointed why RQ2 read 0 confirmed / 0 refuted. It was NOT a plumbing bug: confirm found the baseline and the findings (4 SECURITY on the security file, 1 COMPLEXITY on the complexity file), and 3 of the 4 security findings mapped to functions, so confirm_findings ran on testable findings. The cause: every targeted SECURITY test came back INCONCLUSIVE (a generated exploit that errors or cannot demonstrate the unsafe effect in the sandbox), and inconclusive was never surfaced anywhere. The aggregate only exposed confirmed/refuted, so "every finding inconclusive" was indistinguishable from "no findings to confirm". A legibility bug, not a confirmation bug.

Fix: SessionMetrics and AggregateMetrics now carry `inconclusive` and `not_execution_testable`, surfaced in summary.json, metrics.csv (two new columns), and aggregate.json (total_inconclusive, total_not_execution_testable). confirm_verify logs the verdict breakdown per session. RQ2 is now legible: confirmed / refuted / inconclusive / not-testable are all visible, so a run where security confirmation is inconclusive reads as exactly that.

This also surfaces a real RQ2 finding for the thesis: execution strongly adjudicates RELIABILITY (wrong-value) findings, but SECURITY confirmation via a generated exploit is weaker and often inconclusive under the sandbox. That belongs in RQ2 and threats-to-validity; the reliability headline path is unaffected.

Tests (+2): inconclusive/not-testable surfaced through session and aggregate; the two CSV columns present. Existing to_dict/CSV alignment test still passes.

Suite: 721 passed; ruff clean.