### PR TITLE
fix+docs: confirm-metrics round-trip, mutation viability, recovered docs

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -52,6 +52,9 @@ The mechanics and design record.
 - [`thesis/experiment-plan.md`](thesis/experiment-plan.md): the experiments that answer each RQ, with exact commands and outputs.
 - [`thesis/thesis-structure-and-plan.md`](thesis/thesis-structure-and-plan.md): chapter structure, the three-contribution framing, per-section checklist, and writing-status tracker.
 - [`thesis/audit-2026-06.md`](thesis/audit-2026-06.md): full project audit (strengths, prioritised risks, web-UI assessment, punch list).
+- [`thesis/rq-evolution.md`](thesis/rq-evolution.md): how the research questions changed from the proposal and why (defence-ready motivation).
+- [`thesis/llm-training-analysis.md`](thesis/llm-training-analysis.md): what training an LLM would take, its value, a staged plan, and why it is future work.
+- [`thesis/path-to-finish-2026-06.md`](thesis/path-to-finish-2026-06.md): status as E1 runs, the partial-data findings, and the ordered path to delivery.
 - [`thesis/enrichment-ideas.md`](thesis/enrichment-ideas.md): candidate features and experiments to enrich QALLM, with value/effort/risk and a thesis-scope vs future-work split.
 - [`thesis/security-confirmation-scope.md`](thesis/security-confirmation-scope.md): scope/feasibility/risk-benefit analysis for making security findings confirm rather than land inconclusive (decision aid).
 - [`thesis/session-log.md`](thesis/session-log.md): append-only, dated record of what changed each session and what is outstanding (for cross-session continuity).

