### PR TITLE
docs(experiments): add copy-paste runbook and 2026-06-18 lab calibrat…

### DIFF
--- a/docs/experiments/HOW-TO-RUN-EXPERIMENTS.md
+++ b/docs/experiments/HOW-TO-RUN-EXPERIMENTS.md
@@ -1,4 +1,96 @@
-# QALLM experiment outline
+# How to run the QALLM experiments
+
+If you are unsure what to run, read THIS section only. Copy the block for the
+step you are on, paste it, wait. The rest of the document explains why each step
+exists; you do not need it to run them.
+
+Before any run, once per shell:
+
+    cd ~/qallm-uva
+    source .venv/bin/activate
+    export FEDLLM_API_KEY=...        # from Nafis
+
+## The decision: which command do I run?
+
+- Just want to prove the pipeline works? -> Step 0 (smoke).
+- Validating the instrument against the answer key? -> Step 1 (lab).
+- Want the RQ1 gap counts on real notebooks? -> Step 2 (E1).
+- Want the real gap RATE plus RQ2 and RQ3? -> Step 3 (E2). This is the one the
+  thesis headline needs. RQ1 alone gives a degenerate rate of 1.0.
+- Strategy comparison / "RL beats baseline"? -> Step 4 (HumanEvalFix).
+- Bigger corpus for breadth? -> Step 5 (Li dataset).
+
+## Copy-paste commands
+
+Step 0, smoke test (minutes):
+
+    python scripts/run_gap_experiment.py \
+        --dataset datasets/lab --output runs/smoke \
+        --pattern "*.py" --llm fedllm --rounds 2
+
+Step 1, lab calibration (the control, ~40 min):
+
+    python scripts/run_gap_experiment.py \
+        --dataset datasets/lab --output runs/lab_calibration \
+        --pattern "*.py" --llm fedllm --rounds 5 --oracle correctness \
+        --samples 1 --confirm --mutation-confidence
+
+Step 2, E1 ENVRI headline RQ1 (free, hours):
+
+    python scripts/run_gap_experiment.py \
+        --dataset datasets/envri_forest --output runs/e1_rq1_headline \
+        --pattern "*.ipynb" --llm fedllm --rounds 5 --oracle correctness \
+        --samples 1 --workers 4 --mutation-confidence
+
+Step 3, E2 ENVRI RQ2 + RQ3 + the real gap rate (free, hours). Same as E1 plus
+--confirm. E3 is not a separate run; verified_fix_rate comes out of this one:
+
+    python scripts/run_gap_experiment.py \
+        --dataset datasets/envri_forest --output runs/e2_rq2 \
+        --pattern "*.ipynb" --llm fedllm --rounds 5 --oracle correctness \
+        --samples 1 --workers 4 --confirm --mutation-confidence
+
+Step 4, E4 HumanEvalFix validation + strategy comparison:
+
+    python scripts/run_humaneval.py \
+        --output runs/humaneval --workers 4 --strategy feedback
+    # repeat with --strategy oneshot and --strategy hypothesis to compare
+
+Step 5, Li corpus at scale (free, long; same as E2, bigger dataset):
+
+    python scripts/run_gap_experiment.py \
+        --dataset datasets/li_notebooks --output runs/e4_scale \
+        --pattern "*.ipynb" --llm fedllm --rounds 5 --oracle correctness \
+        --samples 1 --workers 4 --confirm --mutation-confidence
+
+## Knobs you may add to any command
+
+- Fast trial on a subset: --sample 150 --sample-seed 42 --sample-stratify
+- Spend cap on a paid model: --max-cost-usd 5 (halts cleanly at the cap)
+- Switch model: --llm openai --model gpt-4o-mini (or --llm anthropic)
+- Keep full per-round artefacts (large): --retention full
+
+## After a run, send these four files
+
+From the output directory you chose (for example runs/e2_rq2):
+
+    aggregate.json      the count-weighted rates plus the inputs block
+    manifest.json       provenance: commit, model, environment, dataset hash
+    metrics.csv         one row per session, easy to scan
+    results.jsonl       per-session metrics
+
+If unsure of names, run: `find <output_dir> -maxdepth 2 -type f` and send that.
+
+## Reading the result in one glance (metrics.csv columns)
+
+- verification_gap_rate: RQ1. Trustworthy only when confirm was on.
+- confirmation_rate: RQ2. confirmed / (confirmed + refuted).
+- verified_fix_rate: RQ3. verified_fixed / (verified_fixed + not_fixed).
+- not_execution_testable: complexity/maintainability findings, excluded by design.
+- inconclusive: could not be decided (for example security without an oracle).
+- confidence on a gap finding: needs --mutation-confidence AND a working scorer.
+
+---
 
 The full set of runs to produce the thesis results, in order. Each step gives
 the exact command, what it produces, and what to record. Run them from the repo

