### PR TITLE
docs+ui: reality audit, security-scope restore, enrichment ideas

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@ The mechanics and design record.
 
 - [`architecture/workflow-design.md`](architecture/workflow-design.md): what QALLM does (the loop, judge, budget, quality frameworks).
 - [`architecture/run-mechanics-and-diagnostics.md`](architecture/run-mechanics-and-diagnostics.md): rounds, FROZEN+GROW test accumulation, ERROR vs BUG.
+- [`architecture/verification-repair-reward-design.md`](architecture/verification-repair-reward-design.md): the verification/repair/reward design and the key observations behind it.
 - [`architecture/web-ui-automode.md`](architecture/web-ui-automode.md): auto-mode web UI behaviour.
 - [`architecture/web-ui-history.md`](architecture/web-ui-history.md): the Experiments and Sessions history views.
 - [`architecture/design/`](architecture/design/): per-feature design specifications (FEAT-01 .. FEAT-05).
@@ -51,6 +52,8 @@ The mechanics and design record.
 - [`thesis/experiment-plan.md`](thesis/experiment-plan.md): the experiments that answer each RQ, with exact commands and outputs.
 - [`thesis/thesis-structure-and-plan.md`](thesis/thesis-structure-and-plan.md): chapter structure, the three-contribution framing, per-section checklist, and writing-status tracker.
 - [`thesis/audit-2026-06.md`](thesis/audit-2026-06.md): full project audit (strengths, prioritised risks, web-UI assessment, punch list).
+- [`thesis/enrichment-ideas.md`](thesis/enrichment-ideas.md): candidate features and experiments to enrich QALLM, with value/effort/risk and a thesis-scope vs future-work split.
+- [`thesis/security-confirmation-scope.md`](thesis/security-confirmation-scope.md): scope/feasibility/risk-benefit analysis for making security findings confirm rather than land inconclusive (decision aid).
 - [`thesis/session-log.md`](thesis/session-log.md): append-only, dated record of what changed each session and what is outstanding (for cross-session continuity).
 
 ## showcase/ — shareable, self-contained pages