--- a/docs/thesis/llm-training-analysis.md
+++ b/docs/thesis/llm-training-analysis.md
@@ -1,0 +1,128 @@
+# Training an LLM for QALLM: what it would take, value, and how
+
+An honest analysis of moving from "iterative prompting with quantitative
+feedback over an external LLM API" to actually training a model. Written so the
+decision is informed, and with a clear recommendation up front.
+
+## Recommendation up front
+
+Do not train a model for the thesis. The current framing (iterative prompting
+with feedback, no training) is a deliberate scope decision that addresses the
+coordinator's earlier concern, and the thesis's contributions do not depend on
+training. Training is a strong, well-defined future-work direction, and naming it
+precisely (as below) strengthens the future-work section. The rest of this
+document is the basis for that recommendation and the plan if it is ever pursued.
+
+## What "training" could mean here (three rungs, increasing cost)
+
+It is important to separate three different things often lumped as "training",
+because they differ by an order of magnitude in cost and risk.
+
+### Rung 1: supervised fine-tuning (SFT) on QALLM's own traces
+Collect the (prompt, accepted output) pairs QALLM already produces, the test
+suites that scored high confidence, the repairs the judge accepted, and
+fine-tune a smaller open model to imitate them. This is the cheapest rung and
+the most realistic.
+
+### Rung 2: preference optimisation (DPO/ORPO) on judged pairs
+QALLM's judge already produces accept/reject decisions and the mutation scorer
+produces high/low confidence. Those are preference labels. A method like DPO or
+ORPO learns from (preferred, rejected) pairs without a reward model. This is the
+natural fit because QALLM is already a preference-generating machine.
+
+### Rung 3: reinforcement learning with QALLM as the reward (RLAIF/RLVR)
+Use QALLM's execution-based verdict as a programmatic reward signal and optimise
+the model with PPO or GRPO. This is "reinforcement learning with verifiable
+rewards": the reward is not a learned approximation, it is the actual mutation
+score / verified-fix outcome. Conceptually elegant and the most powerful, also
+the most expensive and least stable.
+
+Note the terminology trap: the thesis is careful to say the current loop is NOT
+RL. Rung 3 is the only one that would make "RL" literally true. If training is
+ever pursued, the framing must be updated precisely, because conflating the two
+is exactly the scope concern the project worked to avoid.
+
+## What has to happen (prerequisites, common to all rungs)
+
+1. **A training dataset from QALLM's own runs.** This is the asset QALLM
+   uniquely has: execution-grounded labels. Each example is a function plus a
+   generated artefact (test or repair) plus a verdict (high-confidence /
+   accepted / verified-fixed). The mutation confidence and the verified-fix
+   outcome make the labels trustworthy, which is the whole point: most code-LLM
+   training data has noisy labels; QALLM's are execution-checked. Need on the
+   order of thousands to tens of thousands of clean examples, which is why the
+   full-scale corpus (Li's ~2,800 notebooks, expanded) matters.
+2. **A base model and compute.** An open model in the 1B to 8B range for SFT/DPO
+   (trainable on a single high-memory GPU or a small node); Rung 3 needs more
+   (a rollout loop calling the model many times per step, plus the QALLM reward,
+   so it is GPU-hours-heavy and engineering-heavy).
+3. **A held-out evaluation.** The lab set and a held-out notebook slice, scored
+   with the existing metrics, so "the trained model is better" is itself an
+   execution-based, falsifiable claim, not a vibe.
+4. **A training stack.** TRL or Axolotl for SFT/DPO; TRL or a GRPO implementation
+   for Rung 3. QALLM would need to expose its reward as a callable for Rung 3.
+
+## Anticipated added value
+
+- **Cost and latency.** A small fine-tuned model that matches the API model on
+  QALLM's narrow task (generate a correctness oracle; propose a repair) would
+  cut per-run cost and latency dramatically, making large corpora and frequent
+  re-runs cheap. This is the most concrete, most likely-to-materialise benefit.
+- **Specialisation.** The task is narrow (sound, sensitive oracles; minimal
+  behaviour-preserving repairs). A specialised small model can match or beat a
+  general large model on a narrow task, which is a clean, publishable result if
+  it holds.
+- **A virtuous loop (Rung 3).** If the execution-based reward genuinely improves
+  the model, QALLM becomes a system that both measures and improves
+  AI-generated-code quality, a stronger story. But this is the least certain
+  benefit and the most expensive to establish.
+- **It would make "RL" literally true**, turning a framing the thesis currently
+  avoids into a genuine contribution, if (and only if) Rung 3 is done properly.
+
+Honest counterweight: the thesis's value is the verification gap and the
+confidence check; none of it needs a trained model. Training risks trading a
+finished, defensible contribution for an open-ended research project.
+
+## How to implement (a staged, low-regret plan)
+
+If pursued (post-thesis), do it in the order of the rungs, stopping when the
+value plateaus:
+
+1. **Harvest labels (no training yet).** Add a small exporter that turns
+   persisted run artefacts into a training set: (function, generated artefact,
+   verdict, confidence). This is useful on its own (a dataset of
+   execution-labelled code-LLM examples is a contribution) and is the
+   prerequisite for everything else. Low risk, high reuse.
+2. **SFT a small model (Rung 1)** on the high-confidence subset; evaluate on the
+   held-out set with QALLM's metrics. If it matches the API model at a fraction
+   of the cost, that alone is a result.
+3. **DPO on judged pairs (Rung 2)** using accept/reject and high/low confidence
+   as preferences. Compare to SFT on the same held-out set.
+4. **Only if 2 and 3 show headroom, attempt RLVR (Rung 3)** with QALLM's reward,
+   treating sandbox/reward-hacking and training stability as the gating risks.
+
+Each step is independently evaluable with the metrics QALLM already has, so the
+programme is de-risked: it produces a usable result at every rung and can stop
+early.
+
+## Risks
+
+- **Scope and timeline.** Training is a separate research project; pulling it
+  into the thesis would jeopardise the finished contributions. (Dominant risk
+  now.)
+- **Reward hacking (Rung 3).** A model optimised against QALLM's reward may learn
+  to produce artefacts that game the metric (e.g. tests that trivially pass)
+  rather than genuinely better ones. The mutation-confidence check is a partial
+  guard, but this needs careful held-out evaluation.
+- **Label bias.** Training on QALLM's own accepted outputs risks amplifying
+  QALLM's current preferences, including its blind spots. A held-out,
+  independently-labelled evaluation is essential.
+- **Compute and reproducibility.** Rung 3 especially is compute-heavy and harder
+  to reproduce; provenance discipline would have to extend to training runs.
+
+## One-line summary
+
+Training is a credible, valuable future direction, best entered through label
+harvesting and SFT/DPO before any RL, but it is out of scope for the thesis,
+whose contributions are complete without it; name it precisely as future work and
+keep the current loop framed as iterative prompting with feedback.

--- a/docs/thesis/path-to-finish-2026-06.md
+++ b/docs/thesis/path-to-finish-2026-06.md
@@ -1,0 +1,83 @@
+# Path to finish: audit and calibration, June 16
+
+A clear-eyed status as E1 runs, what is solid, what the partial data revealed,
+and the remaining path to a delivered thesis. Written so the finish line is
+concrete.
+
+## Where we are
+
+The pipeline is complete, the instrument is calibrated, the engineering is clean
+(724 tests, ruff clean), and the headline experiment (E1, the ENVRI verification
+gap) is running. The partial data (the first ~955 of 1843 notebooks) already
+shows the headline result materialising and surfaced two real bugs, both now
+fixed.
+
+## What the partial E1 data shows
+
+- **RQ1 is real.** Across 893 successfully processed notebooks, execution found
+  343 defects in functions that passed static analysis, in 118 distinct
+  notebooks. The verification gap is not a lab artefact; it appears at scale on
+  real research code. The final rate and its CI come from the completed run.
+- **RQ2/RQ3 are zero, as expected.** This E1 run did not use `--confirm` (it is
+  the RQ1 headline pass per the experiment plan). RQ2/RQ3 come from a separate
+  `--confirm` pass; their zero here is correct, not a defect.
+- **62 of 955 notebooks errored** with the same cause and were isolated (the run
+  continued). At ~6.5% this is worth pinpointing; traceback logging is now in
+  place so the next run identifies the exact line.
+
+## Two bugs the data exposed, both fixed
+
+1. **Confirm metrics were lost in aggregation.** The per-session rows carried
+   `inconclusive` / `not_execution_testable`, but the re-aggregation and resume
+   path silently dropped them, which is why `--confirm` lab runs kept showing
+   zeros despite correct per-session verdict logs. Fixed the round-trip.
+2. **Mutation confidence was almost all "unknown" on real code** (336 of 343).
+   Data functions made the generated suite error on mutants, and an all-error
+   run was discarded as not-viable. Fixed: when the suite runs cleanly on the
+   original, a mutant that turns it to errors is detected (killed), not
+   discarded. This should move much of the distribution out of "unknown" and is
+   what makes the confidence contribution land on the headline corpus.
+
+## Calibration status
+
+The lab instrument remains sound (reliability 5/5, clean controls clean). The
+two fixes above do not change the lab verdicts (the lab suites do not error on
+mutants), they fix legibility (RQ2 numbers surviving aggregation) and real-data
+behaviour (confidence on data functions). A single clean `--confirm`
+`--mutation-confidence` lab run after merging will confirm both on ground truth:
+expect `total_inconclusive` non-zero and a confidence distribution that is no
+longer dominated by "unknown".
+
+## The remaining path to deliver
+
+In order, with dependencies:
+
+1. **Merge the two fixes** and run one clean lab pass with `--confirm
+   --mutation-confidence` to confirm RQ2 numbers survive and confidence
+   populates. (Gate: instrument still sound after the fixes.)
+2. **Let E1 finish**, then re-run the confidence scoring (it reads the persisted
+   artefacts) so the headline carries a real confidence distribution, not the
+   pre-fix "unknown" one. If E1 was already far along on the old code, a fresh
+   confidence pass over its artefacts is enough; the gap counts themselves are
+   unaffected by the confidence fix.
+3. **Run E2/E3** (the `--confirm` pass on ENVRI) for RQ2/RQ3.
+4. **Draft the results sections** (thesis 5.2 to 5.4) with the real numbers,
+   plus the enrichment cuts that are now cheap: A1 confidence-stratified gap
+   rate (uses the fixed confidence) and A2 per-EVERSE-dimension breakdown.
+5. **Draft Discussion, Conclusion, Abstract** (5.6 scale if the Li corpus is in
+   by then), making the thesis content-complete.
+6. **Optional, time-permitting**: the A3 crash-vs-correctness ablation; surface
+   gap-confidence inline in the `%%qallm` magic and on a live web-UI metrics
+   page (Tier 3 demo).
+
+## What is explicitly NOT on the critical path
+
+Training an LLM (future work / PhD), safe security confirmation (future work),
+and the broader oracle types. These are named in the thesis as future work and
+must not pull focus from steps 1 to 5.
+
+## One-line status
+
+Instrument sound, headline materialising, two real bugs fixed; the path to
+delivery is finish E1, fix-confirmed lab pass, RQ2/RQ3 run, then write the
+results and closing chapters.

--- a/docs/thesis/rq-evolution.md
+++ b/docs/thesis/rq-evolution.md
@@ -1,0 +1,78 @@
+# Research-question evolution: from proposal to thesis
+
+A short, defensible account of how the research questions changed between the
+proposal and the thesis, and why. This is the kind of change an examiner and the
+thesis coordinator will ask about, so it is written to be stated plainly in the
+defence and, in condensed form, in the thesis introduction.
+
+## The change
+
+The proposal framed the work around building and evaluating an execution-based
+quality-assessment pipeline for AI-generated notebook code, with the empirical
+emphasis on whether iterative, feedback-guided test generation outperforms
+simpler baselines. The thesis keeps the same artifact and the same core idea
+(execution adjudicates static findings) but sharpens the empirical questions into
+three precise, measurable ones:
+
+- **RQ1**: To what extent does execution-based assessment reveal defects that
+  static analysis of AI-generated notebook code misses? (the verification gap)
+- **RQ2**: How reliably can individual static findings be confirmed or refuted
+  by automatically generated, executed tests? (confirmation)
+- **RQ3**: When a repair is applied, can the fix be verified by execution, and
+  how often does a repair that satisfies static analysis fail to fix the
+  underlying defect? (verified fixes)
+
+## Why the change is legitimate, not scope drift
+
+Refining research questions during a project is normal and expected; what matters
+is that the refinement is principled and that the artifact did not change
+underneath it. Here both hold.
+
+1. **The object of study is unchanged.** The proposal and the thesis study the
+   same thing: using execution to assess the quality of AI-generated notebook
+   code. The RQs were made measurable, not redirected. RQ1 to RQ3 are the
+   quantitative form of the proposal's central claim.
+
+2. **The refinement was driven by what turned out to be measurable.** During
+   implementation and calibration it became clear that the strongest, most
+   defensible result was the size of the verification gap and the soundness of
+   the verdicts, not a head-to-head "RL beats baseline" comparison. The three
+   RQs name exactly the quantities the pipeline can measure on real artefacts
+   (gap rate, confirmation rate, verified-fix rate), each with a clear
+   definition and a confidence interval. A measurable question is a better
+   question.
+
+3. **It directly addresses the earlier scope concern.** The coordinator's
+   concern was about AI-heavy framing and scope. Reframing around the
+   verification gap, with the generation loop precisely described as iterative
+   prompting with quantitative feedback over an external LLM API (not model
+   training), narrows and grounds the scope rather than expanding it. The thesis
+   claims are about a measurable property of AI-generated code, not about a novel
+   learning method.
+
+4. **The contribution is sharper.** The three-RQ framing yields three concrete
+   contributions (the verification-gap method, the EVERSE-aligned judge, and the
+   mutation-based oracle confidence) that are each independently defensible,
+   which is stronger than a single comparative result.
+
+## How to state it (for the introduction and the defence)
+
+One or two sentences suffice in the introduction:
+
+> The research questions refine those of the proposal. The object of study,
+> execution-based assessment of AI-generated notebook code, is unchanged; the
+> questions are stated in the measurable form the implementation made possible,
+> namely the size of the verification gap (RQ1), the reliability of confirming
+> or refuting individual findings (RQ2), and the verifiability of repairs (RQ3).
+
+For the defence, the three points above (same object, made measurable, narrows
+scope, sharper contribution) are the answer. The key line: the artifact did not
+change; the questions were made precise.
+
+## Recommended action
+
+Add the one-to-two-sentence note above to the thesis introduction (right after
+the RQs), and keep this document as the longer justification to draw on if the
+coordinator or an examiner presses. If the proposal's exact RQ wording is to
+hand, include a one-line before/after mapping in an appendix; it pre-empts the
+question entirely.

--- a/docs/thesis/thesis-draft-scaffold.md
+++ b/docs/thesis/thesis-draft-scaffold.md
@@ -68,6 +68,13 @@ Research questions (carried from the proposal, refined):
   how often does a repair that satisfies static analysis fail to fix the
   underlying defect?
 
+These refine the proposal's questions. The object of study, execution-based
+assessment of AI-generated notebook code, is unchanged; the questions are stated
+in the measurable form the implementation made possible, namely the size of the
+verification gap (RQ1), the reliability of confirming or refuting individual
+findings (RQ2), and the verifiability of repairs (RQ3). The longer justification
+is recorded in docs/thesis/rq-evolution.md.
+
 ## 2. Background and related work
 
 Purpose: situate the work; show the gap in the literature is real.

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -18,6 +18,7 @@ same per-session record and aggregate.
 from __future__ import annotations
 
 import json
+import traceback
 import logging
 import os
 from dataclasses import dataclass, field
@@ -398,6 +399,7 @@ def _run_one(
         return row
     except Exception as e:  # one bad notebook should not sink the run
         logger.warning("Input failed: %s: %s", input_path, e)
+        logger.debug("Traceback for %s:\n%s", input_path, traceback.format_exc())
         return {"input": str(input_path), "metrics": None, "error": str(e)}
 
 
@@ -435,6 +437,9 @@ def _metrics_from_dict(d: dict) -> SessionMetrics:
         confirmed=d.get("confirmed"),
         refuted=d.get("refuted"),
         confirmation_rate=d.get("confirmation_rate"),
+        inconclusive=d.get("inconclusive"),
+        not_execution_testable=d.get("not_execution_testable"),
+        incoherent_oracles_dropped=int(d.get("incoherent_oracles_dropped", 0) or 0),
         verified_fixed=d.get("verified_fixed"),
         not_fixed=d.get("not_fixed"),
         verified_fix_rate=d.get("verified_fix_rate"),

--- a/src/qallm/verification/mutation_score.py
+++ b/src/qallm/verification/mutation_score.py
@@ -79,21 +79,29 @@ class MutationScore:
         }
 
 
-def _suite_kills(source: str, test_code: str, module_name: str) -> str:
+def _suite_kills(source: str, test_code: str, module_name: str,
+                 baseline_works: bool = True) -> str:
     """Run the suite against one mutant. Returns 'killed', 'survived', or
     'not_viable'.
 
-    A mutant is KILLED if at least one test fails (the suite detected the
-    injected fault). It SURVIVED if every test passes (the suite missed it). It
-    is NOT_VIABLE if every test errors (the mutant cannot even run, so it tells
-    us nothing about discrimination, e.g. it broke an import the tests need).
+    A mutant is KILLED if the suite detects the injected fault, which happens
+    when at least one test fails OR (for a suite that worked on the original
+    code) the mutant turns a working run into errors. Erroring is a detectable
+    behavioural change, not a non-result, so when the suite ran cleanly on the
+    original we count an all-error mutant run as killed rather than discarding
+    it. It SURVIVED if every test still passes (the suite missed the fault). It
+    is NOT_VIABLE only when the suite could not run on the original either (so
+    the mutant tells us nothing), the trivial/broken-suite case.
     """
     result = run_tests(source, test_code, f"{module_name}.py")
     if result.failed > 0:
         return "killed"
     if result.passed > 0:
         return "survived"
-    return "not_viable"
+    # No pass, no fail: the suite errored on this mutant. If the suite worked on
+    # the original, the mutant changed behaviour detectably -> killed. If the
+    # suite did not work on the original, it is genuinely uninformative.
+    return "killed" if baseline_works else "not_viable"
 
 
 def score_oracle(
@@ -118,9 +126,17 @@ def score_oracle(
     if not mutants:
         return score
 
+    # Does the suite actually run on the ORIGINAL code? If it does, a mutant
+    # that turns this clean run into errors has been detected (killed). If it
+    # does not (the suite was broken to begin with), an all-error mutant run is
+    # genuinely uninformative (not viable). Computed once, reused per mutant.
+    base = run_tests(source, test_code, f"{module_name}.py")
+    baseline_works = (base.passed > 0 and base.failed == 0)
+
     for m in mutants:
         try:
-            outcome = _suite_kills(m.source, test_code, module_name)
+            outcome = _suite_kills(m.source, test_code, module_name,
+                                   baseline_works=baseline_works)
         except Exception as exc:  # a mutant that breaks execution entirely
             logger.debug("Mutant errored (%s): %s", m.description, exc)
             outcome = "not_viable"

--- a/tests/test_metrics_export.py
+++ b/tests/test_metrics_export.py
@@ -158,3 +158,19 @@ def test_confirm_columns_present():
     from qallm.metrics_export import CSV_COLUMNS
     assert "inconclusive" in CSV_COLUMNS
     assert "not_execution_testable" in CSV_COLUMNS
+
+
+def test_metrics_roundtrip_preserves_confirm_fields():
+    """The aggregate must not drop inconclusive/not_testable when rebuilding
+    SessionMetrics from row dicts (the resume / re-aggregate path)."""
+    from qallm.metrics_export import build_session_metrics, aggregate_sessions
+    from qallm.experiments.gap_runner import _metrics_from_dict
+    cs = {"confirmed": 0, "refuted": 0, "inconclusive": 3,
+          "not_execution_testable": 1, "confirmation_rate": None}
+    m = build_session_metrics("s", {"model": "m", "oracle": "correctness"}, [], cs)
+    m2 = _metrics_from_dict(m.to_dict())
+    assert m2.inconclusive == 3
+    assert m2.not_execution_testable == 1
+    agg = aggregate_sessions([m2]).to_dict()
+    assert agg["total_inconclusive"] == 3
+    assert agg["total_not_execution_testable"] == 1

--- a/tests/test_mutation_score.py
+++ b/tests/test_mutation_score.py
@@ -57,3 +57,25 @@ def test_confidence_thresholds():
     assert MutationScore("f", killed=5, survived=5).confidence == "medium" # 0.5
     assert MutationScore("f", killed=1, survived=9).confidence == "low"    # 0.1
     assert MutationScore("f").confidence == "unknown"                      # no viable
+
+
+def test_errored_mutant_counts_as_killed_when_baseline_works():
+    """A mutant that turns a clean suite into errors is detected (killed), not
+    discarded as not-viable, so data functions get a real confidence."""
+    from qallm.verification.mutation_score import score_oracle
+    source = (
+        "def scale(values, factor):\n"
+        "    out = []\n"
+        "    for v in values:\n"
+        "        out.append(v * factor + 1)\n"
+        "    return out\n"
+    )
+    test = (
+        "from source_module import scale\n"
+        "def test_basic():\n"
+        "    assert scale([1, 2], 2) == [3, 5]\n"
+    )
+    s = score_oracle(source, "scale", test)
+    assert s.total_mutants > 0
+    assert s.viable > 0
+    assert s.confidence in ("high", "medium", "low")


### PR DESCRIPTION
Self-contained against current dev (PR #135), no dependency on any unmerged branch. Combines the two data-driven code fixes with the docs that were drafted but never merged (the rq-evolution-and-training branch was lost).

Code fixes (surfaced by the partial E1 run, 893 ok / 62 errored of 955):
- metrics round-trip: _metrics_from_dict now reads back inconclusive, not_execution_testable, and incoherent_oracles_dropped. These were written per session but dropped when the runner re-aggregates or resumes, which is why the lab --confirm runs kept showing total_inconclusive=0 despite correct per-session verdict logs.
- mutation viability: when the generated suite runs cleanly on the ORIGINAL code, a mutant that turns that clean run into errors is now counted as killed (a detectable behavioural change) instead of discarded as not_viable. This fixes the 336-unknown / 7-high confidence distribution seen on real data, where data functions made the suite error on mutants. Lab calibration unchanged.
- session failures log a full traceback at debug level so the 62 errored notebooks can be pinpointed (failure was already isolated per notebook).

Docs (recovered, were never merged):
- thesis/rq-evolution.md + the two-sentence note in the Introduction.
- thesis/llm-training-analysis.md (training as future work).
- thesis/path-to-finish-2026-06.md (status + ordered plan).

Tests (+2): mutation viability scores an errored-mutant-on-working-baseline; the metrics round-trip preserves confirm fields through aggregation.

Suite: 725 passed; ruff clean.