### PR TITLE
fix(ui): correctness oracle, unit labels in live table, expandable diff

### DIFF
--- a/src/qallm/api/routers/analysis.py
+++ b/src/qallm/api/routers/analysis.py
@@ -302,14 +302,14 @@ async def run_analysis(req: dict):
         },
         "metrics": metrics,
     }
-    # Store a compact fingerprint of each finding so the re-analyse view can
-    # diff rounds and show which findings were resolved, which are new, and
-    # which persist, not just the totals. Keyed fields are enough to identify a
-    # finding across rounds without storing full snippets.
+    # Store a per-finding record so the re-analyse view can diff rounds (which
+    # findings were resolved, introduced, or persist) AND expand each one to its
+    # detail, the same as the baseline view. code_snippet is included so the
+    # diff rows can show the offending code, matching the baseline finding rows.
     round_findings = [
         {"tool": f.tool, "type": f.type, "severity": f.severity,
          "file": f.file, "line": f.line, "rule_id": f.rule_id,
-         "message": f.message}
+         "message": f.message, "code_snippet": f.code_snippet}
         for f in all_findings
     ]
     state["analysis_rounds"].append({

--- a/web/frontend/src/screens/ReanalyseScreen.tsx
+++ b/web/frontend/src/screens/ReanalyseScreen.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect } from "react";
-import { RotateCw, TrendingUp, AlertTriangle, Layers, CheckCircle2, PlusCircle, MinusCircle } from "lucide-react";
+import { RotateCw, TrendingUp, AlertTriangle, Layers, CheckCircle2, PlusCircle, MinusCircle, ChevronRight } from "lucide-react";
 import { BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip, ResponsiveContainer } from "recharts";
 import { StatCard } from "../components/Shared";
 import type { SessionState } from "../hooks/useSession";
@@ -214,29 +214,63 @@ function DiffGroup({ title, count, items, icon, tone, collapsed }: {
       <summary className={`flex cursor-pointer items-center gap-2 text-sm font-semibold ${tone}`}>
         {icon}{title}: {count}
       </summary>
-      {/* Same column layout as the baseline findings table: severity, tool,
-          location, message. Keeps the two views visually consistent. */}
+      {/* Same column layout as the baseline findings table, and rows expand to
+          the same detail (type, rule, line, code snippet) that Koen asked for. */}
       <table className="mt-2 w-full text-left text-xs">
         <tbody className="divide-y divide-slate-100">
-          {items.map((f, i) => (
-            <tr key={i} className="hover:bg-slate-50/80">
-              <td className="px-3 py-2 align-top">
-                <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${DIFF_SEV_CLS[f.severity] || "bg-slate-100 text-slate-600"}`}>
-                  {f.severity}
-                </span>
-              </td>
-              <td className="px-3 py-2 align-top font-medium text-slate-600">
-                {f.tool}
-                {f.rule_id && <span className="ml-1.5 font-mono text-[10px] text-slate-400">{f.rule_id}</span>}
-              </td>
-              <td className="px-3 py-2 align-top">
-                <span className="font-mono text-[10px] text-slate-500">{f.file || "\u2014"}:{f.line ?? "\u2014"}</span>
-              </td>
-              <td className="px-3 py-2 align-top leading-relaxed text-slate-600">{f.message}</td>
-            </tr>
-          ))}
+          {items.map((f, i) => <DiffFindingRow key={i} f={f} />)}
         </tbody>
       </table>
     </details>
+  );
+}
+
+function DiffFindingRow({ f }: { f: RoundFinding }) {
+  const [open, setOpen] = useState(false);
+  const hasDetail = Boolean(f.code_snippet || f.rule_id || f.type);
+  return (
+    <>
+      <tr
+        onClick={hasDetail ? () => setOpen(o => !o) : undefined}
+        className={`${hasDetail ? "cursor-pointer hover:bg-slate-50/80" : ""} ${open ? "bg-slate-50" : ""}`}
+      >
+        <td className="px-3 py-2 align-top">
+          <div className="flex items-center gap-1.5">
+            {hasDetail && <ChevronRight className={`h-3.5 w-3.5 text-slate-400 transition-transform ${open ? "rotate-90" : ""}`} />}
+            <span className={`rounded-md px-2 py-0.5 text-[10px] font-bold uppercase tracking-wide ${DIFF_SEV_CLS[f.severity] || "bg-slate-100 text-slate-600"}`}>
+              {f.severity}
+            </span>
+          </div>
+        </td>
+        <td className="px-3 py-2 align-top font-medium text-slate-600">
+          {f.tool}
+          {f.rule_id && <span className="ml-1.5 font-mono text-[10px] text-slate-400">{f.rule_id}</span>}
+        </td>
+        <td className="px-3 py-2 align-top">
+          <span className="font-mono text-[10px] text-slate-500">{f.file || "\u2014"}:{f.line ?? "\u2014"}</span>
+        </td>
+        <td className="px-3 py-2 align-top leading-relaxed text-slate-600">{f.message}</td>
+      </tr>
+      {open && (
+        <tr className="bg-slate-50">
+          <td colSpan={4} className="px-3 pb-3 pt-0">
+            <div className="rounded-lg border border-slate-200 bg-white p-3 text-xs">
+              <div className="flex flex-wrap gap-x-6 gap-y-1 text-slate-600">
+                {f.type && <span><span className="font-semibold text-slate-700">Type:</span> {f.type}</span>}
+                {f.rule_id && <span><span className="font-semibold text-slate-700">Rule:</span> <span className="font-mono">{f.rule_id}</span></span>}
+                <span><span className="font-semibold text-slate-700">Tool:</span> {f.tool}</span>
+                {f.line ? <span><span className="font-semibold text-slate-700">Line:</span> {f.line}</span> : null}
+              </div>
+              <p className="mt-2 text-slate-600">{f.message}</p>
+              {f.code_snippet && (
+                <pre className="mt-2 overflow-auto rounded-md bg-slate-900 p-3 font-mono text-[11px] leading-relaxed text-slate-100">
+                  {f.code_snippet}
+                </pre>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }

--- a/web/frontend/src/screens/TestGenScreen.tsx
+++ b/web/frontend/src/screens/TestGenScreen.tsx
@@ -7,6 +7,7 @@ import type { JobProgress } from "../api";
 
 const ORACLES: Record<string, { title: string; desc: string }> = {
   crash: { title: "Crash oracle", desc: "Feeds edge cases (empty inputs, None, overflow) and asserts the function fails cleanly rather than crashing." },
+  correctness: { title: "Correctness oracle", desc: "Reasons from the spec (signature and docstring, never the body) to find functions that do not crash but return wrong values. This is the reliability oracle behind the verification gap." },
   property: { title: "Property oracle", desc: "Checks output invariants: correct return types, size relationships, value range constraints." },
   metamorphic: { title: "Metamorphic oracle", desc: "Tests input/output relationships: permutations, negation, composition. Catches logic bugs without expected outputs." },
 };
@@ -27,6 +28,7 @@ interface ProgressRow {
   roundLabel: string;
   stage: string;
   fn: string | null;
+  unit: string | null;
   fnIndex: number;
   fnTotal: number;
   accepted: number;
@@ -154,6 +156,11 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
         : liveProgress.phase;
     const stage = liveProgress.current_stage || liveProgress.phase;
     const fn = liveProgress.current_function;
+    // current_unit_id looks like "path/to/file.py::cellindex"; show just the
+    // file name so analyse/repair/judge rows (which are unit-level, not
+    // per-function) still say which file they acted on instead of a bare dash.
+    const rawUnit = liveProgress.current_unit_id as string | null | undefined;
+    const unit = rawUnit ? rawUnit.split("::")[0].split("/").pop() || rawUnit : null;
     const key = `${roundLabel}|${stage}|${fn ?? ""}|${liveProgress.function_index}`;
     setTimeline(prev => {
       if (prev.length && prev[prev.length - 1].key === key) return prev;
@@ -162,6 +169,7 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
         roundLabel,
         stage,
         fn,
+        unit,
         fnIndex: liveProgress.function_index,
         fnTotal: liveProgress.function_total,
         accepted: liveProgress.rounds_accepted,
@@ -359,6 +367,8 @@ export default function TestGenScreen({ state, patch, autoMode }: { state: Sessi
                           <td className="px-2 py-1.5 font-mono text-slate-700">
                             {row.fn ? (
                               <span>{row.fn}{row.fnTotal > 0 && <span className="text-slate-400"> ({row.fnIndex}/{row.fnTotal})</span>}</span>
+                            ) : row.unit ? (
+                              <span className="font-mono text-xs text-slate-500">{row.unit}</span>
                             ) : <span className="text-slate-300">—</span>}
                           </td>
                           <td className="px-2 py-1.5 text-right whitespace-nowrap">

--- a/web/frontend/src/screens/UploadScreen.tsx
+++ b/web/frontend/src/screens/UploadScreen.tsx
@@ -27,6 +27,10 @@ const ORACLE_INFO: Record<string, { title: string; desc: string }> = {
     title: "Crash oracle",
     desc: "Feeds edge-case inputs (empty lists, None, zero, overflow) and asserts the function does not raise unhandled exceptions. The simplest but most effective oracle: if the code crashes on valid-typed inputs, it has a bug.",
   },
+  correctness: {
+    title: "Correctness oracle",
+    desc: "Reasons from the spec (signature and docstring only, never the implementation body) to catch functions that run without crashing but return wrong values. This is the reliability oracle behind the verification gap finding.",
+  },
   property: {
     title: "Property oracle",
     desc: "Checks output invariants derivable from docstrings and type hints: correct return types, value range constraints, size relationships. Catches logic errors where the code runs but returns wrong results.",

--- a/web/frontend/src/types.ts
+++ b/web/frontend/src/types.ts
@@ -154,6 +154,7 @@ export interface RoundFinding {
   line?: number;
   rule_id?: string;
   message: string;
+  code_snippet?: string;
 }
 
 export interface AnalysisRound {


### PR DESCRIPTION
Three fixes from run-pipeline screenshot feedback.

1. Correctness oracle was missing from the UI. OracleType in code has four members (crash, correctness, property, metamorphic), but both UI oracle maps (TestGenScreen ORACLES and UploadScreen ORACLE_INFO) listed only three, omitting correctness. Since correctness is the reliability oracle behind the verification gap, its absence was both a sync bug and a confusing gap in the tool. Added to both maps with accurate descriptions (it reasons from the spec, signature and docstring only, never the body). Both screens render the oracle options dynamically from the maps, so it is now selectable.

2. The live verification table showed a bare dash for the analyse, repair, and judge rows, because only verify runs per-function while those stages are unit-level. The progress snapshot already carries current_unit_id, so the frontend now shows the file name on those rows instead of a dash, and keeps the function (with index/total) on verify rows.

3. The re-analyse "What changed" diff rows are now expandable to the same detail as the baseline findings view (type, rule, line, and the offending code snippet), which is the consistency Koen asked for. This required storing code_snippet in the per-round finding records.

Frontend builds clean; backend suite 729 passed; ruff clean.