### PR TITLE
feat+docs+fix: sonar activation, re-analyse finding diff, docs audit,…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -51,10 +51,20 @@ OLLAMA_PORT=11434
 # ---------- SonarQube (optional) ----------
 
 # Optional higher-fidelity static analysis. Leave unset to run on
-# Radon/Bandit only. To enable the in-stack server:
-#   docker compose --profile sonarqube up
-# then create a token at http://localhost:${SONARQUBE_PORT} (admin/admin
-# on first login) and set SONARQUBE_TOKEN below.
+# Radon/Bandit only. SonarQube is part of the default stack, so it starts
+# with `docker compose up` (no profile flag needed).
+#
+# To actually ACTIVATE it, three things are required:
+#   1. Set WITH_SONAR_SCANNER=1 below and rebuild the api image
+#      (docker compose build api), so the scanner CLI is in the container.
+#   2. Create a token: open http://localhost:${SONARQUBE_PORT} (admin/admin
+#      on first login), My Account > Security > Generate Token (Global
+#      Analysis Token), and set SONARQUBE_TOKEN below.
+#   3. Recreate the api container: docker compose up -d --force-recreate api
+# Then `docker compose logs api | grep -i sonarqube` should show
+# "SonarQube analyzer enabled". Without the token the analyzer is never
+# registered and the UI selection has no effect (it falls back silently).
+# Leave SONARQUBE_URL unset to use the in-stack server (http://sonarqube:9000).
 # SONARQUBE_URL=http://sonarqube:9000
 # SONARQUBE_TOKEN=
 # For SonarCloud instead of the self-hosted server:

--- a/docs/README.md
+++ b/docs/README.md
@@ -57,6 +57,7 @@ The mechanics and design record.
 - [`thesis/rq-evolution.md`](thesis/rq-evolution.md): how the research questions changed from the proposal and why (defence-ready motivation).
 - [`thesis/llm-training-analysis.md`](thesis/llm-training-analysis.md): what training an LLM would take, its value, a staged plan, and why it is future work.
 - [`thesis/path-to-finish-2026-06.md`](thesis/path-to-finish-2026-06.md): status as E1 runs, the partial-data findings, and the ordered path to delivery.
+- [`thesis/status-checkpoint-2026-06-16.md`](thesis/status-checkpoint-2026-06-16.md): point-in-time checkpoint (done / in flight / remaining / risks).
 - [`thesis/enrichment-ideas.md`](thesis/enrichment-ideas.md): candidate features and experiments to enrich QALLM, with value/effort/risk and a thesis-scope vs future-work split.
 - [`thesis/security-confirmation-scope.md`](thesis/security-confirmation-scope.md): scope/feasibility/risk-benefit analysis for making security findings confirm rather than land inconclusive (decision aid).
 - [`thesis/session-log.md`](thesis/session-log.md): append-only, dated record of what changed each session and what is outstanding (for cross-session continuity).

--- a/docs/guides/getting-started.md
+++ b/docs/guides/getting-started.md
@@ -23,6 +23,22 @@ notebook code and:
 Each finding also comes with a **confidence**, an indication of how trustworthy
 the test that found it is, so you know which findings to act on first.
 
+## The pipeline at a glance
+
+```mermaid
+flowchart LR
+    A["1. Upload<br/>your .py or .ipynb"] --> B["2. Baseline<br/>static analysis"]
+    B --> C["3. Verify<br/>generate & run tests"]
+    C --> D["4. Repair<br/>fix found defects"]
+    D --> E["5. Judge<br/>accept or abandon"]
+    E --> F["6. Report<br/>gap, confidence, fixes"]
+    C -.the verification gap.-> G["defects static<br/>analysis missed"]
+```
+
+The first two steps tell you what your linter sees. The rest is what makes QALLM
+different: it runs the code to find what the linter missed, fixes it, and proves
+the fix.
+
 ## Your first run (5 minutes)
 
 1. **Open the tool** and stay on the default pipeline screen.

--- a/docs/guides/running-experiments.md
+++ b/docs/guides/running-experiments.md
@@ -68,9 +68,27 @@ datasets.
 
 Under `--workers N`, each worker logs to the same `run.log` (and stderr) with a
 `[pid NNNN]` prefix, so a parallel run is observable live (`tail -f run.log`)