--- a/docs/thesis/enrichment-ideas.md
+++ b/docs/thesis/enrichment-ideas.md
@@ -1,0 +1,110 @@
+# Enrichment ideas for QALLM
+
+Candidate features and experiments that would strengthen QALLM, each with a
+value / effort / risk read, and a clear split between what is worth pulling into
+the thesis scope and what belongs in future work. The guiding principle: the
+thesis is close to done, so anything thesis-scope must sharpen an existing
+contribution, not open a new front.
+
+## Principle for deciding
+
+Pull an idea into thesis scope only if it (a) strengthens an existing
+contribution (the gap, the judge, the confidence), (b) is low-risk, and (c) fits
+before the write-up closes. Everything else is future work, and a strong
+future-work section is itself a thesis asset.
+
+## Tier A: thesis-scope candidates (sharpen what exists)
+
+### A1. Confidence-stratified gap rate as a first-class result
+Report the verification gap rate not just twice (all vs high-confidence) but as
+a small distribution: gap rate within each confidence band. This turns the
+mutation-confidence contribution into a headline figure rather than a footnote.
+Value: high (directly strengthens RQ1 and the confidence contribution). Effort:
+low (the data already exists in the aggregate; it is a reporting/plotting
+choice). Risk: none. **Recommended for the thesis.**
+
+### A2. Per-EVERSE-dimension gap breakdown
+Report the gap rate per quality dimension (Reliability vs Security vs ...), since
+findings are already dimension-tagged. "The gap is concentrated in Reliability"
+is a sharper, more defensible claim than a single blended rate and showcases the
+judge/EVERSE contribution. Value: high. Effort: low-medium (group existing
+findings by their tag in the aggregate). Risk: low. **Recommended.**
+
+### A3. Ablation: crash oracle vs correctness oracle
+A small controlled experiment on the lab set (and a slice of ENVRI) showing the
+gap the crash oracle finds vs the correctness oracle. This quantifies why the
+correctness oracle matters and makes the methodology chapter's oracle discussion
+empirical rather than asserted. Value: high (a clean, citable ablation). Effort:
+low (re-run with `--oracle crash` vs `correctness`). Risk: low. **Recommended.**
+
+### A4. Sensitivity of the gap to rounds
+Run the headline at rounds in {1, 3, 5} on a slice and show how the gap and the
+verified-fix rate move with the repair budget. Cheap insight into how much of the
+gap is reachable, and a natural robustness paragraph. Value: medium. Effort: low.
+Risk: low. **Optional, nice if time allows.**
+
+## Tier B: strong future-work (named in the thesis, built later)
+
+### B1. Fixed-input voting for consensus
+The real fix for consensus: propose inputs once, then have K samples vote on the
+expected output per input. This is the way to make voting actually bind (current
+union consensus never triggers) and would push precision on ambiguous specs.
+Value: high. Effort: medium (a new generation shape). Risk: medium
+(re-calibration). Designed already in oracle-variance-and-consensus.md.
+
+### B2. Broader oracle types (property and metamorphic)
+The oracle interface already names `property` and `metamorphic`; implementing
+them would extend the defect classes QALLM can catch beyond crash and
+wrong-value, especially for numeric/scientific code where invariants and
+relations are natural. Value: high for the research-code domain. Effort: medium.
+Risk: medium (oracle soundness, the same calibration discipline applies).
+
+### B3. Safe, observable security confirmation
+The narrow eval/shell exploit-confirmation work scoped in
+security-confirmation-scope.md. Turns inconclusive security findings into
+confirmed ones. Value: medium. Effort: medium. Risk: high (touches sandbox
+isolation). Explicitly future work, with the risk called out.
+
+### B4. Cross-model comparison
+Run the headline across models (the pilot used gpt-4o-mini, gpt-5-mini,
+gemma3:4b) and report how the gap rate and confidence distribution vary by model.
+Speaks to generality: is the verification gap a property of AI-generated code, or
+of one model? Value: high for external validity. Effort: medium (more runs,
+provenance already captures the model). Risk: low. A strong candidate if the
+timeline allows; otherwise future work.
+
+### B5. Confidence-guided repair prioritisation
+Use the mutation confidence to order repair effort: fix high-confidence defects
+first, since they are the most certainly real. Value: medium (a product feature
+more than a thesis result). Effort: medium. Risk: low. Future work.
+
+### B6. Incremental / cached runs
+Skip re-verifying functions whose source is unchanged across runs (hash-keyed
+cache), so re-running a large corpus after a code change is cheap. Value: medium
+(operational). Effort: medium. Risk: low. Future work / engineering.
+
+## Tier C: dissemination (Tier 3 of the roadmap)
+
+### C1. In-app architecture page
+A live architecture view in the web UI (the pipeline diagram, clickable to the
+relevant docs). Value: high for the demo and the defence. Effort: low-medium.
+Risk: none.
+
+### C2. Live metrics page
+Once E1 is in, a page that reads the run aggregate and shows the headline gap
+rate, the confidence distribution, and the per-dimension breakdown. Value: high
+for the demo. Effort: low (the aggregate endpoint exists). Risk: none.
+
+### C3. One-click reproduce
+A button that surfaces a run's provenance (commit, model, dataset fingerprint)
+and the exact command to reproduce it. Value: medium (reinforces the
+reproducibility story to a committee). Effort: low. Risk: none.
+
+## Recommendation
+
+For the thesis, do A1, A2, and A3: they are cheap, low-risk, and each directly
+strengthens one of the three contributions (confidence, judge, oracle). A4 if
+time allows. For the demo, C1 and C2. Everything in Tier B is genuine future
+work; naming it well (especially B1, B2, B4) makes the future-work section
+credible and shows the work has a clear forward path. Do not open a Tier B front
+before the headline and the write-up are done.

