### PR TITLE
feat(ui+docs): end-user onboarding (intro, mode clarity, user guide)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -13,7 +13,8 @@ The reasoning the thesis rests on.
 - [`concepts/oracles-and-defect-classes.md`](concepts/oracles-and-defect-classes.md): which oracle catches which defect class, and why the correctness oracle withholds the implementation (illustrated).
 - [`concepts/oracle-confidence-mutation-testing.md`](concepts/oracle-confidence-mutation-testing.md): mutation-testing the oracle to give every gap finding a confidence (the positive soundness check; illustrated).
 
-## guides/ — how to run and operate QALLM
+## guides/
+- [`guides/getting-started.md`](guides/getting-started.md): first-time user guide (what the tool does, your first run, manual vs automatic, reading results). — how to run and operate QALLM
 
 Practical, task-oriented.
 

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -1,0 +1,85 @@
+# Getting started with QALLM
+
+A short guide for anyone trying QALLM for the first time: researchers, testers,
+and collaborators. No prior knowledge of the tool is needed.
+
+## What QALLM does, in one minute
+
+Static analysers (the tools that flag style, complexity, and security issues)
+tell you whether code *looks* right. They never run the code, so they miss
+defects that only show up at runtime: a function that passes every check and
+still returns the wrong answer.
+
+QALLM checks whether your code *runs* right. It takes your Python or Jupyter
+notebook code and:
+
+1. runs static analysis to get a baseline,
+2. generates and executes tests to find defects that static analysis misses,
+   the gap between "looks right" and "runs right" (we call it the
+   **verification gap**),
+3. where it finds a defect, it can propose a fix and verify the fix by running
+   the tests again.
+
+Each finding also comes with a **confidence**, an indication of how trustworthy
+the test that found it is, so you know which findings to act on first.
+
+## Your first run (5 minutes)
+
+1. **Open the tool** and stay on the default pipeline screen.
+2. **Load the sample project** (a button on the setup screen) if you just want
+   to see it work, or **upload your own** `.py` or `.ipynb` files.
+3. **Pick a quality model** (the default is fine to start).
+4. **Choose Manual mode** (recommended for your first run, see below).
+5. **Start the pipeline.** You will reach the baseline first.
+
+## Manual vs Automatic mode
+
+Both modes run the exact same pipeline. The difference is only how much you see
+along the way.
+
+- **Manual**: you step through each stage (analyse, then verify, then repair,
+  then judge) and can inspect the output of each before continuing. Best for
+  understanding what the tool is doing, and the right choice the first time.
+- **Automatic**: runs everything end to end and drops you at the results. Best
+  once you know the tool and just want the outcome.
+
+If in doubt, use Manual.
+
+## Reading the baseline
+
+The baseline screen lists the static findings: severity, the tool that raised
+each one, the location (file and line), and a message. **Click any finding row
+to expand it** and see the detail: the finding type, the rule, the exact line,
+and the offending code snippet.
+
+The interesting part is what comes next: when QALLM runs its tests, it shows
+which findings execution actually confirms, and the defects it found that static
+analysis never flagged. That second group is the verification gap.
+
+## What the results mean
+
+- **Verification gap**: functions that passed static analysis but that execution
+  proved are defective. This is the headline, the bugs your linter would have
+  let through.
+- **Confidence (high / medium / low)**: how well the test that found a defect
+  detects injected faults. Act on high-confidence findings first.
+- **Confirmed / refuted / inconclusive**: for the findings static analysis did
+  raise, whether execution could reproduce the issue. "Inconclusive" is honest,
+  it means the generated test could not settle it (common for some security
+  findings).
+- **Verified fix**: where QALLM repaired a defect, whether re-running the tests
+  confirms the fix.
+
+## Tips
+
+- Start with the **sample project** to see a clean end-to-end run before using
+  your own code.
+- Notebooks (`.ipynb`) and scripts (`.py`) both work.
+- A finding with **low or unknown confidence** is not necessarily wrong; it
+  means the test that found it is weak, so treat it as a lead, not a verdict.
+
+## Giving feedback
+
+Found something confusing or missing? That feedback is genuinely useful. Note the
+step you were on and what you expected to see, and send it along. The tool is
+under active development and tester input shapes it directly.

