### PR TITLE
fix(verification): unique test identity so same-named tests

### DIFF
--- a/docs/experiments/test-accumulation-findings-2026-06-18.md
+++ b/docs/experiments/test-accumulation-findings-2026-06-18.md
@@ -1,0 +1,76 @@
+# What the round-by-round artefacts show, and the fix
+
+Session 20260618_071812 (reliability_gap, correctness oracle, web UI). I went
+through the per-round test files in lineage and abandoned. Two things stand out:
+one is good and we should lean on it, one is a real bug you correctly spotted.
+
+## Good: tests accumulate and re-run, and the judge uses that
+
+The frozen-and-grow policy is working. Tests generated in round N are kept and
+re-executed against the round N+1 variant, so a repair has to satisfy the whole
+accumulated suite, not just the current round's tests. This is exactly what
+makes the reliability judgment trustworthy: a variant cannot pass by breaking an
+earlier test. The learning curve (more bugs found as rounds progress) is a direct
+consequence. We should keep leaning on this; it is the mechanism behind the
+"verification improves across rounds" story.
+
+## Bug: same-named tests from different rounds collide, and one is lost
+
+You noticed tests with the same name reappearing in later rounds, sometimes with
+different logic. I confirmed it and measured it. In this single five-function
+file, across four rounds, there were 10 carried-over test names, and 5 of those
+were the SAME name with a DIFFERENT body. Concrete example, inclusive_range_count:
+
+    round 0:  def test_start_greater_than_end():
+                  start = 10; end = 0
+                  assert inclusive_range_count(start, end) == expected_count(start, end)
+
+    round 1:  def test_start_greater_than_end():
+                  start, end = 10, 2
+                  assert inclusive_range_count(start, end) == expected_count(start, end)
+
+Same name, genuinely different inputs (10,0 versus 10,2), testing different points
+in the input space. Both are useful. But the consequence was worse than a report
+display issue: when the accumulated tests are stitched into one pytest module,
+Python keeps only the LAST definition of a duplicated function name, so pytest
+silently ran the round-1 version and never executed the round-0 version at all.
+The earlier test was not just lost in the report; it was lost from the run. That
+weakens the no-regression guarantee the accumulation policy is supposed to give.
+
+## The fix (implemented)
+
+Two parts, matching your two observations.
+
+1. Unique test identity. Each stored test now has a `test_id` of the form
+   `r{round}_{hash}`, where the hash is a short, whitespace-normalised digest of
+   the test source. Identical regenerations share a hash (so they are deduplicated
+   rather than stored twice), while same-name-different-logic tests get distinct
+   ids and are both kept.
+
+2. No more shadowing. When tests are concatenated for a run, each `test_*`
+   function is renamed with its id suffix, for example
+   `test_start_greater_than_end__r0_aa5e6de9`. Both versions now execute, and the
+   pytest nodeid carries the provenance. Helper functions and call sites inside
+   the test body are left untouched.
+
+3. Provenance in results. The executor parses the suffix back out of the nodeid,
+   so every TestDetail now carries `origin_round`, `test_id`, and a clean
+   `display_name`. The report (and the web UI) can show the original test name
+   while indicating which round each test came from, which is the round-specific
+   indicator you asked for.
+
+## What this unlocks for the thesis
+
+The accumulation-and-no-regression property is now actually sound, not just
+nominally so, which strengthens the RQ3 verified-fix argument. And because every
+executed test is now tied to a round, we can show, per function, the round in
+which each surviving defect-finding test first appeared. That is a clean way to
+visualise "iterative feedback finds more over rounds" with the provenance to back
+it.
+
+## Note for the web UI (frontend, not in this backend PR)
+
+The data is now present (`origin_round`, `display_name` on each TestDetail). The
+remaining step is purely display: in the clickable per-round test detail, group
+or badge tests by `origin_round`, for example "carried from round 1." No backend
+work is needed for that; it reads the fields this change adds.

--- a/src/qallm/verification/executor.py
+++ b/src/qallm/verification/executor.py
@@ -11,6 +11,7 @@ copies sibling modules so the target code's own imports resolve.
 from __future__ import annotations
 
 import json
+import re
 import logging
 import shutil
 import subprocess
@@ -24,6 +25,26 @@ from qallm.verification.extraction import DependencyMapper
 logger = logging.getLogger(__name__)
 
 DEFAULT_TIMEOUT_SECONDS = 60