--- a/docs/thesis/roadmap.md
+++ b/docs/thesis/roadmap.md
@@ -23,18 +23,23 @@ is the headline experiment and the write-up, not detector correctness.
 These directly determine whether the thesis results are trustworthy and
 defensible. Highest leverage.
 
-0. **Confirm the lab calibration with consensus actually running.** The
-   empty-session guard that disabled consensus is fixed; re-run
-   `--oracle correctness --samples 5` and confirm clean_control 0,
-   complexity_findings 0, reliability_gap 5. This is the gate that says the
-   instrument is sound. Cheap, decisive, do it first.
+0. **Lab calibration. DONE.** The instrument is sound: with the correctness
+   oracle at `--samples 1`, the lab set gives reliability_gap 5/5,
+   security 0 exec-only, and at most one documented false positive each on
+   clean_control and complexity_findings (an under-specified function the oracle
+   cannot disambiguate). Consensus by union (`--samples 5`) was investigated and
+   abandoned: votes are never cast because samples test different inputs, and
+   union accumulates stray assertions that hurt clean code. Single-sample is the
+   calibrated, defensible setting (see docs/experiments/oracle-variance-and-consensus.md).
 
-1. **Run the full verification-gap experiment (ENVRI) and fill Chapter 5.** The
-   machinery exists (`scripts/run_gap_experiment.py --confirm`). Run with
-   `--oracle correctness --samples 5` under tmux, metrics_only retention, and
-   report the gap rate with its 95% CI. This converts the bracketed
+1. **Run the full verification-gap experiment (ENVRI) and fill Chapter 5.**
+   In progress. The machinery exists (`scripts/run_gap_experiment.py`). Run with
+   `--oracle correctness --samples 1 --workers 4` under tmux, metrics_only
+   retention (add `--mutation-confidence` for the per-finding confidence and
+   `--confirm` for RQ2/RQ3). Report the gap rate with its 95% CI, twice: over
+   all findings and over high-confidence findings. This converts the bracketed
    placeholders in the thesis scaffold into real numbers. Everything else is
-   secondary to this.
+   secondary to this. See docs/thesis/experiment-plan.md for the full plan.
 
 2. **Harden the statistical layer (started).** `stats.py` is now tested and a
    JSON-serialisation bug is fixed. Remaining: add a confidence interval or

