### PR TITLE
feat(analysis): cross-evaluation, judge every variant by the same fin…

### DIFF
--- a/docs/experiments/cross-evaluation-2026-06-18.md
+++ b/docs/experiments/cross-evaluation-2026-06-18.md
@@ -1,0 +1,52 @@
+# Cross-evaluation: judging every variant by the same final test suite
+
+This note records the first cross-evaluation result and what it shows. The
+method is described in MD-005.
+
+## The problem it solves
+
+In the live loop, round N's accumulated tests run only against round N's code
+variant. So the reliability numbers the judge compares (test_pass_rate,
+bugs_caught) are each measured against a different test suite. A variant can
+look stronger merely because its round generated gentler tests. That is not a
+sound basis for comparing variants.
+
+Cross-evaluation holds the suite fixed: it assembles each function's final
+accumulated suite and runs it against every variant (baseline, accepted, and
+abandoned). Every cell is then measured against the same yardstick.
+
+## First result (reliability_gap lab session)
+
+Final suite versus every variant, pass / fail counts:
+
+| Function | round 0 (baseline) | round 1 (accepted) | round 2 (abandoned) | round 4 (accepted) |
+| --- | --- | --- | --- | --- |
+| inclusive_range_count | 4 / 20 | 23 / 1 | 23 / 1 | 23 / 1 |
+| first_even | 5 / 22 | 25 / 2 | 25 / 2 | 25 / 2 |
+| normalise_unit | 6 / 23 | 22 / 7 | 13 / 16 | 22 / 7 |
+| safe_divide | 18 / 8 | 25 / 1 | 25 / 1 | 25 / 1 |
+| accumulate | 10 / 13 | 18 / 5 | 10 / 13 | 18 / 5 |
+
+## What it shows
+
+1. Repair works, measured fairly. Every function improves sharply from the
+   baseline to the accepted variant under the same suite: inclusive_range_count
+   goes from 4 pass / 20 fail to 23 / 1, first_even from 5 / 22 to 25 / 2. This
+   is the verification-gap repair demonstrated on a common yardstick, not on
+   per-round suites.
+
+2. The judge's abandon decisions hold up. normalise_unit round 2 was abandoned
+   by the judge. Under the common suite it is measurably worse (13 pass / 16
+   fail) than the accepted round-1 variant (22 / 7). accumulate round 2 is
+   likewise back at baseline level (10 / 13). The judge rejected variants that a
+   fair, fixed test suite also rejects, which independently corroborates the
+   lexicographic judge using a comparison the live loop could not make.
+
+## For the thesis
+
+This supports RQ3 (verified fixes) with a common-yardstick comparison and gives
+a concrete, defensible answer to "how do you know an accepted variant is really
+better than an abandoned one?". State the limitation honestly: the final suite
+is generated, so it is the strongest suite the session produced rather than an
+external ground truth; on the labelled lab set it can be cross-checked against
+the MANIFEST answer key.

--- a/docs/thesis/methodology-decisions.md
+++ b/docs/thesis/methodology-decisions.md
@@ -127,3 +127,41 @@ baseline, so they need no change.
 Any external tooling that assumed the verification session was 1-indexed should
 read 0 as the baseline. The learning-curve helpers iterate rounds positionally
 and are unaffected.
