### PR TITLE
feat(ui): expandable finding detail; clean leaked cite artifacts

### DIFF
--- a/docs/architecture/design/FEAT-01/FEAT-01-ext.md
+++ b/docs/architecture/design/FEAT-01/FEAT-01-ext.md
@@ -1,8 +1,8 @@
 # FEAT-01 Extension: Multi-Source Ingestion
 
 ## 1. Requirement Analysis
-* [cite_start]**Goal**: Support single scripts (.py), ZIP archives, and GitHub repositories[cite: 146].
-* [cite_start]**Logic**: Automated source detection and recursive scanning of directories[cite: 75].
+* [cite_start]**Goal**: Support single scripts (.py), ZIP archives, and GitHub repositories.
+* [cite_start]**Logic**: Automated source detection and recursive scanning of directories.
 
 ## 2. Technical Scope
 * **Zip Support**: Temporary extraction of archives using `zipfile`.

--- a/docs/architecture/design/FEAT-01/FEAT-01.md
+++ b/docs/architecture/design/FEAT-01/FEAT-01.md
@@ -1,18 +1,18 @@
 # FEAT-01: Jupyter Preprocessing Adapter
 
 ## 1. Requirement Analysis
-* [cite_start]**Context**: Thesis Stage 1 - Preprocessing[cite: 616].
+* [cite_start]**Context**: Thesis Stage 1 - Preprocessing.
 * **Goal**: Transform `.ipynb` (JSON) into a structured Python representation suitable for execution-based testing.
 * **Research Traceability**:
-    - [cite_start]**Extraction**: Filter only `cell_type == "code"`[cite: 616].
-    - [cite_start]**Normalization**: Strip Jupyter-specific magic commands (`%matplotlib`, `!pip`)[cite: 616, 808].
-    - [cite_start]**Mapping**: Must preserve cell order and index for per-cell reporting in Stage 4[cite: 616, 652].
+    - [cite_start]**Extraction**: Filter only `cell_type == "code"`.
+    - [cite_start]**Normalization**: Strip Jupyter-specific magic commands (`%matplotlib`, `!pip`).
+    - [cite_start]**Mapping**: Must preserve cell order and index for per-cell reporting in Stage 4.
 
 ## 2. Technical Scope
-* [cite_start]Implement `NotebookAdapter` using the standard Python `json` library[cite: 801].
+* [cite_start]Implement `NotebookAdapter` using the standard Python `json` library.
 * Create a regex-based `MagicStripper` to clean source code without altering line counts (to maintain traceback accuracy).
 
 ## 3. Definition of Done (DoD)
-- [ ] [cite_start]Successfully parses Li's (2025) dataset sample[cite: 810].
+- [ ] [cite_start]Successfully parses Li's (2025) dataset sample.
 - [ ] [cite_start]Strips all magic patterns identified in the proposal.
 - [ ] Logic documented in `FEAT-01-logic.puml`.

--- a/docs/architecture/design/FEAT-02/FEAT-02.md
+++ b/docs/architecture/design/FEAT-02/FEAT-02.md
@@ -1,12 +1,12 @@
 # FEAT-02: Quantitative Quality Engine (QQE)
 
 ## 1. Requirement Analysis
-* [cite_start]**Goal**: Implement Stage 2 of the thesis pipeline: Static Quality Analysis[cite: 617].
+* [cite_start]**Goal**: Implement Stage 2 of the thesis pipeline: Static Quality Analysis.
 * **Research Traceability**:
-    - [cite_start]**Security**: Integrate Bandit for CWE vulnerabilities and TruffleHog for secrets[cite: 608, 634].
-    - [cite_start]**Complexity**: Integrate Radon for Maintainability Index (MI) and Cyclomatic Complexity (CC)[cite: 608, 633].
-    - [cite_start]**Linting**: Integrate Ruff for style violations and dead code[cite: 608, 631].
-* [cite_start]**Baseline Context**: This analysis provides the baseline quality metrics Li's tool performs[cite: 618].
+    - [cite_start]**Security**: Integrate Bandit for CWE vulnerabilities and TruffleHog for secrets.
+    - [cite_start]**Complexity**: Integrate Radon for Maintainability Index (MI) and Cyclomatic Complexity (CC).
+    - [cite_start]**Linting**: Integrate Ruff for style violations and dead code.
+* [cite_start]**Baseline Context**: This analysis provides the baseline quality metrics Li's tool performs.
 
 ## 2. Technical Scope
 * Create `StaticAnalyzer` to orchestrate tools via isolated subprocesses.