-and interleaved lines stay attributable to their worker. Control verbosity with
+and interleaved lines stay attributable to their worker. Each completed file
+also logs a `Progress: k/total (pct%)` line, counted against the whole run
+(already-done on resume plus this run's pending), so the true position in the
+dataset is visible (`tail -f run.log | grep Progress`). Control verbosity with
 `--log-level` (DEBUG for per-step detail, WARNING to quieten); it applies to the
 workers too.
+
+To get a representative signal fast while a full run is still going, sample the
+dataset: `--sample N` runs a random subset of N files, `--sample-seed S` makes
+the subset reproducible (so a sampled run can be cited and repeated), and
+`--sample-stratify` buckets files by size into small/medium/large and samples
+proportionally so the subset spans the size range rather than over-representing
+one band. `--sample 0` (the default) runs everything. Example, a 150-file
+stratified pilot:
+
+```
+python scripts/run_gap_experiment.py \
+    --dataset datasets/envri_forest --output runs/pilot --pattern "*.ipynb" \
+    --llm fedllm --rounds 5 --oracle correctness --samples 1 --workers 4 \
+    --mutation-confidence --sample 150 --sample-seed 42 --sample-stratify
+```
 
 `--mutation-confidence` adds a soundness check to each gap finding: after the
 gap is measured, the oracle for each execution-only function is mutation-tested

--- a/docs/thesis/status-checkpoint-2026-06-16.md
+++ b/docs/thesis/status-checkpoint-2026-06-16.md
@@ -1,0 +1,90 @@
+# QALLM status checkpoint, June 16 2026
+
+A point-in-time snapshot to anchor where the project stands, what is done, what
+is in flight, and what remains. Use this as the reference when picking the work
+back up.
+
+## One-paragraph summary
+
+QALLM is feature-complete and deployed. The pipeline runs end to end (static
+baseline, execution-based verification, repair, EVERSE-aligned judge, report),
+the instrument is calibrated on the lab set, the three contributions
+(verification-gap method, EVERSE judge, mutation-based oracle confidence) are all
+implemented and surfaced in the UI, and the tool is live on the VM and being
+used by external testers. The headline experiment (E1, the ENVRI verification
+gap) is running. The thesis draft covers every results-independent section. What
+remains is finishing E1, the RQ2/RQ3 confirm pass, and writing the results
+chapters.
+
+## What is done
+
+- **Pipeline**: ingestion (.py and .ipynb), five static analysers via a
+  registry, sandboxed execution, repair loop, lexicographic EVERSE judge,
+  resumable parallel runner, provenance manifests.
+- **Three contributions, all implemented and tested**: the verification gap
+  (RQ1), confirm/refute with legible inconclusive/not-testable accounting (RQ2),
+  verified fixes (RQ3), and mutation-based oracle confidence, now correctly
+  scored against the repaired (correct) source rather than the buggy original.
+- **Calibration**: lab set validated, reliability 5/5, clean controls clean,
+  RQ2 legible, confidence no longer collapsing to "unknown".
+- **Web UI**: full pipeline UI (manual and auto modes), the gap panel with the
+  confidence view, expandable finding detail, a re-analyse comparison that now
+  shows which findings were resolved / introduced / still present, an end-user
+  onboarding intro and clarified mode descriptions, a curated Docs tab opening
+  on a user getting-started guide (with a pipeline diagram).
+- **Deployment**: live on nis05.lab.uvalight.net via docker compose; first
+  external tester feedback received and acted on.
+- **Quality**: 729 passing tests, ruff clean, frontend builds clean.
+- **Thesis draft**: Introduction, Background (2.1 to 2.5), Method (3.1 to 3.9),
+  Implementation (4.1 to 4.6), Setup (5.1), Threats (5.5), Appendix definitions,
+  plus the planning docs (experiment plan, structure, RQ evolution, LLM-training
+  analysis, enrichment ideas, experiment catalog, security-confirmation scope).
+
+## In flight
+
+- **E1, the ENVRI verification-gap headline run.** Partial data already shows
+  the gap materialising (hundreds of execution-only defects across the corpus).
+  Confidence labels from before the repaired-source fix should be re-scored once
+  the run completes; the gap counts are unaffected.
+- **SonarQube on the VM**: server is up and the scanner is installed on the
+  host, but the containerised api needs `SONARQUBE_TOKEN` in `.env` and
+  `WITH_SONAR_SCANNER=1` (rebuild) for it to register. Optional; not on the
+  critical path. Documented in `.env.example`.
+
+## What remains (the critical path)
+
+1. Finish E1; re-score its confidence over the artefacts.
+2. Run E2/E3 (the `--confirm` pass on ENVRI) for RQ2/RQ3.
+3. Draft results 5.2 to 5.4 with the confidence-stratified (A1) and
+   per-EVERSE-dimension (A2) cuts.
+4. Draft Discussion, Conclusion, and Abstract, making the thesis
+   content-complete.
+5. Editing pass into the LaTeX template.
+
+## Off the critical path (future work / optional)
+
+Training an LLM (future work / PhD), safe security confirmation, broader oracle
+types, cross-model comparison, the .py-vs-.ipynb and oracle ablation
+experiments. All named in the experiment catalog and enrichment-ideas docs.
+
+## Health indicators
+
+- Tests: 729 passing.
+- Lint: clean.
+- Frontend: builds clean; deployed.
+- Calibration: instrument sound on the lab answer key.
+- External use: live, with tester feedback incorporated.
+
+## Risks to watch
+
+- E1 runtime (large corpus; sampling is available for a faster representative
+  signal if needed).
+- A small fraction of notebooks error and are isolated (logged with tracebacks
+  now); worth a glance once E1 finishes to confirm the loss rate is acceptable.
+- The thesis results chapters are the main remaining writing effort and depend
+  on E1/E2/E3 completing.
+
+## One-line status
+
+Feature-complete, calibrated, deployed, and in use; headline experiment running;
+remaining work is finish the runs and write the results.

--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -243,7 +243,20 @@ async def run_analysis(req: dict):
             for s in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
         },
     }
