### PR TITLE
fix: ruff clean repo-wide; mark 91.3% as provisional pre-MD-001 pilot

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ flowchart LR
     Decision -->|With QALLM| Evidence[Answered with<br/>runtime evidence]
 ```
 
-Pilot results across 31 functions, 5 files, and three models (gpt-4o-mini, gpt-5-mini, gemma3:4b) showed a 91.3 percent false confidence rate when relying on static signals alone: code that passed every static check but contained a logic bug surfaced only once it was executed. That finding motivates execution-based verification inside the loop. The verification-strategy ablation supports the design choice: the iterative-feedback verifier found significantly more bugs than the one-shot and Hypothesis baselines (all pairwise Wilcoxon tests at p < 0.005).
+A pilot across 31 functions, 5 files, and three models (gpt-4o-mini, gpt-5-mini, gemma3:4b) indicated a large verification gap: code that passed every static check but contained a logic bug surfaced only once it was executed. The pilot's headline figure (a 91.3 percent false confidence rate) is a provisional estimate produced under the pre-MD-001 protocol and is pending the validated re-run; it is reported here as motivation, not as a final result. The validated figure, with its bootstrap confidence interval, will come from the full MD-001 run. That signal is what motivates execution-based verification inside the loop. The verification-strategy ablation supports the design choice: the iterative-feedback verifier found significantly more bugs than the one-shot and Hypothesis baselines (all pairwise Wilcoxon tests at p < 0.005).
 
 ## EVERSE alignment
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,3 +60,6 @@ where = ["src"]
 [tool.ruff]
 line-length = 88
 target-version = "py310"
+# qallm-demo-case is an intentional demonstration input with deliberate defects
+# (it exists to be analysed, not to pass linting), so it is excluded from ruff.
+extend-exclude = ["qallm-demo-case"]

--- a/tests/test_gap_runner_discovery.py
+++ b/tests/test_gap_runner_discovery.py
@@ -1,7 +1,5 @@
 """Sampling selects a reproducible, size-spanning subset of inputs."""
 
-from pathlib import Path
-
 from qallm.experiments.gap_runner import _sample_inputs
 
 


### PR DESCRIPTION
Acts on the two clean P0/P1 items from the 17 June independent audit.

1. "ruff clean" was inaccurate repo-wide. Two causes: an unused `Path` import in tests/test_gap_runner_discovery.py (removed), and qallm-demo-case, which is an intentional demonstration input with deliberate defects, being linted as if it were project code. Excluded qallm-demo-case from ruff via extend-exclude. `ruff check .` now passes, so the claim is true and can be kept true in CI.

2. The README stated the 91.3% false-confidence figure as a flat result, but the methodology log (MD-001) says it was produced under the pre-MD-001 protocol and must not be reported as a result before the validated re-run. Reworded the README to present it explicitly as a provisional pilot estimate, pending the MD-001 re-run, reported as motivation rather than a final result, with the validated figure (and its bootstrap CI) to come from the full run.

These are the claim-integrity fixes; the larger audit items (retire the consensus apparatus, rename sandbox.py and the isolation docstrings, harden the container, replace the import-* header, run E1 under MD-001) are tracked separately and need decisions before action.