### PR TITLE
Web UI doesn't pass it → keeps using outputs/quality_reporter. Unchan…

### DIFF
--- a/docs/architecture/sessions-vs-experiments.md
+++ b/docs/architecture/sessions-vs-experiments.md
@@ -48,11 +48,24 @@ are not lost, they are simply not mixed into the interactive Sessions tab.
 ## Directory conventions
 
 Interactive sessions: `outputs/quality_reporter/<run_id>` (the orchestrator's
-default reporter base; overridable via `QALLM_SESSIONS_DIR`).
+default reporter base, the configured `QALLM_SESSIONS_DIR`). The web layer does
+not override the reporter dir, so interactive runs land here.
 
-Experiment runs: wherever `--output` points, by convention `runs/<name>`, with
-`results.jsonl`, `manifest.json`, `aggregate.json`, and (under full retention)
-per-unit artefacts.
+Experiment reporter artefacts: written away from the web-UI directory. The batch
+gap runner writes them under its own `--output/reports`, so each experiment run
+is fully self-contained (deleting `runs/<name>` removes its artefacts too). The
+HumanEval runner uses `QALLM_EXPERIMENT_REPORTER_DIR`
+(default `outputs/experiment_reporter`). Either way the orchestrator's
+`reporter_dir` parameter is what selects this; experiments pass it, the web UI
+does not.
+
+Experiment run outputs (results.jsonl, manifest.json, aggregate.json): wherever
+`--output` points, by convention `runs/<name>`.
+
+This matters operationally: a large run creates one reporter subdirectory per
+processed file plus its lineage artefacts, which is tens to hundreds of
+thousands of directories. Keeping that out of `outputs/quality_reporter` is what
+prevents the session directory (and the host disk) from being swamped.
 
 ## Why a marker rather than just separate directories
 

--- a/docs/thesis/session-log.md
+++ b/docs/thesis/session-log.md
@@ -4,6 +4,21 @@ Newest first. Append-only.
 
 ---
 
+## 2026-06-17 (reporter dir separation: experiments stop bloating the web-UI dir)
+
+The orchestrator hardcoded outputs/quality_reporter as its reporter base, so
+experiment runs (one session subdir + lineage per file) bloated the web-UI
+session directory and filled the VM disk. Added a reporter_dir param to the
+orchestrator (defaults to settings.QALLM_SESSIONS_DIR). The web UI does not
+override it; the gap runner now writes reporter artefacts under its own
+--output/reports (self-contained per run), and the HumanEval runner uses
+QALLM_EXPERIMENT_REPORTER_DIR (default outputs/experiment_reporter). New config
+setting + doc update in sessions-vs-experiments.md. +3 tests. Suite 724.
+
+Also gave Mohssin the fast-delete recipe for the already-bloated dir (mv to
+.trash then background rm; or rsync --delete an empty dir over it).
+
+
 ## 2026-06-17 (HumanEvalFix: parallel runner + clearer purpose)
 
 - run_humaneval.py / humaneval_runner.py now take --workers N: combinations run

--- a/src/qallm/config.py
+++ b/src/qallm/config.py
@@ -59,6 +59,14 @@ class Settings:
         "QALLM_SESSIONS_DIR", "outputs/quality_reporter"
     )
 
+    # Reporter base dir for EXPERIMENT runs (batch runner). Kept separate from
+    # QALLM_SESSIONS_DIR so a large experiment, which creates one session
+    # subdirectory per processed file plus its lineage artefacts, never bloats
+    # the Web-UI session directory. Defaults to a sibling under outputs/.
+    QALLM_EXPERIMENT_REPORTER_DIR: str = os.getenv(
+        "QALLM_EXPERIMENT_REPORTER_DIR", "outputs/experiment_reporter"
+    )
+
     # Budget caps. All are floors, not ceilings: code-level ceilings in
     # `qallm.cost` override these if they are too large. The intent is
     # that a typo in this file or an .env cannot blow the budget.

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -204,6 +204,11 @@ def _default_orchestrator_factory(config: GapExperimentConfig):
         judge_strategy=config.judge_strategy,
         artefact_retention=_effective_retention(config),
         stage=config.stage,