-    state["analysis_rounds"].append({"round": len(state["analysis_rounds"]), **summary})
+    # Store a compact fingerprint of each finding so the re-analyse view can
+    # diff rounds and show which findings were resolved, which are new, and
+    # which persist, not just the totals. Keyed fields are enough to identify a
+    # finding across rounds without storing full snippets.
+    round_findings = [
+        {"tool": f.tool, "type": f.type, "severity": f.severity,
+         "file": f.file, "line": f.line, "rule_id": f.rule_id,
+         "message": f.message}
+        for f in all_findings
+    ]
+    state["analysis_rounds"].append({
+        "round": len(state["analysis_rounds"]), **summary,
+        "findings": round_findings,
+    })
 
     return {"findings": [asdict(f) for f in all_findings], "summary": summary}
 

--- a/web/frontend/src/screens/ReanalyseScreen.tsx
+++ b/web/frontend/src/screens/ReanalyseScreen.tsx
@@ -1,8 +1,9 @@
 import { useState, useEffect } from "react";
-import { RotateCw, TrendingUp, AlertTriangle, Layers } from "lucide-react";
+import { RotateCw, TrendingUp, AlertTriangle, Layers, CheckCircle2, PlusCircle, MinusCircle } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { StatCard } from "../components/Shared";
 import type { SessionState } from "../hooks/useSession";
+import type { AnalysisRound, RoundFinding } from "../types";
 import * as api from "../api";
 import PaperMetricsPanel from "./PaperMetricsPanel";
 
@@ -127,6 +128,9 @@ export default function ReanalyseScreen({ state, patch }: { state: SessionState;
         </div>
       )}
 