+
+
+def _parse_test_provenance(nodeid: str) -> tuple[int | None, str | None, str]:
+    """Recover (origin_round, test_id, display_name) from a pytest nodeid.
+
+    Accumulated tests are suffixed ``__r{round}_{hash}`` (see
+    test_persistence) so same-named tests from different rounds do not shadow
+    one another. This reverses that: it returns the round, the stored-test id,
+    and the original test name with the suffix removed for display. A nodeid
+    without the suffix yields (None, None, original_name).
+    """
+    # nodeid looks like "test_generated.py::test_name__r2_ab12cd34"
+    func = nodeid.split("::")[-1]
+    m = re.search(r"^(?P<base>.+?)__r(?P<round>\d+)_(?P<hash>[0-9a-f]{8})$", func)
+    if not m:
+        return None, None, func
+    base = m.group("base")
+    rnd = int(m.group("round"))
+    test_id = f"r{rnd}_{m.group('hash')}"
+    return rnd, test_id, base
 
 
 def _parse_pytest_json(report_path: Path) -> tuple[list[TestDetail], dict[str, int]]:
@@ -69,10 +90,15 @@ def _parse_pytest_json(report_path: Path) -> tuple[list[TestDetail], dict[str, i
                 message = (prefix + str(longrepr))[:2000]
                 break
 
+        nodeid = test.get("nodeid", "unknown")
+        origin_round, test_id, display_name = _parse_test_provenance(nodeid)
         details.append(TestDetail(
-            name=test.get("nodeid", "unknown"), status=status,
+            name=nodeid, status=status,
             message=message,
             duration_seconds=call_info.get("duration", 0.0) if call_info else 0.0,
+            origin_round=origin_round,
+            test_id=test_id,
+            display_name=display_name,
         ))
 
     return details, counts

--- a/src/qallm/verification/models.py
+++ b/src/qallm/verification/models.py
@@ -79,6 +79,15 @@ class TestDetail:
     status: Literal["passed", "failed", "error", "skipped"]
     message: str | None = None
     duration_seconds: float = 0.0
+    # Provenance recovered from the suffixed nodeid (see test_persistence): the
+    # round the test was generated in, and the unique stored-test id. Both are
+    # None for tests whose name carries no suffix (for example a fresh
+    # PER_ROUND run, or confirm/refute tests that are not accumulated).
+    origin_round: int | None = None
+    test_id: str | None = None
+    # The display name with the provenance suffix stripped, so the report can
+    # show the original test name while still distinguishing rounds.
+    display_name: str | None = None
 
 
 @dataclass

--- a/src/qallm/verification/test_persistence.py
+++ b/src/qallm/verification/test_persistence.py
@@ -34,8 +34,10 @@ for the session.
 
 from __future__ import annotations
 
+import hashlib
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, field
 from enum import Enum
 from pathlib import Path
@@ -113,8 +115,34 @@ class StoredTest:
     # store does not modify it.
     original: GeneratedTest
 
+    @property
+    def content_hash(self) -> str:
+        """Short, stable hash of the test source.
+
+        Two regenerations with identical code share a hash (so they can be
+        deduplicated); the same test name with different logic across rounds
+        gets distinct hashes (so neither is silently lost). Whitespace is
+        normalised so cosmetic reformatting does not change the hash.
+        """
+        normalised = re.sub(r"\s+", " ", self.test_code).strip()
+        return hashlib.sha256(normalised.encode("utf-8")).hexdigest()[:8]
+
+    @property
+    def test_id(self) -> str:
+        """Unique identity for this stored test within a function record.
+
+        Round-stamped and content-hashed, so a test carried unchanged from an
+        earlier round, a test regenerated with new logic under the same name,
+        and a genuinely new test are all distinguishable. This is the key the
+        report and the executor should use instead of (filename, test_name),
+        which collapses same-named tests from different rounds.
+        """
+        return f"r{self.generated_in_round}_{self.content_hash}"
+
     def as_dict(self) -> dict:
         d = {
+            "test_id": self.test_id,
+            "content_hash": self.content_hash,
             "test_code": self.test_code,
             "generated_in_round": self.generated_in_round,
             "is_valid": self.is_valid,
@@ -131,15 +159,26 @@ class FunctionRecord:
     session: Optional[TestGenerationSession] = None
 
     def append_test(self, generated: GeneratedTest, round_number: int) -> None:
-        self.tests.append(
-            StoredTest(
-                test_code=generated.test_code,
-                generated_in_round=round_number,
-                is_valid=generated.is_valid,
-                model=generated.model or "unknown",
-                original=generated,
-            )
+        candidate = StoredTest(
+            test_code=generated.test_code,
+            generated_in_round=round_number,
+            is_valid=generated.is_valid,
+            model=generated.model or "unknown",
+            original=generated,
         )
+        # Deduplicate: if an identical test (same normalised source) was already
+        # stored in an earlier round, keep the earlier one rather than adding a
+        # byte-for-byte copy. This keeps the suite from inflating when a round
+        # regenerates the same test verbatim. A same-named test with *different*
+        # logic has a different content hash and is kept as a distinct entry.
+        existing_hashes = {t.content_hash for t in self.tests}
+        if candidate.content_hash in existing_hashes:
+            logger.debug(
+                "skip duplicate test (hash %s) regenerated in round %d",
+                candidate.content_hash, round_number,
+            )
+            return
+        self.tests.append(candidate)
 
     def valid_tests(self) -> List[StoredTest]:
         return [t for t in self.tests if t.is_valid]

--- a/src/qallm/verification/verification_manager.py
+++ b/src/qallm/verification/verification_manager.py
@@ -15,6 +15,7 @@ After each function completes, artifacts are saved immediately to disk.
 import dataclasses
 import json
 import logging
+import re
 import time
 import ast as _ast
 from dataclasses import asdict
@@ -53,17 +54,41 @@ def _has_test_function(code: str) -> bool:
     )
 
 
+def _suffix_test_functions(test_code: str, suffix: str) -> str:
+    """Append a unique suffix to every top-level ``test_*`` function name.
+
+    When tests from several rounds are stitched into one module, two rounds can
+    define a ``test_*`` function with the same name but different bodies. Python
+    keeps only the last definition, so pytest silently runs one and drops the
+    other, and the dropped test never executes. Suffixing each function with the
+    stored test's unique id keeps every version live and individually
+    identifiable in the pytest nodeid. Only the ``def`` site is renamed; helper
+    functions and references inside the body are left untouched because each
+    stored test is self-contained.
+    """
+    return re.sub(
+        r"(?m)^(def\s+)(test_\w+)(\s*\()",
+        lambda m: f"{m.group(1)}{m.group(2)}__{suffix}{m.group(3)}",
+        test_code,
+    )
+
+
 def _concatenate_test_codes(stored: list[StoredTest]) -> str:
     """Combine multiple stored test files into a single pytest module.
 
-    Each test's source is included with a small header indicating its origin
-    round. pytest is happy with multiple `def test_*` functions in one file
-    and we get a single coverage report.
+    Each test's source is included with a header indicating its origin round,
+    and its ``test_*`` functions are suffixed with the stored test's unique id
+    so that same-named tests from different rounds do not shadow one another.
+    pytest is happy with multiple ``def test_*`` functions in one file and we
+    get a single coverage report.
     """
     parts: list[str] = []
     for i, t in enumerate(stored):
-        parts.append(f"# --- stored test {i + 1} (generated in round {t.generated_in_round}) ---")
-        parts.append(t.test_code.strip())
+        parts.append(
+            f"# --- stored test {i + 1} "
+            f"(id {t.test_id}, generated in round {t.generated_in_round}) ---"
+        )
+        parts.append(_suffix_test_functions(t.test_code.strip(), t.test_id))
         parts.append("")  # blank line between blocks
     return "\n".join(parts)
 

--- a/tests/test_test_persistence.py
+++ b/tests/test_test_persistence.py
@@ -239,8 +239,12 @@ class TestSummary:
         key_a = TestSuiteStore.make_key(src_a, -1, "f")
         key_b = TestSuiteStore.make_key(src_b, -1, "g")
 
-        store.record_generated(key_a, "f", _make_generated_test(), 1)
-        store.record_generated(key_a, "f", _make_generated_test(), 2)
+        store.record_generated(
+            key_a, "f", _make_generated_test(test_code="def test_a(): assert f() is None"), 1
+        )
+        store.record_generated(
+            key_a, "f", _make_generated_test(test_code="def test_b(): assert f() == None"), 2
+        )
         store.record_generated(key_b, "g", _make_generated_test(), 1)
 
         summary = store.summary()

--- a/tests/test_unique_test_identity.py
+++ b/tests/test_unique_test_identity.py
@@ -1,0 +1,95 @@
+"""Tests for unique test identity across rounds.
+
+Same-named tests generated in different rounds must not shadow one another
+when concatenated into a single pytest module, and their provenance (origin
+round) must be recoverable from the nodeid.
+"""
+from __future__ import annotations
+
+from qallm.verification.executor import _parse_test_provenance
+from qallm.verification.models import GeneratedTest
+from qallm.verification.test_persistence import (
+    FunctionRecord,
+    StoredTest,
+)
+from qallm.verification.verification_manager import (
+    _concatenate_test_codes,
+    _suffix_test_functions,
+)
+
+
+def _gen(code: str, model: str = "m") -> GeneratedTest:
+    return GeneratedTest(
+        function_name="f", oracle="correctness", test_code=code,
+        is_valid=True, model=model,
+    )
+
+
+def _stored(code: str, rnd: int) -> StoredTest:
+    return StoredTest(
+        test_code=code, generated_in_round=rnd, is_valid=True,
+        model="m", original=_gen(code),
+    )
+
+
+class TestContentHashAndId:
+    def test_identical_code_same_hash(self) -> None:
+        a = _stored("def test_x(): assert True", 0)
+        b = _stored("def test_x():   assert True  ", 1)  # whitespace only
+        assert a.content_hash == b.content_hash
+
+    def test_different_logic_different_hash(self) -> None:
+        a = _stored("def test_x(): assert f(1, 5) == 4", 0)
+        b = _stored("def test_x(): assert f(1, 5) == 5", 1)
+        assert a.content_hash != b.content_hash
+
+    def test_test_id_is_round_stamped(self) -> None:
+        s = _stored("def test_x(): assert True", 3)
+        assert s.test_id.startswith("r3_")
+
+
+class TestDeduplication:
+    def test_identical_regeneration_is_deduped(self) -> None:
+        rec = FunctionRecord(function_name="f")
+        rec.append_test(_gen("def test_x(): assert True"), 0)
+        rec.append_test(_gen("def test_x(): assert True"), 1)
+        assert len(rec.tests) == 1
+
+    def test_different_logic_is_kept(self) -> None:
+        rec = FunctionRecord(function_name="f")
+        rec.append_test(_gen("def test_x(): assert f() == 1"), 0)
+        rec.append_test(_gen("def test_x(): assert f() == 2"), 1)
+        assert len(rec.tests) == 2
+
+
+class TestSuffixing:
+    def test_same_name_different_rounds_both_survive(self) -> None:
+        s0 = _stored("def test_x(): assert f(1, 5) == 4", 0)
+        s1 = _stored("def test_x(): assert f(1, 5) == 5", 1)
+        out = _concatenate_test_codes([s0, s1])
+        import re
+        names = re.findall(r"def (test_\w+)\(", out)
+        assert len(set(names)) == 2, "both versions must survive, not shadow"
+        assert all("__r" in n for n in names)
+
+    def test_helper_functions_not_renamed(self) -> None:
+        code = "def helper(): return 1\n\ndef test_x(): assert helper() == 1"
+        out = _suffix_test_functions(code, "r0_abcd1234")
+        assert "def helper():" in out
+        assert "def test_x__r0_abcd1234(" in out
+        assert "helper() == 1" in out  # call site preserved
+
+
+class TestProvenanceParsing:
+    def test_round_trip(self) -> None:
+        nodeid = "test_generated.py::test_start_greater_than_end__r2_ab12cd34"
+        rnd, test_id, display = _parse_test_provenance(nodeid)
+        assert rnd == 2
+        assert test_id == "r2_ab12cd34"
+        assert display == "test_start_greater_than_end"
+
+    def test_unsuffixed_nodeid(self) -> None:
+        rnd, test_id, display = _parse_test_provenance("test_generated.py::test_plain")
+        assert rnd is None
+        assert test_id is None
+        assert display == "test_plain"


### PR DESCRIPTION
 across rounds do not collide

Same-named tests generated in different rounds were stitched into one pytest module by _concatenate_test_codes; Python keeps only the last definition of a duplicated function name, so pytest silently ran one and never executed the other. The earlier round's test was lost from the run, not just the report, weakening the no-regression guarantee of frozen-and-grow accumulation.

- StoredTest gains content_hash (whitespace-normalised digest) and test_id (r{round}_{hash}). FunctionRecord.append_test deduplicates byte-identical regenerations while keeping same-name-different-logic tests as distinct entries.
- _concatenate_test_codes suffixes each test_* function with its test_id, so every version executes and is individually identifiable; helper functions and call sites are left untouched.
- executor parses the suffix back out of the nodeid; TestDetail gains origin_round, test_id, and display_name so the report and web UI can show the original name and indicate which round each test came from.

Adds tests/test_unique_test_identity.py (9 tests). Updates one persistence test that relied on identical tests being stored twice (now deduplicated). Full suite 733 passed, ruff clean. Adds docs/experiments/test-accumulation-findings.