--- a/docs/experiments/lab-calibration-2026-06-18.md
+++ b/docs/experiments/lab-calibration-2026-06-18.md
@@ -1,0 +1,65 @@
+# Lab calibration reading: correctness oracle, 2026-06-18
+
+Run: `runs/lab_calibration`, commit 095dd53, FedLLM gpt-oss-120b, correctness
+oracle, 5 rounds, samples=1, confirm on, mutation-confidence requested. Four
+sessions, one per lab file. Cost 0.00 USD. This is the instrument validation:
+the lab set has a documented answer key (datasets/lab/MANIFEST.md), so these
+numbers say whether QALLM measures correctly before any headline claim.
+
+## Result against the answer key
+
+| File | Key expectation | Measured | Verdict |
+| --- | --- | --- | --- |
+| reliability_gap | 5 seeded reliability bugs, all found by execution, none by static | static 0, execution-only 5 | PASS, 5/5 recall |
+| clean_control | clean; at most the one known safe_mean false positive | static 0, execution-only 1 (safe_mean) | PASS, expected single FP |
+| complexity_findings | complexity/maintainability findings, no runtime bug, marked not execution testable | static 1, not_execution_testable 1, but also execution-only 1 | PARTIAL, see below |
+| security_findings | Bandit findings; eval and shell confirmable, build_query not | static 4, confirmed 0, inconclusive 3 | PARTIAL, see below |
+
+## What is solid
+
+The headline calibration claim holds: on reliability_gap, the correctness oracle
+recovers all five seeded wrong-value defects (off-by-one, divide-by-max, mutable
+default, None-guard, odd/even), none of which static analysis flagged and none of
+which the crash oracle could ever catch because none of them throws. The failing
+assertions are exact-value comparisons, for example inclusive_range_count(0,10)
+returns 10 where the oracle expects 11. This is the 5/5 reliability recall that
+validates the instrument, and it is the direct contrast with the earlier crash
+oracle run which caught these only incidentally.
+
+clean_control behaves as documented: a single false positive on safe_mean, where
+a generated test asserts safe_mean("") returns None while the code correctly
+raises TypeError on a string. The test is wrong, not the code. Its presence and
+its singularity are both expected.
+
+## Three things to fix or note before this goes in the thesis
+
+1. Mutation confidence did not land. Every finding carries "confidence": null
+   even though --mutation-confidence was set. The mutation scorer is not writing
+   per-finding scores into the artefacts. Without it the gap findings cannot be
+   reported high vs all confidence, which is the soundness check the thesis
+   leans on. This needs a code fix before the headline run, otherwise the E1/E2
+   artefacts will have the same gap.
+
+2. complexity_findings shows an unexpected execution-only bug. The deeply_nested
+   and cryptic functions are meant to be behaviourally correct (complexity is
+   structural). The generated tests failed anyway, for example cryptic(5)
+   returned 15 where the test expected 11, and deeply_nested(None,...) raised.
+   These look like the oracle inferring a wrong specification from the function
+   body, not real defects. This is exactly the weak-oracle artefact class, and
+   it is why item 1 matters: with a confidence score these would likely be
+   low-confidence and separable. Worth a sentence in threats to validity.
+
+3. security_findings confirmed 0, inconclusive 3. The MANIFEST expects the eval
+   and shell findings to be confirmable. Under the current run they all land
+   inconclusive, which matches the documented honest position that execution
+   based security confirmation is hard and out of scope, but it means the lab
+   set does not currently demonstrate a positive RQ2 confirmation. State this
+   as the known limit rather than a target number.
+
+## One-line summary for section 5.1
+
+On a labelled control the correctness oracle recovered all five seeded
+reliability defects (5/5) with the single documented false positive on the clean
+control; complexity and security fixtures exposed the weak-oracle and
+security-inconclusive limits that the confidence layer and threats section
+address.


### PR DESCRIPTION
…ion reading

Rename run-outline.md to HOW-TO-RUN-EXPERIMENTS.md and add a quick-reference section at the top: a decision list (which command for which goal) and copy-paste command blocks for steps 0 to 5, the optional knobs, the four files to send after a run, and a one-glance guide to the metrics.csv columns. The step-by-step rationale that follows is unchanged.

Add lab-calibration-2026-06-18.md: the correctness-oracle calibration reading. reliability_gap 5/5 recall confirmed; clean_control single documented FP; flags three items for the headline run (mutation confidence wrote null, complexity weak-oracle artefact, security inconclusive).