### PR TITLE
feat(ui,verification): outcome-type test filter and baseline-0 round …

### DIFF
--- a/docs/thesis/methodology-decisions.md
+++ b/docs/thesis/methodology-decisions.md
@@ -104,3 +104,26 @@ the mismatch; the fixture now uses the real naming.
 
 **Implication**: RQ2/RQ3 should be re-run; the confirmation and verified-fix
 rates that previously read as null/zero are expected to populate.
+
+
+## MD-004: verification round numbering aligned to the baseline-0 convention
+
+**Date**: 2026-06-18
+
+**Decision**: the verification session's `RoundResult.round_number` now uses the
+orchestrator's round number, where 0 is the baseline (original code, no repair)
+and 1..N are improvement rounds. It previously used a session-local 1-indexed
+counter, so `verification.json` labelled the baseline as "round 1".
+
+**Why**: the orchestrator, the gap metrics, and the lineage directories all use
+round 0 for the baseline (see MD-003). Only the verification session was out of
+step, which made the same baseline appear as "round 0" in one artefact and
+"round 1" in another. `verify()` appends exactly one `RoundResult` per
+orchestrator round, so stamping it with the orchestrator round is unambiguous.
+The gap runner and results reader already treated `round_number == 0` as the
+baseline, so they need no change.
+
+**Implication**: artefacts are now internally consistent on round numbering.
+Any external tooling that assumed the verification session was 1-indexed should
+read 0 as the baseline. The learning-curve helpers iterate rounds positionally
+and are unaffected.

--- a/src/qallm/verification/verification_manager.py
+++ b/src/qallm/verification/verification_manager.py
@@ -163,8 +163,11 @@ class VerificationManager:
                 models: without this, the orchestrator's snapshot would stay
                 on the previous function's name for the full duration of the
                 next function's LLM call. Signature: ``(name, idx, total)``.