+
+
+## MD-005: cross-evaluation, judging variants against a common final test suite
+
+**Date**: 2026-06-18
+
+**Decision**: add a post-hoc cross-evaluation that runs each function's *final*
+accumulated test suite against *every* code variant of that function (baseline,
+accepted, and abandoned). The result is a variant x test-suite matrix in which
+every cell is measured against the same yardstick.
+
+**Why**: in the live loop, round N's tests run only against round N's code
+variant, so `test_pass_rate` and `bugs_caught` are computed against a different
+suite for each variant. Comparing variants on those numbers is apples-to-oranges:
+a variant can look stronger simply because its round generated gentler tests.
+Cross-evaluation removes that confound by holding the test suite fixed across
+variants, which is the sound basis for the reliability comparison the thesis
+makes for RQ3.
+
+**Evidence it works**: on the reliability_gap lab session, the baseline fails
+most of the final suite (for example inclusive_range_count 4 pass / 20 fail)
+while the repaired variant passes nearly all of it (23 pass / 1 fail), and the
+*abandoned* normalise_unit variant is measurably worse under the common suite
+(16 failures) than the accepted one (7 failures). The latter independently
+corroborates the judge's decision to abandon it, using a comparison the live
+loop could not make.
+
+**Scope and safety**: read-only and post-hoc. It reads the persisted source.py
+and tests/ artefacts and does not change the live judging path, so existing
+behaviour and tests are unaffected. It is exposed at
+`GET /api/session/{id}/cross-evaluation` for the comparison-table UI.
+
+**Implication for the thesis**: the RQ3 verified-fix argument can now cite a
+common-yardstick comparison rather than per-round suites, and the abandoned-vs-
+accepted contrast is a concrete demonstration that the judge's decisions hold up
+under a fairer test. A limitation to state: the final suite is itself generated,
+so it is the strongest suite the session produced, not an external ground truth;
+on the labelled set it can be cross-checked against the answer key.