+        # Reporter artefacts live UNDER this run's own output dir, not the
+        # shared Web-UI session directory. Each experiment run is then fully
+        # self-contained: deleting runs/<name> removes its artefacts too, and a
+        # large run never bloats outputs/quality_reporter.
+        reporter_dir=str(config.output_dir / "reports"),
     )
 
 

--- a/src/qallm/experiments/humaneval_runner.py
+++ b/src/qallm/experiments/humaneval_runner.py
@@ -364,9 +364,11 @@ def _default_orchestrator_factory(
     rounds: int,
     oracle: str,
     judge_strategy: str,
+    reporter_dir: str | None = None,
 ):
     """Build a real QALLMOrchestrator from a model id like ``openai:gpt-4o-mini``."""
     from qallm.orchestrator import QALLMOrchestrator
+    from qallm.config import settings
     llm_type, _, model_name = model.partition(":")
     return QALLMOrchestrator(
         llm_type=llm_type,
@@ -375,6 +377,9 @@ def _default_orchestrator_factory(
         rounds=rounds,
         oracle=oracle,
         judge_strategy=judge_strategy,
+        # Experiments write reporter artefacts to a separate dir (defaulting to
+        # the experiment reporter dir), never the Web-UI session directory.
+        reporter_dir=reporter_dir or settings.QALLM_EXPERIMENT_REPORTER_DIR,
     )
 
 

--- a/src/qallm/orchestrator.py
+++ b/src/qallm/orchestrator.py
@@ -50,6 +50,7 @@ import uuid
 from typing import Literal, Optional
 
 from qallm.analysis.normalizer import LifecycleStage
+from qallm.config import settings
 from qallm.ingestion.ingestion_manager import IngestionManager
 from qallm.common.model import CodeUnit
 from qallm.cost import BudgetCaps, BudgetState, HaltReason
@@ -134,6 +135,7 @@ class QALLMOrchestrator:
             tags: list[str] | None = None,
             artefact_retention: str = "full",
             origin: str = "experiment",
+            reporter_dir: str | None = None,
     ) -> None:
         """Construct the orchestrator.
 
@@ -186,7 +188,7 @@ class QALLMOrchestrator:
                 + "_" + uuid.uuid4().hex[:8]
             )
             self.reporter = QualityReporter(
-                "outputs/quality_reporter", effective_run_id,
+                reporter_dir or settings.QALLM_SESSIONS_DIR, effective_run_id,
                 artefact_retention=artefact_retention,
                 origin=origin,
             )

--- a/tests/test_reporter_dir_separation.py
+++ b/tests/test_reporter_dir_separation.py
@@ -1,0 +1,24 @@
+"""The orchestrator's reporter dir is configurable, so experiment runs write
+their per-session artefacts away from the Web-UI session directory."""
+
+from qallm.config import settings
+from qallm.orchestrator import QALLMOrchestrator
+
+
+def test_reporter_dir_defaults_to_web_ui_sessions_dir():
+    orch = QALLMOrchestrator(strategy="oneshot", llm_type="fedllm", rounds=1)
+    assert settings.QALLM_SESSIONS_DIR in str(orch.reporter.report_dir)
+
+
+def test_explicit_reporter_dir_is_honoured(tmp_path):
+    target = str(tmp_path / "experiment_artefacts")
+    orch = QALLMOrchestrator(
+        strategy="oneshot", llm_type="fedllm", rounds=1, reporter_dir=target,
+    )
+    assert str(orch.reporter.report_dir).startswith(target)
+
+
+def test_web_ui_and_experiment_dirs_differ_by_default():
+    # The two configured directories are distinct, so a large experiment run
+    # cannot bloat the Web-UI session library directory.
+    assert settings.QALLM_SESSIONS_DIR != settings.QALLM_EXPERIMENT_REPORTER_DIR


### PR DESCRIPTION
…ged.

Gap runner writes reporter artefacts under its own --output/reports, so each experiment run is fully self-contained, deleting runs/<name> removes everything with it. This is the sustainable answer you asked about: no shared growing directory, and cleanup is per-run. HumanEval runner uses a new QALLM_EXPERIMENT_REPORTER_DIR (default outputs/experiment_reporter).