-            round_number: 1-indexed QALLM round number. Used to label stored
-                tests with their origin round.
+            round_number: the QALLM round number, matching the orchestrator's
+                convention: 0 for the baseline (original code, no repair) and
+                1..N for improvement rounds. Used to label stored tests and the
+                session RoundResult with their origin round. Defaults to 1 for
+                direct callers that are not running a baseline.
         """
         unit = repaired_unit.repaired_code_unit
         source, path = unit.source_code, unit.original_path
@@ -419,7 +422,16 @@ class VerificationManager:
 
             session.rounds.append(
                 RoundResult(
-                    round_number=len(session.rounds) + 1,
+                    # Use the orchestrator's round number, not a session-local
+                    # 1-indexed counter. The orchestrator labels the baseline as
+                    # round 0 (original code, no repair) and improvement rounds
+                    # as 1..N; the gap metrics and lineage already use that
+                    # convention. Stamping the session-local counter here made
+                    # verification.json label the baseline as "round 1", which
+                    # disagreed with every other artefact. verify() appends
+                    # exactly one RoundResult per orchestrator round, so this is
+                    # unambiguous.
+                    round_number=round_number,
                     generated_test=generated_for_record,
                     execution=execution,
                     reward=reward,

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -116,14 +116,70 @@ function Field({ label, body, highlight }: { label: string; body: string; highli
   );
 }
 
+// Outcome types a test result can have, in display order. "failed" is shown
+// as "bug" to match the rest of the UI. Generalising over this list (rather
+// than hardcoding bug/error) means a new status would surface automatically.
+const OUTCOME_ORDER: import("../api").BugTest["status"][] = ["passed", "failed", "error", "skipped"];
+const OUTCOME_LABEL: Record<string, string> = { passed: "pass", failed: "bug", error: "error", skipped: "skipped" };
+const OUTCOME_CHIP: Record<string, string> = {
+  passed: "bg-emerald-50 text-emerald-700 border-emerald-200",
+  failed: "bg-rose-50 text-rose-700 border-rose-200",
+  error: "bg-amber-50 text-amber-700 border-amber-200",
+  skipped: "bg-slate-50 text-slate-500 border-slate-200",
+};
+
 function BugDetailView({ functions }: { functions: import("../api").FunctionBugDetail[] }) {
+  // Which outcome types are present anywhere in this round, in display order.
+  const present = OUTCOME_ORDER.filter((s) =>
+    functions.some((fn) => fn.all_tests.some((t) => t.status === s)),
+  );
+  // Active filter: a set of statuses to show. Starts with all present statuses
+  // (no filtering). Unselecting a chip hides that outcome across every function.
+  const [active, setActive] = useState<Set<string>>(() => new Set(present));
+
   if (!functions.length) {
     return <div className="px-1 py-2 text-xs text-slate-400">No verification results recorded for this round.</div>;
   }
+
+  const toggle = (s: string) =>
+    setActive((prev) => {
+      const next = new Set(prev);
+      if (next.has(s)) next.delete(s); else next.add(s);
+      return next;
+    });
+  const allOn = present.every((s) => active.has(s));
+  const counts: Record<string, number> = {};
+  for (const fn of functions) for (const t of fn.all_tests) counts[t.status] = (counts[t.status] || 0) + 1;
+
   return (
     <div className="space-y-3">
+      {present.length > 1 && (
+        <div className="flex flex-wrap items-center gap-1.5 text-[11px]">
+          <span className="mr-1 font-semibold uppercase tracking-wide text-slate-400">Show</span>
+          {present.map((s) => {
+            const on = active.has(s);
+            return (
+              <button
+                key={s}
+                onClick={() => toggle(s)}
+                aria-pressed={on}
+                className={`rounded-full border px-2 py-0.5 font-medium transition ${on ? OUTCOME_CHIP[s] : "border-slate-200 bg-white text-slate-300"}`}
+              >
+                {OUTCOME_LABEL[s]} ({counts[s] || 0})
+              </button>
+            );
+          })}
+          <button
+            onClick={() => setActive(allOn ? new Set() : new Set(present))}
+            className="ml-1 rounded-full px-2 py-0.5 font-medium text-slate-400 underline-offset-2 hover:underline"
+          >
+            {allOn ? "none" : "all"}
+          </button>
+        </div>
+      )}
       {functions.map((fn) => {
         const cov = fn.coverage_percent === null ? "n/a" : `${fn.coverage_percent.toFixed(0)}%`;
+        const shown = fn.all_tests.filter((t) => active.has(t.status));
         return (
           <div key={fn.function} className="rounded-lg border border-slate-100">
             <div className="flex items-center justify-between gap-2 border-b border-slate-100 px-3 py-2">
@@ -149,7 +205,10 @@ function BugDetailView({ functions }: { functions: import("../api").FunctionBugD
               {fn.all_tests.length === 0 && (
                 <div className="px-3 py-2 text-xs text-slate-400">No tests executed.</div>
               )}
-              {fn.all_tests.map((t, i) => {
+              {fn.all_tests.length > 0 && shown.length === 0 && (
+                <div className="px-3 py-2 text-xs text-slate-400">No tests match the selected outcomes.</div>
+              )}
+              {shown.map((t, i) => {
                 const isBug = t.status === "failed";
                 const isErr = t.status === "error";
                 const dot = isBug ? "bg-rose-500" : isErr ? "bg-amber-500" : t.status === "passed" ? "bg-emerald-500" : "bg-slate-300";


### PR DESCRIPTION
…numbering

Two user-requested improvements plus a methodology-log entry.

1. Web UI outcome filter (ImprovementView): the per-round test detail now has toggle chips to show/hide test results by outcome (pass, bug, error, skipped). Generalised over the status set, so the chips reflect whichever outcomes are present and a new status would appear automatically. Includes per-outcome counts and an all/none toggle.

2. Round numbering aligned to baseline-0 (verification_manager): RoundResult now carries the orchestrator's round number instead of a session-local 1-indexed counter, so the baseline reads as round 0 in verification.json, consistent with the gap metrics, lineage directories, and the round-0 convention from MD-003. verify() appends one RoundResult per orchestrator round, so this is unambiguous; gap runner and results reader already treated round 0 as the baseline.

3. docs/thesis/methodology-decisions.md: MD-004 records the round-numbering alignment for committee auditability.

Full suite 733 passed, ruff clean, frontend vite build clean.