--- a/src/qallm/analysis/cross_evaluation.py
+++ b/src/qallm/analysis/cross_evaluation.py
@@ -1,0 +1,259 @@
+"""Cross-evaluation: run the final accumulated test suite against every code
+variant produced in a session.
+
+Motivation
+----------
+During a live session, round N's tests run only against round N's code variant
+(see verification_manager.verify). Each variant is therefore judged with the
+test suite as it stood at that moment, so ``test_pass_rate`` and ``bugs_caught``
+are measured against *different* suites per round. That is an apples-to-oranges
+comparison: a variant can look stronger merely because its round generated
+gentler tests, not because the code is better.
+
+Cross-evaluation removes that confound. After a session completes, it assembles
+the *final* accumulated test suite per function (the strongest suite the session
+ever produced) and runs it against *every* variant of that function, the
+baseline and every accepted and abandoned variant. The result is a
+variant x test-suite matrix in which every cell is measured against the same
+yardstick, so variants can be compared on equal terms.
+
+This is a post-hoc, read-only analysis. It does not touch the live judging
+loop; it reads the persisted ``source.py`` and ``tests/`` artefacts that the
+reporter already writes per round. It is the data foundation for the round
+comparison table and for a sounder reliability comparison in the thesis.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Optional
+
+from qallm.verification.executor import run_tests
+
+# ----- helpers -----
+
+
+def _read_text(path: str) -> str:
+    try:
+        with open(path, encoding="utf-8") as fh:
+            return fh.read()
+    except OSError:
+        return ""
+
+
+def _content_hash(test_code: str) -> str:
+    """Whitespace-normalised digest, matching test_persistence.StoredTest."""
+    normalised = re.sub(r"\s+", " ", test_code).strip()
+    return hashlib.sha256(normalised.encode("utf-8")).hexdigest()[:8]
+
+
+def _round_no(name: str) -> Optional[int]:
+    try:
+        return int(name.replace("round_", ""))
+    except ValueError:
+        return None
+
+
+# ----- data model -----
+
+
+@dataclass
+class VariantCell:
+    """One cell of the matrix: a final suite run against one variant."""
+
+    function_name: str
+    round_number: int
+    bucket: str  # "lineage" (accepted) or "abandoned" (rejected)
+    passed: int = 0
+    failed: int = 0
+    errors: int = 0
+    skipped: int = 0
+    execution_error: Optional[str] = None
+
+    @property
+    def total(self) -> int:
+        return self.passed + self.failed + self.errors + self.skipped
+
+    @property
+    def outcome(self) -> str:
+        """A single colour-coded outcome for the comparison table.
+
+        green: all tests passed; red: at least one failed (a real defect under
+        the final suite); orange: an execution error prevented a clean verdict.
+        """
+        if self.execution_error or self.errors:
+            return "error"
+        if self.failed:
+            return "fail"
+        if self.passed:
+            return "pass"
+        return "none"
+
+    def to_dict(self) -> dict:
+        return {
+            "function_name": self.function_name,
+            "round_number": self.round_number,
+            "bucket": self.bucket,
+            "passed": self.passed,
+            "failed": self.failed,
+            "errors": self.errors,
+            "skipped": self.skipped,
+            "total": self.total,
+            "outcome": self.outcome,
+            "execution_error": self.execution_error,
+        }
+
+
+@dataclass
+class CrossEvaluation:
+    """The full variant x final-suite matrix for one session."""
+
+    functions: list[str] = field(default_factory=list)
+    rounds: list[int] = field(default_factory=list)
+    cells: list[VariantCell] = field(default_factory=list)
+
+    def to_dict(self) -> dict:
+        return {
+            "functions": self.functions,
+            "rounds": self.rounds,
+            "cells": [c.to_dict() for c in self.cells],
+        }
+
+
+# ----- discovery -----
+
+
+@dataclass
+class _Variant:
+    round_number: int
+    bucket: str
+    source: str
+    unit_dir: str
+
+
+def _discover_variants(report_dir: str) -> list[_Variant]:
+    """Every persisted code variant, baseline plus accepted and abandoned."""
+    variants: list[_Variant] = []
+    for bucket in ("lineage", "abandoned"):
+        bucket_dir = os.path.join(report_dir, bucket)
+        if not os.path.isdir(bucket_dir):
+            continue
+        for round_name in sorted(os.listdir(bucket_dir)):
+            rno = _round_no(round_name)
+            if rno is None:
+                continue
+            round_path = os.path.join(bucket_dir, round_name)
+            if not os.path.isdir(round_path):
+                continue
+            for unit_seg in sorted(os.listdir(round_path)):
+                unit_dir = os.path.join(round_path, unit_seg)
+                source = _read_text(os.path.join(unit_dir, "source.py"))
+                if source:
+                    variants.append(
+                        _Variant(rno, bucket, source, unit_dir)
+                    )
+    return variants
+
+
+def _collect_final_suites(variants: list[_Variant]) -> dict[str, str]:
+    """Per function, the accumulated test suite across all rounds.
+
+    Reads each variant's ``tests/test_<fn>.py`` files and unions them by
+    content hash (so a test carried unchanged across rounds is counted once,
+    while a same-named test with different logic is kept). Returns a mapping
+    from function name to a single concatenated pytest module.
+    """
+    # function -> {hash: test_code}
+    by_function: dict[str, dict[str, str]] = {}
+    for v in variants:
+        tests_dir = os.path.join(v.unit_dir, "tests")
+        if not os.path.isdir(tests_dir):
+            continue
+        for fname in sorted(os.listdir(tests_dir)):
+            if not fname.startswith("test_") or not fname.endswith(".py"):
+                continue
+            func = fname[len("test_"):-len(".py")]
+            code = _read_text(os.path.join(tests_dir, fname))
+            if not code.strip():
+                continue
+            by_function.setdefault(func, {})[_content_hash(code)] = code
+    return {
+        func: "\n\n".join(blocks.values())
+        for func, blocks in by_function.items()
+    }
+
+
+def _function_in_source(source: str, function_name: str) -> bool:
+    return re.search(rf"(?m)^\s*def\s+{re.escape(function_name)}\s*\(", source) is not None
+
+
+def _expected_module_name(suite: str) -> Optional[str]:
+    """The source module name the tests import from.
+
+    Generated tests import the function under test with a line like
+    ``from source_reliability_gap_c0 import inclusive_range_count``. The
+    variant must be written to a file of that exact name or the import fails
+    and pytest collects nothing. Recover the name from the first matching
+    import so cross-evaluation does not depend on reconstructing the pipeline's
+    naming scheme.
+    """
+    m = re.search(r"(?m)^\s*from\s+(source_\w+)\s+import\b", suite)
+    return m.group(1) if m else None
+
+
+# ----- the matrix -----
+
+
+def cross_evaluate(report_dir: str) -> CrossEvaluation:
+    """Run each function's final accumulated suite against every variant.
+
+    Read-only. Safe to call on a completed session's report directory.
+    """
+    variants = _discover_variants(report_dir)
+    final_suites = _collect_final_suites(variants)
+
+    result = CrossEvaluation()
+    result.rounds = sorted({v.round_number for v in variants})
+    result.functions = sorted(final_suites.keys())
+
+    for func, suite in final_suites.items():
+        # The tests import the function from a specific source module name; the
+        # variant must be written under that name or the import fails and no
+        # tests run. Fall back to a generic name if no import is present.
+        expected = _expected_module_name(suite)
+        module_basename = expected or "variant_source"
+        for v in variants:
+            # Only evaluate the suite against variants whose source actually
+            # defines this function; otherwise an import error would masquerade
+            # as a defect.
+            if not _function_in_source(v.source, func):
+                continue
+            exec_result = run_tests(
+                v.source, suite, f"{module_basename}.py", Path(v.unit_dir)
+            )
+            result.cells.append(
+                VariantCell(
+                    function_name=func,
+                    round_number=v.round_number,
+                    bucket=v.bucket,
+                    passed=getattr(exec_result, "passed", 0),
+                    failed=getattr(exec_result, "failed", 0),
+                    errors=getattr(exec_result, "errors", 0),
+                    skipped=getattr(exec_result, "skipped", 0),
+                    execution_error=exec_result.execution_error,
+                )
+            )
+    return result
+
+
+def cross_evaluate_to_json(report_dir: str, out_path: Optional[str] = None) -> dict:
+    """Compute the matrix and optionally write it to ``out_path``."""
+    matrix = cross_evaluate(report_dir).to_dict()
+    if out_path:
+        Path(out_path).write_text(json.dumps(matrix, indent=2), encoding="utf-8")
+    return matrix

--- a/src/qallm/api/routers/results.py
+++ b/src/qallm/api/routers/results.py
@@ -333,6 +333,27 @@ async def get_gap_confidence(session_id: str):
     return result
 
 
+@router.get("/api/session/{session_id}/cross-evaluation")
+async def get_cross_evaluation(session_id: str):
+    """The variant x final-suite matrix for this session.
+
+    Runs each function's final accumulated test suite against every code
+    variant (baseline, accepted, and abandoned), so all variants are compared
+    on the same yardstick. Returns a matrix the UI can render as a comparison
+    table: rows are functions, columns are rounds, each cell is the outcome
+    (pass/fail/error) of the final suite against that variant. Read-only and
+    post-hoc; it does not affect the live judging loop.
+    """
+    report_dir = _resolve_report_dir(session_id)
+    if not report_dir:
+        return {"available": False,
+                "reason": "No run artefacts yet. Run the pipeline first."}
+    from qallm.analysis.cross_evaluation import cross_evaluate
+    matrix = cross_evaluate(report_dir).to_dict()
+    matrix["available"] = True
+    return matrix
+
+
 @router.get("/api/session/{session_id}/metrics")
 async def get_session_metrics(session_id: str):
     """Thesis-ready metrics for one session: run metadata plus the