@@ -14,4 +14,4 @@
 
 ## 3. Definition of Done (DoD)
 - [ ] Successfully generates a consolidated diagnostic report for a `List[CodeUnit]`.
-- [ ] [cite_start]Tool execution is robust against cell-level syntax errors (NFR6)[cite: 165].
+- [ ] [cite_start]Tool execution is robust against cell-level syntax errors (NFR6).

--- a/docs/architecture/design/FEAT-03/FEAT-03.md
+++ b/docs/architecture/design/FEAT-03/FEAT-03.md
@@ -1,7 +1,7 @@
 # FEAT-03: Lifecycle-Aware Normalizer
 
 ## 1. Requirement Analysis
-* [cite_start]**Goal**: Normalize raw static metrics into quality states based on the research software lifecycle[cite: 170].
+* [cite_start]**Goal**: Normalize raw static metrics into quality states based on the research software lifecycle.
 * **Lifecycle Stages**:
     * [cite_start]**Initialization**: Focus on basic structure; high complexity is tolerated.
     * **Implementation**: Standard thresholds apply; security is prioritized.

--- a/docs/architecture/design/FEAT-04/FEAT-04-logic.puml
+++ b/docs/architecture/design/FEAT-04/FEAT-04-logic.puml
@@ -23,7 +23,7 @@ deactivate EB
 ORC -> PC : build_test_prompt(bundle_obj)
 activate PC STAGE3
 PC -> PC : Inject Oracle Instructions
-note right: Instructs LLM on Crash, Property,\nand Metamorphic oracles [cite: 221]
+note right: Instructs LLM on Crash, Property,\nand Metamorphic oracles
 PC --> ORC : formatted_prompt_string
 deactivate PC
 @enduml

--- a/docs/architecture/design/FEAT-04/FEAT-04.md
+++ b/docs/architecture/design/FEAT-04/FEAT-04.md
@@ -1,12 +1,12 @@
 # FEAT-04: Prompt Construction Module (Test Case Agent)
 
 ## 1. Requirement Analysis
-* [cite_start]**Context**: Stage 3 - RL-Based Verification[cite: 79].
-* [cite_start]**Goal**: Construct "Evidence Bundles" that provide the LLM with sufficient context to generate high-quality test cases[cite: 73, 215].
+* [cite_start]**Context**: Stage 3 - RL-Based Verification.
+* [cite_start]**Goal**: Construct "Evidence Bundles" that provide the LLM with sufficient context to generate high-quality test cases.
 * **Oracle Support**: The prompt must guide the LLM toward:
-    * [cite_start]**Crash Oracles**: Unhandled runtime exceptions[cite: 223].
-    * [cite_start]**Property Oracles**: Invariants from docstrings/hints[cite: 225, 227].
-    * [cite_start]**Metamorphic Oracles**: Domain-general relations[cite: 228, 230].
+    * [cite_start]**Crash Oracles**: Unhandled runtime exceptions.
+    * [cite_start]**Property Oracles**: Invariants from docstrings/hints.
+    * [cite_start]**Metamorphic Oracles**: Domain-general relations.
 
 ## 2. Technical Scope
 * Implement `EvidenceBundle` to pair source code with its `StructuredDiagnostics` (from Stage 2).

--- a/docs/project/Repository_Structure.puml
+++ b/docs/project/Repository_Structure.puml
@@ -9,12 +9,12 @@ package "qallm-uva (Root)" {
             [context.py]
         }
         package "stage1_qqe" {
-            note right: Quantitative Quality Engine [cite: 170]
+            note right: Quantitative Quality Engine
             [metrics.py]
             [normalizer.py]
         }
         package "stage2_lre" {
-            note right: LLM Refinement Engine [cite: 172]
+            note right: LLM Refinement Engine
             [prompter.py]
             [refiner.py]
         }

--- a/src/qallm/analysis/ruff_analyzer.py
+++ b/src/qallm/analysis/ruff_analyzer.py
@@ -24,7 +24,7 @@ class RuffAnalyzer(StaticCodeAnalyzer):
         if shutil.which("ruff") is None:
             return RawToolResult("ruff", 127, "", "ruff not installed")
 