--- a/src/qallm/api/routers/docs.py
+++ b/src/qallm/api/routers/docs.py
@@ -93,6 +93,7 @@ def _resolve(rel: str) -> Path | None:
 # rather than injected inline, where their full-page markup would clash with
 # the app shell.
 _DOCS: dict[str, tuple[str, str, str]] = {
+    "getting-started": ("Getting started (for users)", "docs/guides/getting-started.md", "md"),
     "readme": ("Overview (README)", "README.md", "md"),
     "workflow": ("How QALLM works", "docs/architecture/workflow-design.md", "md"),
     "surpassing": ("Why execution beats static analysis", "docs/concepts/surpassing-static-analysers.md", "md"),

--- a/tests/test_docs_router.py
+++ b/tests/test_docs_router.py
@@ -21,7 +21,10 @@ def test_list_docs_includes_readme():
     r = client.get("/api/docs")
     assert r.status_code == 200
     ids = [d["id"] for d in r.json()["docs"]]
-    assert ids and ids[0] == "readme"
+    # The user getting-started guide leads (first thing a tester should see);
+    # the README is still present in the list.
+    assert ids and ids[0] == "getting-started"
+    assert "readme" in ids
 
 
 def test_listed_docs_all_exist_and_render():

--- a/web/frontend/src/screens/DocsView.tsx
+++ b/web/frontend/src/screens/DocsView.tsx
@@ -29,7 +29,7 @@ export default function DocsView() {
   const contentRef = useRef<HTMLElement | null>(null);
   const activeKind = docs.find((d) => d.id === activeId)?.kind ?? "md";
 
-  // Load the doc list once, then select the first (README).
+  // Load the doc list once, then select the first (the user getting-started guide).
   useEffect(() => {
     let alive = true;
     api.listDocs()

--- a/web/frontend/src/screens/UploadScreen.tsx
+++ b/web/frontend/src/screens/UploadScreen.tsx
@@ -172,7 +172,32 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
   const selectedOracle = ORACLE_INFO[config.oracle];
 
   return (
-    <div className="grid gap-6 lg:grid-cols-2">
+    <div className="space-y-6">
+      <details className="rounded-2xl border border-indigo-100 bg-indigo-50/50 p-5" open>
+        <summary className="cursor-pointer text-sm font-semibold text-slate-800">
+          New here? What this tool does
+        </summary>
+        <div className="mt-3 space-y-2 text-sm text-slate-600">
+          <p>
+            Static analysers tell you whether code <em>looks</em> right. This tool
+            checks whether it <em>runs</em> right. It takes your Python or Jupyter
+            notebook code, runs static analysis to get a baseline, then generates
+            and executes tests to find defects that pass static analysis but fail
+            at runtime, the verification gap. Where it finds a defect it can also
+            propose a fix and verify the fix by execution.
+          </p>
+          <p className="text-slate-500">
+            Three steps: <strong>1.</strong> upload your code and pick a quality
+            model, <strong>2.</strong> get the baseline (static findings plus what
+            execution reveals), <strong>3.</strong> review the gap, the
+            confidence in each finding, and any verified fixes. Pick Manual mode
+            below to step through and inspect each stage, or load the sample
+            project to see it work first.
+          </p>
+        </div>
+      </details>
+
+      <div className="grid gap-6 lg:grid-cols-2">
       {/* Left: configuration */}
       <div className="rounded-2xl border bg-white p-6 shadow-sm space-y-5">
         <h2 className="text-xl font-semibold">Research Pipeline Setup</h2>
@@ -424,6 +449,11 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
         {/* Execution mode toggle */}
         <div className="border-t pt-4 space-y-3">
           <label className="text-xs font-bold text-slate-500 uppercase">Execution Mode</label>
+          <p className="text-xs text-slate-500">
+            Both run the same pipeline. Manual lets you inspect each stage before
+            moving on; Automatic runs everything and shows you the result. New
+            here? Manual is the better way to understand what the tool does.
+          </p>
           <div className="grid grid-cols-2 gap-3">
             <button
               onClick={() => setAutoMode(false)}
@@ -432,7 +462,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
               <MousePointerClick className={`h-5 w-5 ${!autoMode ? "text-slate-900" : "text-slate-400"}`} />
               <div>
                 <div className="text-sm font-medium">Manual</div>
-                <div className="text-xs text-slate-500">Click through each step</div>
+                <div className="text-xs text-slate-500">Step through and inspect each stage</div>
               </div>
             </button>
             <button
@@ -442,7 +472,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
               <Play className={`h-5 w-5 ${autoMode ? "text-indigo-600" : "text-slate-400"}`} />
               <div>
                 <div className="text-sm font-medium">Automatic</div>
-                <div className="text-xs text-slate-500">Run all steps, observe</div>
+                <div className="text-xs text-slate-500">Run end to end, then review</div>
               </div>
             </button>
           </div>
@@ -485,6 +515,7 @@ export default function UploadScreen({ state, patch, onSessionReady }: any) {
           </div>
         </div>
       </div>
+    </div>
     </div>
   );
 }


### PR DESCRIPTION
From tester feedback and the observation that the manual/automatic distinction and the tool's purpose are not explained for newcomers.

- UploadScreen opens with a collapsible "New here? What this tool does" panel: plain-language explanation of the verification gap and the three-step flow (upload -> baseline -> review), so a first-time user is oriented before the configuration form rather than dropped straight into a quality-model dropdown.
- Execution-mode toggle clarified: a line stating both modes run the same pipeline and that Manual lets you inspect each stage (recommended when new) while Automatic runs end to end; the per-button descriptions are reworded to be self-explanatory ("Step through and inspect each stage" / "Run end to end, then review").
- New docs/guides/getting-started.md for users, testers, and researchers: what the tool does in a minute, a first run, manual vs automatic, how to read the baseline and the results (gap, confidence, confirmed/refuted, verified fix), and how to give feedback. Registered as the FIRST curated doc, so the Docs tab opens on the user guide instead of the developer README. The curated _DOCS registry still keeps the 30+ internal/thesis docs out of the end-user view.

Tests: docs-router test updated for the new first entry. Frontend builds clean; backend suite 729 passed.