### PR TITLE
fix: real per-round code metrics (not fabricated); drop $BUILDPLATFORM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@
 
 
 # -------- Stage 1: build the frontend --------
-FROM --platform=$BUILDPLATFORM node:20-alpine AS node-build
+FROM node:20-alpine AS node-build
 
 WORKDIR /app/frontend
 
@@ -26,7 +26,7 @@ RUN npm run build
 
 
 # -------- Stage 2: Python runtime --------
-FROM --platform=$BUILDPLATFORM python:3.12-slim AS runtime
+FROM python:3.12-slim AS runtime
 
 # System dependencies:
 #   git           ingestion can clone repos

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -16,8 +16,6 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
-      platforms:
-        - $BUILDPLATFORM
       args:
         WITH_SONAR_SCANNER: ${WITH_SONAR_SCANNER:-0}
     image: qallm:latest

--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -22,6 +22,52 @@ logger = logging.getLogger(__name__)
 router = APIRouter()
 
 
+def _round_code_metrics(sources: list[str]) -> dict:
+    """Compute real code metrics for a round from its analysed sources.
+
+    Uses Radon for maintainability index (mi, averaged across units),
+    cyclomatic complexity (cc, summed), and lines of code (loc, summed). These
+    are the metrics we can compute directly and honestly. Cognitive complexity
+    (cs), code duplication (codu), and comment density (code) require SonarQube
+    measures that are not retained per round, so they are reported as null
+    rather than fabricated. Returns a dict with numeric values where available.
+    """
+    if not sources:
+        return {"mi": None, "cc": None, "loc": None,
+                "cs": None, "codu": None, "code": None}
+    try:
+        from radon.complexity import cc_visit
+        from radon.metrics import mi_visit
+        from radon.raw import analyze as raw_analyze
+    except Exception:  # radon missing for some reason: report nothing rather than fake
+        return {"mi": None, "cc": None, "loc": None,
+                "cs": None, "codu": None, "code": None}
+
+    mis: list[float] = []
+    cc_total = 0
+    loc_total = 0
+    for src in sources:
+        try:
+            mis.append(float(mi_visit(src, True)))
+        except Exception:
+            pass
+        try:
+            cc_total += sum(b.complexity for b in cc_visit(src))
+        except Exception:
+            pass
+        try:
+            loc_total += raw_analyze(src).loc
+        except Exception:
+            pass
+    return {
+        "mi": round(sum(mis) / len(mis), 2) if mis else None,
+        "cc": cc_total,
+        "loc": loc_total,
+        # Not computed here (need SonarQube measures); null, not zero.
+        "cs": None, "codu": None, "code": None,
+    }
+
+
 @router.post("/api/session/{session_id}/confirm-findings")
 async def confirm_findings(session_id: str):
     """Confirm or refute each static finding individually by execution.
@@ -236,12 +282,25 @@ async def run_analysis(req: dict):
         sid, used_repaired, used_original,
     )
 
+    # Real code metrics for this round, computed from the analysed source via
+    # Radon (MI, CC, LoC), not faked from severity buckets. Averaged/summed
+    # across the analysed units. These feed the "paper metrics" panel honestly;
+    # metrics that need SonarQube measures (cognitive complexity, duplication,
+    # comment density) are left null when unavailable rather than shown as zero.
+    metrics = _round_code_metrics(
+        [state["analysed_units"][u.original_path.name].code_unit.source_code
+         for u in state["units"]
+         if u.original_path.name in selected_files
+         and u.original_path.name in state["analysed_units"]]
+    )
+
     summary = {
         "total": len(all_findings),
         "by_severity": {
             s: len([f for f in all_findings if f.severity == s])
             for s in ["CRITICAL", "HIGH", "MEDIUM", "LOW"]
         },
+        "metrics": metrics,
     }
     # Store a compact fingerprint of each finding so the re-analyse view can
     # diff rounds and show which findings were resolved, which are new, and
@@ -279,15 +338,19 @@ async def get_paper_metrics_history(session_id: str):
     state = get_state(session_id)
     rounds_data = []
     for i, ar in enumerate(state.get("analysis_rounds", [])):
+        m = ar.get("metrics") or {}
         rounds_data.append({
             "round": i,
             "label": "Baseline" if i == 0 else f"Round {i}",
-            "cs": ar.get("by_severity", {}).get("HIGH", 0) + ar.get("by_severity", {}).get("CRITICAL", 0),
-            "mi": 0,  # Would need radon re-run for real MI
-            "codu": 0,
-            "code": 0,
-            "loc": 0,
-            "cc": ar.get("by_severity", {}).get("MEDIUM", 0),
+            # Real metrics computed from the round's source. null where a metric
+            # is not available (e.g. SonarQube measures not retained per round),
+            # rather than fabricated as zero.
+            "cs": m.get("cs"),
+            "mi": m.get("mi"),
+            "codu": m.get("codu"),
+            "code": m.get("code"),
+            "loc": m.get("loc"),
+            "cc": m.get("cc"),
         })
     return {"rounds": rounds_data}
 
@@ -301,18 +364,27 @@ async def get_comparisons(session_id: str):
     for i in range(1, len(rounds)):
         prev = rounds[i - 1]
         curr = rounds[i]
+        cm = curr.get("metrics") or {}
+        bm = rounds[0].get("metrics") or {}
+
+        def _delta(a, b):
+            # Delta only when both ends are real numbers; else null.
+            return (a - b) if isinstance(a, (int, float)) and isinstance(b, (int, float)) else None
+
         comparisons.append({
             "round": i,
             "vs_baseline": {
-                "cs_delta": curr.get("total", 0) - rounds[0].get("total", 0),
-                "mi_delta": 0,
-                "codu_delta": 0,
-                "code_delta": 0,
-                "loc_delta": 0,
-                "cc_delta": 0,
+                "cs_delta": _delta(cm.get("cs"), bm.get("cs")),
+                "mi_delta": _delta(cm.get("mi"), bm.get("mi")),
+                "codu_delta": _delta(cm.get("codu"), bm.get("codu")),
+                "code_delta": _delta(cm.get("code"), bm.get("code")),
+                "loc_delta": _delta(cm.get("loc"), bm.get("loc")),
+                "cc_delta": _delta(cm.get("cc"), bm.get("cc")),
+                # Total findings delta is a real, separate signal worth keeping.
+                "findings_delta": curr.get("total", 0) - rounds[0].get("total", 0),
             },
             "vs_previous": {
-                "cs_delta": curr.get("total", 0) - prev.get("total", 0),
+                "findings_delta": curr.get("total", 0) - prev.get("total", 0),
             },
         })
     return {"comparisons": comparisons}

--- a/web/frontend/src/screens/PaperMetricsPanel.tsx
+++ b/web/frontend/src/screens/PaperMetricsPanel.tsx
@@ -1,23 +1,30 @@
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer, Legend } from "recharts";
 
 interface PaperMetrics {
-  cs: number;
-  mi: number;
-  codu: number;
-  code: number;
-  loc: number;
-  cc: number;
+  cs: number | null;
+  mi: number | null;
+  codu: number | null;
+  code: number | null;
+  loc: number | null;
+  cc: number | null;
   round?: number;
   label?: string;
 }
 
 interface Comparison {
   round: number;
-  vs_baseline?: Record<string, number>;
-  vs_previous?: Record<string, number>;
+  vs_baseline?: Record<string, number | null>;
+  vs_previous?: Record<string, number | null>;
 }
 
-function DeltaBadge({ value, inverted }: { value: number; inverted?: boolean }) {
+function fmtMetric(v: number | null | undefined): string {
+  return v === null || v === undefined ? "\u2014" : String(v);
+}
+
+function DeltaBadge({ value, inverted }: { value: number | null | undefined; inverted?: boolean }) {
+  if (value === null || value === undefined) {
+    return <span className="inline-block rounded-md bg-slate-100 px-1.5 py-0.5 text-xs font-medium text-slate-400">{"\u2014"}</span>;
+  }
   const improved = inverted ? value > 0 : value < 0;
   const cls = improved
     ? "bg-emerald-100 text-emerald-800"
@@ -70,12 +77,12 @@ export default function PaperMetricsPanel({
             {rounds.map((r, i) => (
               <tr key={i} className={`border-b border-slate-100 ${i === 0 ? "bg-slate-50 font-medium" : "hover:bg-slate-50"}`}>
                 <td className="px-3 py-2">{r.label || (r.round === 0 ? "Baseline" : `Round ${r.round}`)}</td>
-                <td className="px-3 py-2">{r.cs}</td>
-                <td className="px-3 py-2">{r.mi}</td>
-                <td className="px-3 py-2">{r.codu}</td>
-                <td className="px-3 py-2">{r.code}</td>
-                <td className="px-3 py-2">{r.loc}</td>
-                <td className="px-3 py-2">{r.cc}</td>
+                <td className="px-3 py-2">{fmtMetric(r.cs)}</td>
+                <td className="px-3 py-2">{fmtMetric(r.mi)}</td>
+                <td className="px-3 py-2">{fmtMetric(r.codu)}</td>
+                <td className="px-3 py-2">{fmtMetric(r.code)}</td>
+                <td className="px-3 py-2">{fmtMetric(r.loc)}</td>
+                <td className="px-3 py-2">{fmtMetric(r.cc)}</td>
               </tr>
             ))}
           </tbody>
@@ -89,27 +96,27 @@ export default function PaperMetricsPanel({
           <div className="grid grid-cols-3 gap-3 sm:grid-cols-6">
             <div className="text-center">
               <div className="text-xs text-slate-500">CS</div>
-              <DeltaBadge value={latestComparison.vs_baseline.cs_delta || 0} />
+              <DeltaBadge value={latestComparison.vs_baseline.cs_delta} />
             </div>
             <div className="text-center">
               <div className="text-xs text-slate-500">MI</div>
-              <DeltaBadge value={latestComparison.vs_baseline.mi_delta || 0} inverted />
+              <DeltaBadge value={latestComparison.vs_baseline.mi_delta} inverted />
             </div>
             <div className="text-center">
               <div className="text-xs text-slate-500">CoDu</div>
-              <DeltaBadge value={latestComparison.vs_baseline.codu_delta || 0} />
+              <DeltaBadge value={latestComparison.vs_baseline.codu_delta} />
             </div>
             <div className="text-center">
               <div className="text-xs text-slate-500">CoDe</div>
-              <DeltaBadge value={latestComparison.vs_baseline.code_delta || 0} inverted />
+              <DeltaBadge value={latestComparison.vs_baseline.code_delta} inverted />
             </div>
             <div className="text-center">
               <div className="text-xs text-slate-500">LoC</div>
-              <DeltaBadge value={latestComparison.vs_baseline.loc_delta || 0} />
+              <DeltaBadge value={latestComparison.vs_baseline.loc_delta} />
             </div>
             <div className="text-center">
               <div className="text-xs text-slate-500">CC</div>
-              <DeltaBadge value={latestComparison.vs_baseline.cc_delta || 0} inverted />
+              <DeltaBadge value={latestComparison.vs_baseline.cc_delta} inverted />
             </div>
           </div>
         </div>

--- a/web/frontend/src/screens/ReanalyseScreen.tsx
+++ b/web/frontend/src/screens/ReanalyseScreen.tsx
@@ -193,6 +193,13 @@ function FindingsDiff({ rounds }: { rounds: AnalysisRound[] }) {
   );
 }
 
+const DIFF_SEV_CLS: Record<string, string> = {
+  CRITICAL: "bg-red-100 text-red-800",
+  HIGH: "bg-orange-100 text-orange-800",
+  MEDIUM: "bg-yellow-100 text-yellow-800",
+  LOW: "bg-blue-100 text-blue-800",
+};
+
 function DiffGroup({ title, count, items, icon, tone, collapsed }: {
   title: string; count: number; items: RoundFinding[];
   icon: React.ReactNode; tone: string; collapsed?: boolean;
@@ -207,16 +214,29 @@ function DiffGroup({ title, count, items, icon, tone, collapsed }: {
       <summary className={`flex cursor-pointer items-center gap-2 text-sm font-semibold ${tone}`}>
         {icon}{title}: {count}
       </summary>
-      <ul className="mt-2 space-y-1">
-        {items.map((f, i) => (
-          <li key={i} className="flex flex-wrap items-center gap-2 rounded-md border border-slate-100 bg-slate-50/60 px-2 py-1.5 text-xs">
-            <span className="rounded bg-slate-200 px-1.5 py-0.5 font-medium text-slate-700">{f.tool}</span>
-            {f.rule_id && <span className="font-mono text-slate-500">{f.rule_id}</span>}
-            <span className="font-mono text-[10px] text-slate-400">{f.file || "\u2014"}:{f.line ?? "\u2014"}</span>
-            <span className="text-slate-600">{f.message}</span>
-          </li>
-        ))}
-      </ul>
+      {/* Same column layout as the baseline findings table: severity, tool,
+          location, message. Keeps the two views visually consistent. */}
+      <table className="mt-2 w-full text-left text-xs">
+        <tbody className="divide-y divide-slate-100">
+          {items.map((f, i) => (
+            <tr key={i} className="hover:bg-slate-50/80">
+              <td className="px-3 py-2 align-top">
+                <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${DIFF_SEV_CLS[f.severity] || "bg-slate-100 text-slate-600"}`}>
+                  {f.severity}
+                </span>
+              </td>
+              <td className="px-3 py-2 align-top font-medium text-slate-600">
+                {f.tool}
+                {f.rule_id && <span className="ml-1.5 font-mono text-[10px] text-slate-400">{f.rule_id}</span>}
+              </td>
+              <td className="px-3 py-2 align-top">
+                <span className="font-mono text-[10px] text-slate-500">{f.file || "\u2014"}:{f.line ?? "\u2014"}</span>
+              </td>
+              <td className="px-3 py-2 align-top leading-relaxed text-slate-600">{f.message}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
     </details>
   );
 }


### PR DESCRIPTION
The "paper metrics" panel showed Round 1 as all zeros (screenshot). Root cause: the metrics were fabricated from severity buckets, cs = HIGH+CRITICAL count, cc = MEDIUM count, and mi/codu/code/loc hardcoded to 0. At round 1 every finding was LOW severity, so those buckets were empty and the metrics read zero. The comparisons endpoint fabricated the same way. It looked like it worked but the numbers were not the metrics they claimed to be.

Fix: compute real metrics. _round_code_metrics derives MI (averaged), CC (summed), and LoC (summed) from each round's analysed source via Radon, stored on the round record. Metrics that genuinely need SonarQube measures (cognitive complexity cs, duplication codu, comment density code) are reported as null rather than fabricated as zero. The metrics-history and comparisons endpoints read the real stored values; the frontend renders null as an em-dash and the delta badges handle null. A metric is now either real or visibly absent.

Also:
- Removed $BUILDPLATFORM from docker-compose.yml and Dockerfile. It is a buildx-only variable and is empty under plain `docker compose build`, which caused the undefined-variable warning. Builds now use the host's native platform, which is what the single-node VM deployment wants.
- Restyled the re-analyse "What changed" diff rows to match the baseline findings table layout (severity badge, tool + rule, location, message), so the two views are visually consistent.

Frontend builds clean; backend suite 729 passed; ruff clean.