-        # Run ruff check on stdin[cite: 19]
+        # Run ruff check on stdin
         process = subprocess.run(
             ["ruff", "check", "--format", "json", "-"],
             input=unit.source_code,

--- a/src/qallm/common/model.py
+++ b/src/qallm/common/model.py
@@ -2,7 +2,7 @@ from pathlib import Path
 
 
 class CodeUnit:
-    """Represents a single executable unit of code[cite: 76]."""
+    """Represents a single executable unit of code."""
 
     def __init__(self, source_code: str, cell_index: int, original_path: Path):
         self.source_code = source_code

--- a/src/qallm/ingestion/ingestion_model.py
+++ b/src/qallm/ingestion/ingestion_model.py
@@ -7,7 +7,7 @@ from qallm.common.model import CodeUnit
 
 
 class NotebookAdapter:
-    """Handles .ipynb files by stripping magics and preserving cell order[cite: 76]."""
+    """Handles .ipynb files by stripping magics and preserving cell order."""
     MAGIC_PATTERN = re.compile(r"^(%|!|%%).*$", re.MULTILINE)
 
     def parse(self, path: Path) -> List[CodeUnit]:

--- a/src/qallm/llm/base.py
+++ b/src/qallm/llm/base.py
@@ -88,18 +88,18 @@ class TokenTracker:
         return max(0, self.budget - self.total_tokens)
 
     def record(self, resp: LLMResponse) -> None:
-        """Records the results of an LLM call and updates cumulative metrics[cite: 37]."""
+        """Records the results of an LLM call and updates cumulative metrics."""
         self.calls += 1
         self.last_activity = time.monotonic()
 
-        # Extract safe values once[cite: 37]
+        # Extract safe values once
         in_tokens = resp.input_tokens if resp.input_tokens is not None else 0
         out_tokens = resp.output_tokens if resp.output_tokens is not None else 0
 
         self.total_input += in_tokens
         self.total_output += out_tokens
 
-        # Calculate cost using the safe values[cite: 37]
+        # Calculate cost using the safe values
         call_cost = calculate_cost_usd(resp.model, in_tokens, out_tokens)
         self.total_cost_usd += call_cost
 

--- a/src/qallm/verification/generator.py
+++ b/src/qallm/verification/generator.py
@@ -239,7 +239,7 @@ class TestGenerator:
             logger.info("Generating initial %s tests for %s", oracle, func.name)
             user_prompt = builder(func)
 
-        # 2. Call the LLM[cite: 39]
+        # 2. Call the LLM
         resp = self.llm.chat(SYSTEM_PROMPT, user_prompt, self.tracker)
 
         if resp.error:
@@ -255,7 +255,7 @@ class TestGenerator:
         extracted_code, strategy = CodeExtractor.extract(resp.content)
         logger.info("Extraction strategy: %s", strategy)
 
-        # Apply module name fixing and validation[cite: 39]
+        # Apply module name fixing and validation
         test_code = _fix_source_import(extracted_code, module_name)
         is_valid, validation_error = _validate_test_code(test_code)
 

--- a/src/qallm/verification/models.py
+++ b/src/qallm/verification/models.py
@@ -22,13 +22,13 @@ class TestedCodeUnit:
     @property
     def total_bugs(self) -> int:
         """Sum of bugs found across all function sessions."""
-        return sum(s.final_bugs for s in self.sessions) #[cite: 41]
+        return sum(s.final_bugs for s in self.sessions)
 
     @property
     def avg_coverage(self) -> float:
         """Average coverage across all tested functions."""
         valid_covs = [s.final_coverage for s in self.sessions if s.final_coverage is not None]
-        return sum(valid_covs) / len(valid_covs) if valid_covs else 0.0 #[cite: 41]
+        return sum(valid_covs) / len(valid_covs) if valid_covs else 0.0
 
 @dataclass(frozen=True)
 class FunctionInfo:
@@ -200,7 +200,7 @@ class TestGenerationSession:
 
     @property
     def learning_curve(self) -> list[float]:
-        """Cumulative reward trend across rounds[cite: 28]."""
+        """Cumulative reward trend across rounds."""
         curve = []
         cumulative = 0.0
         for r in self.rounds:

--- a/web/frontend/src/screens/AnalyseScreen.tsx
+++ b/web/frontend/src/screens/AnalyseScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { AlertTriangle, FileCode2, Search, Shield, CheckSquare, Square, FolderTree } from "lucide-react";
+import { AlertTriangle, FileCode2, Search, Shield, CheckSquare, Square, FolderTree, ChevronRight } from "lucide-react";
 import { StatCard } from "../components/Shared";
 import type { SessionState } from "../hooks/useSession";
 import type { Finding } from "../types";
@@ -15,18 +15,19 @@ const SEV_CLS: Record<string, string> = {
 export default function AnalyseScreen({ state, patch }: { state: SessionState; patch: (p: Partial<SessionState>) => void; autoMode?: boolean }) {
   const [availableTools, setAvailableTools] = useState<string[]>([]);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
+  const [expanded, setExpanded] = useState<number | null>(null);
   const [selectedFiles, setSelectedFiles] = useState<Set<string>>(new Set(state.files));
   const [filter, setFilter] = useState("");
   const [sevF, setSevF] = useState("");
   const [toolF, setToolF] = useState("");
 
-  // Fetch available analysis tools from the server on component mount[cite: 35]
+  // Fetch available analysis tools from the server on component mount
   useEffect(() => {
     api.getAnalysisTools()
       .then(res => {
         if (res.tools) {
           setAvailableTools(res.tools);
-          setSelectedTools(res.tools); // Default to all tools enabled[cite: 35]
+          setSelectedTools(res.tools); // Default to all tools enabled
         }
       })
       .catch(err => patch({ error: "Failed to load tools: " + err.message }));
@@ -34,14 +35,14 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
 
   const has = state.findings.length > 0 || state.summary !== null;
 
-  // Toggle selection for analysis tools[cite: 35]
+  // Toggle selection for analysis tools
   const toggleTool = (tool: string) => {
     setSelectedTools(prev =>
       prev.includes(tool) ? prev.filter(t => t !== tool) : [...prev, tool]
     );
   };
 
-  // Toggle selection for specific files in the directory[cite: 35]
+  // Toggle selection for specific files in the directory
   const toggleFile = (file: string) => {
     const next = new Set(selectedFiles);
     if (next.has(file)) {
@@ -53,15 +54,15 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
   };
 
   async function run() {
-    // Ensure both files and tools are selected before proceeding[cite: 35]
+    // Ensure both files and tools are selected before proceeding
     if (!state.sessionId || selectedTools.length === 0 || selectedFiles.size === 0) return;
 
     patch({ loading: true, error: null });
     try {
-      // Execute multi-tool analysis via the API with three required arguments[cite: 30, 35]
+      // Execute multi-tool analysis via the API with three required arguments
       const r = await api.runAnalysis(state.sessionId, Array.from(selectedFiles), selectedTools);
 
-      // Retrieve the updated analysis history[cite: 30, 35]
+      // Retrieve the updated analysis history
       const rounds = await api.getAnalysisHistory(state.sessionId).catch(() => []);
 
       patch({
@@ -75,7 +76,7 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
     }
   }
 
-  // Filter findings based on user input for severity, tool, or search text[cite: 35]
+  // Filter findings based on user input for severity, tool, or search text
   const shown = state.findings.filter((f: Finding) => {
     if (sevF && f.severity !== sevF) return false;
     if (toolF && f.tool.toLowerCase() !== toolF.toLowerCase()) return false;
@@ -88,7 +89,7 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
   return (
     <div className="space-y-6">
       <div className="grid gap-6 lg:grid-cols-3">
-        {/* Tool Selection Section[cite: 35] */}
+        {/* Tool Selection Section */}
         <div className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
           <h3 className="mb-4 flex items-center gap-2 font-semibold">
             <Shield className="h-4 w-4" /> Analysis Tools
@@ -106,7 +107,7 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
               </label>
             ))}
           </div>
-          <p className="mt-3 text-[10px] text-slate-400">At least one tool must be selected[cite: 35].</p>
+          <p className="mt-3 text-[10px] text-slate-400">At least one tool must be selected.</p>
         </div>
 
         {/* File Selection Section */}
@@ -147,7 +148,7 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
             ))}
           </div>
 
-          {/* Analysis Trigger: Disabled if selections are missing[cite: 35] */}
+          {/* Analysis Trigger: Disabled if selections are missing */}
           <button
             onClick={run}
             disabled={state.loading || selectedTools.length === 0 || selectedFiles.size === 0}
@@ -221,20 +222,9 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
                 </thead>
                 <tbody className="divide-y divide-slate-100">
                   {shown.map((f, i) => (
-                    <tr key={i} className="hover:bg-slate-50/80 transition-colors">
-                      <td className="px-3 py-2.5">
-                        <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase ${SEV_CLS[f.severity]}`}>
-                          {f.severity}
-                        </span>
-                      </td>
-                      <td className="px-3 py-2.5 font-medium text-slate-600">{f.tool}</td>
-                      <td className="px-3 py-2.5">
-                        <div className="font-mono text-[10px] text-slate-500">
-                          {f.file || "\u2014"}:{f.line || "\u2014"}
-                        </div>
-                      </td>
-                      <td className="px-3 py-2.5 text-slate-600 leading-relaxed">{f.message}</td>
-                    </tr>
+                    <FindingRow key={i} f={f}
+                      open={expanded === i}
+                      onToggle={() => setExpanded(expanded === i ? null : i)} />
                   ))}
                   {shown.length === 0 && (
                     <tr>
@@ -250,5 +240,57 @@ export default function AnalyseScreen({ state, patch }: { state: SessionState; p
         </>
       )}
     </div>
+  );
+}
+function FindingRow({ f, open, onToggle }: { f: Finding; open: boolean; onToggle: () => void }) {
+  // A finding carries more than the table columns show (its type, rule id, and
+  // the offending code snippet). Clicking the row reveals that detail, which is
+  // what testers asked for: "how do I see the details of a finding?".
+  const hasDetail = Boolean(f.code_snippet || f.rule_id || f.type);
+  return (
+    <>
+      <tr
+        onClick={hasDetail ? onToggle : undefined}
+        className={`transition-colors ${hasDetail ? "cursor-pointer hover:bg-slate-50/80" : ""} ${open ? "bg-slate-50" : ""}`}
+      >
+        <td className="px-3 py-2.5">
+          <div className="flex items-center gap-1.5">
+            {hasDetail && (
+              <ChevronRight className={`h-3.5 w-3.5 text-slate-400 transition-transform ${open ? "rotate-90" : ""}`} />
+            )}
+            <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold tracking-wide uppercase ${SEV_CLS[f.severity]}`}>
+              {f.severity}
+            </span>
+          </div>
+        </td>
+        <td className="px-3 py-2.5 font-medium text-slate-600">{f.tool}</td>
+        <td className="px-3 py-2.5">
+          <div className="font-mono text-[10px] text-slate-500">
+            {f.file || "\u2014"}:{f.line || "\u2014"}
+          </div>
+        </td>
+        <td className="px-3 py-2.5 text-slate-600 leading-relaxed">{f.message}</td>
+      </tr>
+      {open && (
+        <tr className="bg-slate-50">
+          <td colSpan={4} className="px-3 pb-3 pt-0">
+            <div className="rounded-lg border border-slate-200 bg-white p-3 text-xs">
+              <div className="flex flex-wrap gap-x-6 gap-y-1 text-slate-600">
+                {f.type && <span><span className="font-semibold text-slate-700">Type:</span> {f.type}</span>}
+                {f.rule_id && <span><span className="font-semibold text-slate-700">Rule:</span> <span className="font-mono">{f.rule_id}</span></span>}
+                <span><span className="font-semibold text-slate-700">Tool:</span> {f.tool}</span>
+                {f.line ? <span><span className="font-semibold text-slate-700">Line:</span> {f.line}</span> : null}
+              </div>
+              <p className="mt-2 text-slate-600">{f.message}</p>
+              {f.code_snippet && (
+                <pre className="mt-2 overflow-auto rounded-md bg-slate-900 p-3 font-mono text-[11px] leading-relaxed text-slate-100">
+                  {f.code_snippet}
+                </pre>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }


### PR DESCRIPTION
Answers tester feedback (Koen, via the qcdis deployment): "once I have arrived at the baseline, how do I see the details of a finding?".

- AnalyseScreen findings rows are now expandable. Clicking a row reveals the finding's type, rule id, tool, line, full message, and the offending code snippet. The Finding model already carried type/rule_id/code_snippet and the /api/analyse endpoint already returned them (asdict), so this surfaces data that was present but hidden. A chevron indicates expandable rows; rows with no extra detail are not clickable.

- Removed leaked "[cite: N]" text artifacts from the frontend, source comments, and a few docs. One was user-visible in the analysis screen ("At least one tool must be selected[cite: 35]."), the rest were code comments. Comments and one UI string only; no logic change.

Frontend builds clean; backend suite 729 passed; ruff clean.