--- a/docs/thesis/security-confirmation-scope.md
+++ b/docs/thesis/security-confirmation-scope.md
@@ -1,0 +1,104 @@
+# Scope of work: making security findings confirm (not inconclusive)
+
+A decision aid for whether to invest in turning security findings from
+"inconclusive" into "confirmed" on the RQ2 path. Written so you can decide, not
+to push a direction.
+
+## The current behaviour
+
+For a SECURITY finding (e.g. `eval(user_input)`, `subprocess.run(..., shell=True)`),
+QALLM generates a targeted test whose job is to demonstrate the unsafe effect
+actually occurs. A verdict of "confirmed" requires that test to PASS (the unsafe
+behaviour was reachable). On the lab set, those tests instead error under the
+sandbox, so they land "inconclusive". The reliability path is unaffected; this
+is only about security findings.
+
+## Why it is hard
+
+The difficulty is not in QALLM's plumbing; it is the nature of demonstrating an
+exploit safely and observably:
+
+1. **Demonstrating eval/shell safely.** To "confirm" `eval(expr)` you must make
+   it do something observable without doing something harmful. The test has to
+   supply an input that proves arbitrary evaluation (e.g. evaluate `2+2` and
+   assert `4`, or set a sentinel via a side effect) without ever running
+   anything dangerous. That is a careful, finding-specific test design.
+2. **The sandbox fights you, correctly.** The execution sandbox is built to
+   contain code. A shell or filesystem side effect that an exploit test wants to
+   observe is often exactly what the sandbox blocks or isolates, so the test
+   errors rather than demonstrating the effect. Loosening the sandbox to let the
+   exploit through is the opposite of what a security tool should do.
+3. **The LLM must generate a sound exploit oracle.** The correctness oracle was
+   hard enough to calibrate; a security-exploit oracle is harder, it must be
+   safe, observable, and specific to the finding type (eval vs shell vs
+   deserialization each differ).
+
+## Scope of work (if pursued)
+
+A realistic, bounded version, not "confirm any vulnerability":
+
+- **A2 (small):** Restrict to two well-understood finding classes, `eval`/`exec`
+  and `subprocess(..., shell=True)`. Add a dedicated security-oracle prompt that
+  asks for a safe, observable demonstration (evaluate a benign arithmetic
+  sentinel through the eval path; echo a unique token through the shell path and
+  capture it). ~2 to 3 days including prompt iteration.
+- **A3 (medium):** Add a controlled-observation channel in the sandbox: a
+  per-run temp file or captured stdout the exploit test can write a sentinel to,
+  so "the unsafe path executed" is observable without a real harmful effect.
+  This is the load-bearing, risky part. ~3 to 5 days, plus careful review,
+  because it touches the sandbox's isolation.
+- **A4 (validation):** Re-calibrate on the lab security file (expect the 3
+  mappable findings to confirm), and add tests so a future change cannot
+  silently re-break it. ~1 to 2 days.
+
+Total: roughly 1.5 to 2 weeks of focused work, most of the risk concentrated in
+A3.
+
+## Feasibility
+
+Technically feasible for the narrow eval/shell classes. Not feasible as a
+general "confirm any security finding" capability within the thesis timeline,
+and not advisable to attempt generally. The narrow version is the only sensible
+scope.
+
+## Risk analysis
+
+- **Sandbox integrity (high).** Any change that lets an exploit test observe a
+  side effect risks weakening the isolation that protects the host running the
+  experiments (especially on the VM). A bug here is a security risk in a
+  security tool, the worst kind of irony. This is the dominant risk.
+- **Re-calibration cost (medium).** A new oracle type means re-running and
+  re-validating; it could surface its own false positives/negatives that need
+  another calibration cycle, exactly the kind of cycle that consumed weeks
+  earlier.
+- **Scope creep (medium).** "Make security confirm" invites "what about
+  deserialization, SSRF, path traversal", a long tail that does not end.
+- **Opportunity cost (high right now).** The headline (E1, the ENVRI gap rate)
+  is the thesis's central result and is reliability-driven. Time spent here is
+  time not spent on the headline and the write-up.
+
+## Benefit analysis
+
+- **Marginal benefit to the thesis.** RQ2's strength is already demonstrable on
+  the reliability path. A non-zero security-confirmation number is a nice-to-have,
+  not load-bearing. The "security confirmation is often inconclusive" result is
+  itself a clean, honest, defensible finding, arguably more interesting than a
+  forced number, because it shows QALLM knows the limits of execution
+  adjudication.
+- **It does not move RQ1.** The verification gap (the headline) does not depend
+  on security confirmation at all.
+
+## Recommendation
+
+**Do not pursue it for the thesis. Document the inconclusive result instead.**
+The honest framing is strong: execution strongly adjudicates reliability defects
+(where the verification gap lives), and is appropriately conservative about
+security findings, demonstrating an exploit safely and observably is a hard
+problem, and QALLM reports "inconclusive" rather than overclaiming. That is a
+mature, examiner-friendly position. If, after the thesis, there is appetite to
+extend QALLM, the narrow A2+A3+A4 scope above is the way to do it, with the
+sandbox-integrity risk treated as the gating concern.
+
+The decision rule: pursue only if a non-zero security-confirmation number is a
+stated requirement from a supervisor. Absent that, the inconclusive finding is
+the better use of the remaining time.

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -4,6 +4,21 @@ Newest first. Append-only.
 
 ---
 