--- a/tests/test_cross_evaluation.py
+++ b/tests/test_cross_evaluation.py
@@ -1,0 +1,75 @@
+"""Tests for the variant x final-suite cross-evaluation."""
+from __future__ import annotations
+
+from pathlib import Path
+
+from qallm.analysis.cross_evaluation import (
+    _collect_final_suites,
+    _content_hash,
+    _discover_variants,
+    _expected_module_name,
+    _function_in_source,
+    cross_evaluate,
+)
+
+
+def _make_session(tmp: Path) -> str:
+    """A minimal two-round session: a buggy baseline and a repaired variant.
+
+    inclusive_range_count is off-by-one in round 0 (end - start) and fixed in
+    round 1 (end - start + 1). The same test suite is stored in both rounds.
+    """
+    suite = (
+        "import pytest\n"
+        "from source_unit_c0 import inclusive_range_count\n"
+        "def expected(s, e):\n    return e - s + 1\n"
+        "def test_basic():\n    assert inclusive_range_count(0, 10) == expected(0, 10)\n"
+    )
+    buggy = "def inclusive_range_count(start, end):\n    return end - start\n"
+    fixed = "def inclusive_range_count(start, end):\n    return end - start + 1\n"
+
+    for bucket, rnd, src in [("lineage", 0, buggy), ("lineage", 1, fixed)]:
+        unit = tmp / bucket / f"round_{rnd:02d}" / "unit_c0"
+        (unit / "tests").mkdir(parents=True)
+        (unit / "source.py").write_text(src)
+        (unit / "tests" / "test_inclusive_range_count.py").write_text(suite)
+    return str(tmp)
+
+
+class TestHelpers:
+    def test_content_hash_normalises_whitespace(self) -> None:
+        assert _content_hash("def t():  pass") == _content_hash("def t(): pass")
+
+    def test_expected_module_name(self) -> None:
+        suite = "from source_foo_c0 import bar\ndef test_x(): pass"
+        assert _expected_module_name(suite) == "source_foo_c0"
+
+    def test_function_in_source(self) -> None:
+        assert _function_in_source("def foo():\n    pass", "foo")
+        assert not _function_in_source("def bar():\n    pass", "foo")
+
+
+class TestDiscovery:
+    def test_finds_both_variants(self, tmp_path: Path) -> None:
+        report_dir = _make_session(tmp_path)
+        variants = _discover_variants(report_dir)
+        assert len(variants) == 2
+        assert {v.round_number for v in variants} == {0, 1}
+
+    def test_collects_one_suite_per_function(self, tmp_path: Path) -> None:
+        report_dir = _make_session(tmp_path)
+        suites = _collect_final_suites(_discover_variants(report_dir))
+        assert set(suites) == {"inclusive_range_count"}
+
+
+class TestMatrix:
+    def test_baseline_fails_repaired_passes_under_same_suite(self, tmp_path: Path) -> None:
+        report_dir = _make_session(tmp_path)
+        matrix = cross_evaluate(report_dir)
+        by_round = {c.round_number: c for c in matrix.cells}
+        # Same final suite: the off-by-one baseline fails, the repair passes.
+        assert by_round[0].failed >= 1
+        assert by_round[0].outcome == "fail"
+        assert by_round[1].failed == 0
+        assert by_round[1].passed >= 1
+        assert by_round[1].outcome == "pass"


### PR DESCRIPTION
…al test suite

In the live loop, round N's accumulated tests run only against round N's code variant, so test_pass_rate and bugs_caught are each measured against a different suite per variant. Comparing variants on those numbers is apples-to-oranges: a variant can look stronger only because its round generated gentler tests.

Add qallm.analysis.cross_evaluation: a post-hoc, read-only analysis that assembles each function's final accumulated suite (unioned across rounds by content hash) and runs it against every persisted variant (baseline, accepted, abandoned). Produces a variant x suite matrix with a colour-coded outcome per cell, exposed at GET /api/session/{id}/cross-evaluation for a comparison table.

On the reliability_gap lab session it shows repair working under a common yardstick (inclusive_range_count 4/20 -> 23/1) and, crucially, that the judge's abandon decisions hold up: the abandoned normalise_unit variant is measurably worse (13/16) than the accepted one (22/7), corroborating the lexicographic judge with a comparison the live loop cannot make.

Does not touch the live judging path. Adds tests/test_cross_evaluation.py (6), docs/experiments/cross-evaluation-2026-06-18.md, and MD-005. 739 passed, ruff clean.