+      {/* What changed: per-finding diff between the first and latest round */}
+      <FindingsDiff rounds={analysisRounds} />
+
       {/* Paper metrics panel (Table 6 view) */}
       {metricsHistory.length > 0 && (
         <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
@@ -142,5 +146,77 @@ export default function ReanalyseScreen({ state, patch }: { state: SessionState;
         </div>
       )}
     </div>
+  );
+}
+
+function _key(f: RoundFinding): string {
+  // Identity of a finding across rounds: same rule at the same place. Message
+  // is excluded so a reworded message does not look like a different finding.
+  return `${f.tool}|${f.rule_id || f.type}|${f.file || ""}|${f.line ?? ""}`;
+}
+
+function FindingsDiff({ rounds }: { rounds: AnalysisRound[] }) {
+  // Compare the first (baseline) and latest round that carry finding lists.
+  const withFindings = rounds.filter(r => Array.isArray(r.findings));
+  if (withFindings.length < 2) return null;
+  const before = withFindings[0].findings ?? [];
+  const after = withFindings[withFindings.length - 1].findings ?? [];
+
+  const beforeKeys = new Map(before.map(f => [_key(f), f]));
+  const afterKeys = new Map(after.map(f => [_key(f), f]));
+
+  const resolved = before.filter(f => !afterKeys.has(_key(f)));
+  const introduced = after.filter(f => !beforeKeys.has(_key(f)));
+  const persisting = after.filter(f => beforeKeys.has(_key(f)));
+
+  if (!resolved.length && !introduced.length && !persisting.length) return null;
+
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h3 className="mb-1 font-semibold">What changed</h3>
+      <p className="mb-4 text-sm text-slate-500">
+        Findings resolved, newly introduced, and still present, comparing the
+        baseline to the latest re-analysis.
+      </p>
+      <div className="space-y-4">
+        <DiffGroup title="Resolved" count={resolved.length} items={resolved}
+          icon={<CheckCircle2 className="h-4 w-4 text-emerald-600" />}
+          tone="text-emerald-700" />
+        <DiffGroup title="Newly introduced" count={introduced.length} items={introduced}
+          icon={<PlusCircle className="h-4 w-4 text-rose-600" />}
+          tone="text-rose-700" />
+        <DiffGroup title="Still present" count={persisting.length} items={persisting}
+          icon={<MinusCircle className="h-4 w-4 text-slate-400" />}
+          tone="text-slate-600" collapsed />
+      </div>
+    </div>
+  );
+}
+
+function DiffGroup({ title, count, items, icon, tone, collapsed }: {
+  title: string; count: number; items: RoundFinding[];
+  icon: React.ReactNode; tone: string; collapsed?: boolean;
+}) {
+  if (count === 0) return (
+    <div className="flex items-center gap-2 text-sm text-slate-400">
+      {icon}<span>{title}: none</span>
+    </div>
+  );
+  return (
+    <details open={!collapsed}>
+      <summary className={`flex cursor-pointer items-center gap-2 text-sm font-semibold ${tone}`}>
+        {icon}{title}: {count}
+      </summary>
+      <ul className="mt-2 space-y-1">
+        {items.map((f, i) => (
+          <li key={i} className="flex flex-wrap items-center gap-2 rounded-md border border-slate-100 bg-slate-50/60 px-2 py-1.5 text-xs">
+            <span className="rounded bg-slate-200 px-1.5 py-0.5 font-medium text-slate-700">{f.tool}</span>
+            {f.rule_id && <span className="font-mono text-slate-500">{f.rule_id}</span>}
+            <span className="font-mono text-[10px] text-slate-400">{f.file || "\u2014"}:{f.line ?? "\u2014"}</span>
+            <span className="text-slate-600">{f.message}</span>
+          </li>
+        ))}
+      </ul>
+    </details>
   );
 }

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -146,8 +146,19 @@ export interface VersionInfo {
   files: number;
 }
 
+export interface RoundFinding {
+  tool: string;
+  type: string;
+  severity: string;
+  file?: string;
+  line?: number;
+  rule_id?: string;
+  message: string;
+}
+
 export interface AnalysisRound {
   round: number;
   total: number;
   by_severity: Record<string, number>;
+  findings?: RoundFinding[];
 }


### PR DESCRIPTION
… checkpoint

Addresses several items from this session's review.

1. SonarQube activation (config, not code bug). VM checks all pass (server UP, scanner installed, Java fine), so the issue was that the analysis manager only registers SonarQube when SONARQUBE_URL+SONARQUBE_TOKEN are set at server start, and the containerised api also needs WITH_SONAR_SCANNER=1 (rebuild). The UI selection has no effect if the analyzer was never registered. Fixed .env.example: it referenced a non-existent "--profile sonarqube" (sonarqube is in the default stack) and omitted the token+scanner+recreate steps. Now it documents the three required steps clearly.

2. Re-analyse comparison shows the finding diff (tester request). The analyse endpoint now stores a compact per-round finding fingerprint list, and ReanalyseScreen gains a "What changed" section: findings resolved, newly introduced, and still present, each listed. Previously only totals and a chart were shown, so a user could not see which findings a repair fixed or introduced.

3. Docs audit of the web-exposed set. running-experiments guide updated with the new --sample/--sample-seed/--sample-stratify flags and the per-file Progress logging (both were undocumented). getting-started guide gained a mermaid pipeline diagram (the Docs tab renders mermaid) and keeps its numbered steps.

4. Status checkpoint: docs/thesis/status-checkpoint-2026-06-16.md (done / in flight / remaining / risks) as a reference point.

Frontend builds clean; backend suite 729 passed; ruff clean.