+## 2026-06-15 (docs/UI reality audit)
+
+### Delivered for review (`docs/reality-audit-and-enrichment`)
+- Roadmap items 0 and 1 corrected: they still said "confirm consensus running"
+  and --samples 5; reality is consensus abandoned, samples=1 is the calibrated
+  setting (5/5 recall), and item 1 (ENVRI) is in progress with the right flags.
+- README index: added verification-repair-reward-design.md and (re)added the
+  security-confirmation-scope decision aid (restored; its PR was not merged).
+- About screen: added the mutation-confidence story (a "How do we know the bugs
+  are real?" card + a "Score confidence" pipeline step), so the UI reflects the
+  third contribution that is now live in the gap panel.
+- New: docs/thesis/enrichment-ideas.md, candidate features and experiments to
+  enrich QALLM, each with value/effort/risk, separated into thesis-scope vs
+  future-work.
+
 ## 2026-06-15 (web UI: oracle-confidence view)
 
 ### Delivered for review

--- a/web/frontend/src/screens/AboutView.tsx
+++ b/web/frontend/src/screens/AboutView.tsx
@@ -267,13 +267,24 @@ export default function AboutView() {
           test after a repair to prove the fix rather than assert it.
         </p>
         <div className="mt-6 flex flex-wrap items-center justify-center gap-2 font-mono text-[12px]">
-          {["Static analysis", "Execute & confirm", "Repair", "Verify the fix"].map((s, i, arr) => (
+          {["Static analysis", "Execute & confirm", "Repair", "Verify the fix", "Score confidence"].map((s, i, arr) => (
             <span key={i} className="flex items-center gap-2">
               <span className="rounded-md border border-slate-200 px-3 py-2 text-slate-700">{s}</span>
               {i < arr.length - 1 && <span className="text-amber-500">→</span>}
             </span>
           ))}
         </div>
+      </div>
+
+      <div className="my-10 rounded-2xl border border-slate-200 bg-white p-8 text-center">
+        <h3 className="text-2xl font-bold tracking-tight text-slate-900">How do we know the bugs are real?</h3>
+        <p className="mx-auto mt-3 max-w-xl text-slate-500">
+          A found bug is only as trustworthy as the test that found it. QALLM stress-tests each
+          test by injecting small faults into the function and checking the test catches them.
+          A test that kills the injected faults is a sensitive detector, so its finding is high
+          confidence; one that misses them is flagged low. Every gap finding carries a confidence,
+          so the result is not just how many bugs, but how sure we are of each.
+        </p>
       </div>
     </div>
   );


### PR DESCRIPTION
Make the docs and the UI map the real QALLM, and answer "what could enrich it".

Reality fixes:
- roadmap items 0 and 1 were stale: they said "confirm consensus actually running" with --samples 5. Reality: consensus by union was abandoned (votes never cast), --samples 1 is the calibrated setting (5/5 reliability recall), and item 1 (ENVRI headline) is in progress with the correct flags (--samples 1, --mutation-confidence, --confirm). Corrected both, pointed to the experiment plan.
- README index: added verification-repair-reward-design.md (was orphaned) and re-added the security-confirmation-scope decision aid (restored; its earlier PR was never merged).
- About screen: added the mutation-confidence contribution, a "How do we know the bugs are real?" card and a "Score confidence" pipeline step, so the UI reflects the third contribution that is now live in the gap panel.

New:
- docs/thesis/enrichment-ideas.md: candidate features and experiments, each with value/effort/risk, split into thesis-scope (A1 confidence-stratified gap, A2 per-EVERSE-dimension breakdown, A3 crash-vs-correctness ablation) and future-work (fixed-input voting, property/metamorphic oracles, cross-model comparison, safe security confirmation, etc.). Recommendation: do the cheap low-risk A-tier items that sharpen the three contributions; name the rest as future work.

Frontend builds clean; backend suite 723 passed.