### PR TITLE
feat(ui): round comparison table with per-test heat map

### DIFF
--- a/src/qallm/analysis/cross_evaluation.py
+++ b/src/qallm/analysis/cross_evaluation.py
@@ -33,7 +33,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Optional
 
-from qallm.verification.executor import run_tests
+from qallm.verification.executor import _parse_test_provenance, run_tests
 
 # ----- helpers -----
 
@@ -63,6 +63,18 @@ def _round_no(name: str) -> Optional[int]:
 
 
 @dataclass
+class CellTest:
+    """One test's outcome within a cell, for the per-test heat map."""
+
+    name: str  # display name, provenance suffix stripped
+    status: str  # passed | failed | error | skipped
+    origin_round: Optional[int] = None  # round the test was generated in
+
+    def to_dict(self) -> dict:
+        return {"name": self.name, "status": self.status, "origin_round": self.origin_round}
+
+
+@dataclass
 class VariantCell:
     """One cell of the matrix: a final suite run against one variant."""
 
@@ -74,6 +86,7 @@ class VariantCell:
     errors: int = 0
     skipped: int = 0
     execution_error: Optional[str] = None
+    tests: list[CellTest] = field(default_factory=list)
 
     @property
     def total(self) -> int:
@@ -106,6 +119,7 @@ class VariantCell:
             "total": self.total,
             "outcome": self.outcome,
             "execution_error": self.execution_error,
+            "tests": [t.to_dict() for t in self.tests],
         }
 
 
@@ -236,6 +250,16 @@ def cross_evaluate(report_dir: str) -> CrossEvaluation:
             exec_result = run_tests(
                 v.source, suite, f"{module_basename}.py", Path(v.unit_dir)
             )
+            cell_tests: list[CellTest] = []
+            for d in getattr(exec_result, "test_details", []) or []:
+                origin, _tid, display = _parse_test_provenance(d.name)
+                cell_tests.append(
+                    CellTest(
+                        name=display,
+                        status=d.status,
+                        origin_round=origin,
+                    )
+                )
             result.cells.append(
                 VariantCell(
                     function_name=func,
@@ -246,6 +270,7 @@ def cross_evaluate(report_dir: str) -> CrossEvaluation:
                     errors=getattr(exec_result, "errors", 0),
                     skipped=getattr(exec_result, "skipped", 0),
                     execution_error=exec_result.execution_error,
+                    tests=cell_tests,
                 )
             )
     return result

--- a/tests/test_cross_evaluation.py
+++ b/tests/test_cross_evaluation.py
@@ -73,3 +73,6 @@ class TestMatrix:
         assert by_round[1].failed == 0
         assert by_round[1].passed >= 1
         assert by_round[1].outcome == "pass"
+        # Per-test detail is populated for the heat map.
+        assert len(by_round[0].tests) >= 1
+        assert by_round[0].tests[0].status in {"passed", "failed", "error", "skipped"}

--- a/web/frontend/src/api.ts
+++ b/web/frontend/src/api.ts
@@ -818,3 +818,37 @@ export async function getDoc(docId: string): Promise<{ id: string; title: string
 export function docRawUrl(docId: string): string {
   return `/api/docs/${encodeURIComponent(docId)}/raw`;
 }
+
+// ----- Cross-evaluation: variant x final-suite matrix -----
+
+export interface CrossEvalCellTest {
+  name: string;
+  status: "passed" | "failed" | "error" | "skipped";
+  origin_round: number | null;
+}
+
+export interface CrossEvalCell {
+  function_name: string;
+  round_number: number;
+  bucket: "lineage" | "abandoned";
+  passed: number;
+  failed: number;
+  errors: number;
+  skipped: number;
+  total: number;
+  outcome: "pass" | "fail" | "error" | "none";
+  execution_error: string | null;
+  tests: CrossEvalCellTest[];
+}
+
+export interface CrossEvaluation {
+  available: boolean;
+  reason?: string;
+  functions: string[];
+  rounds: number[];
+  cells: CrossEvalCell[];
+}
+
+export async function getCrossEvaluation(sid: string): Promise<CrossEvaluation> {
+  return req<CrossEvaluation>(`/api/session/${sid}/cross-evaluation`);
+}

--- a/web/frontend/src/screens/CrossEvalTable.tsx
+++ b/web/frontend/src/screens/CrossEvalTable.tsx
@@ -1,0 +1,173 @@
+import { Fragment, useEffect, useState } from "react";
+import {
+  getCrossEvaluation,
+  type CrossEvaluation,
+  type CrossEvalCell,
+} from "../api";
+
+// Outcome -> cell colour. Green pass, red fail, amber error, grey none.
+const OUTCOME_BG: Record<string, string> = {
+  pass: "bg-emerald-500 text-white",
+  fail: "bg-rose-500 text-white",
+  error: "bg-amber-500 text-white",
+  none: "bg-slate-100 text-slate-400",
+};
+// Per-test status -> small heat cell colour.
+const STATUS_BG: Record<string, string> = {
+  passed: "bg-emerald-500",
+  failed: "bg-rose-500",
+  error: "bg-amber-500",
+  skipped: "bg-slate-300",
+};
+
+function colKey(c: CrossEvalCell): string {
+  return `${c.round_number}:${c.bucket}`;
+}
+function colLabel(round: number, bucket: string): string {
+  const tag = bucket === "abandoned" ? " (aband)" : round === 0 ? " (base)" : "";
+  return `R${round}${tag}`;
+}
+
+export default function CrossEvalTable({ sessionId }: { sessionId: string }) {
+  const [data, setData] = useState<CrossEvaluation | null>(null);
+  const [reason, setReason] = useState<string | null>(null);
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  useEffect(() => {
+    let live = true;
+    getCrossEvaluation(sessionId)
+      .then((res) => {
+        if (!live) return;
+        if (res.available && res.cells.length) setData(res);
+        else setReason(res.reason ?? "No cross-evaluation available yet.");
+      })
+      .catch(() => live && setReason("Could not load cross-evaluation."));
+    return () => {
+      live = false;
+    };
+  }, [sessionId]);
+
+  if (reason) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-4">
+        <h3 className="text-sm font-semibold text-slate-700">Round comparison</h3>
+        <p className="mt-1 text-xs text-slate-400">{reason}</p>
+      </div>
+    );
+  }
+  if (!data) {
+    return (
+      <div className="rounded-xl border border-slate-200 bg-white p-4 text-xs text-slate-400">
+        Loading round comparison…
+      </div>
+    );
+  }
+
+  // Stable ordered columns: every (round, bucket) pair that appears, sorted by
+  // round then accepted-before-abandoned.
+  const colSet = new Map<string, { round: number; bucket: string }>();
+  for (const c of data.cells) colSet.set(colKey(c), { round: c.round_number, bucket: c.bucket });
+  const cols = [...colSet.entries()].sort((a, b) =>
+    a[1].round - b[1].round || (a[1].bucket === "lineage" ? -1 : 1),
+  );
+
+  // index: function -> colKey -> cell
+  const byFn = new Map<string, Map<string, CrossEvalCell>>();
+  for (const c of data.cells) {
+    if (!byFn.has(c.function_name)) byFn.set(c.function_name, new Map());
+    byFn.get(c.function_name)!.set(colKey(c), c);
+  }
+
+  const toggle = (fn: string) =>
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(fn)) next.delete(fn); else next.add(fn);
+      return next;
+    });
+
+  return (
+    <div className="rounded-xl border border-slate-200 bg-white p-4">
+      <div className="flex items-baseline justify-between gap-3">
+        <h3 className="text-sm font-semibold text-slate-700">Round comparison</h3>
+        <p className="text-xs text-slate-400">
+          Final accumulated test suite run against every variant. Click a function for the per-test heat map.
+        </p>
+      </div>
+
+      <div className="mt-3 overflow-x-auto">
+        <table className="w-full border-collapse text-xs">
+          <thead>
+            <tr>
+              <th className="sticky left-0 bg-white px-2 py-1.5 text-left font-semibold text-slate-500">Function</th>
+              {cols.map(([k, m]) => (
+                <th key={k} className="px-2 py-1.5 text-center font-semibold text-slate-500">
+                  {colLabel(m.round, m.bucket)}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {data.functions.map((fn) => {
+              const row = byFn.get(fn) ?? new Map();
+              const isOpen = expanded.has(fn);
+              // Union of test names across this function's cells, in first-seen order.
+              const testNames: string[] = [];
+              const seen = new Set<string>();
+              for (const [, m] of cols) {
+                const cell = row.get(`${m.round}:${m.bucket}`);
+                if (!cell) continue;
+                for (const t of cell.tests) if (!seen.has(t.name)) { seen.add(t.name); testNames.push(t.name); }
+              }
+              return (
+                <Fragment key={fn}>
+                  <tr className="border-t border-slate-100">
+                    <td className="sticky left-0 bg-white px-2 py-1.5">
+                      <button onClick={() => toggle(fn)} className="flex items-center gap-1 font-mono font-medium text-slate-700 hover:text-slate-900">
+                        <span className="text-slate-400">{isOpen ? "▾" : "▸"}</span>
+                        {fn}()
+                      </button>
+                    </td>
+                    {cols.map(([k, m]) => {
+                      const cell = row.get(`${m.round}:${m.bucket}`);
+                      if (!cell) return <td key={k} className="px-2 py-1.5 text-center text-slate-300">—</td>;
+                      return (
+                        <td key={k} className="px-1.5 py-1.5 text-center">
+                          <span className={`inline-block min-w-[3.5rem] rounded px-1.5 py-0.5 text-[11px] font-semibold ${OUTCOME_BG[cell.outcome]}`}>
+                            {cell.passed}/{cell.total}
+                          </span>
+                        </td>
+                      );
+                    })}
+                  </tr>
+                  {isOpen && testNames.map((tn) => (
+                    <tr key={`${fn}:${tn}`} className="border-t border-slate-50 bg-slate-50/40">
+                      <td className="sticky left-0 bg-slate-50/40 py-1 pl-6 pr-2 font-mono text-[10px] text-slate-500">{tn}</td>
+                      {cols.map(([k, m]) => {
+                        const cell = row.get(`${m.round}:${m.bucket}`);
+                        const t = cell?.tests.find((x: import("../api").CrossEvalCellTest) => x.name === tn);
+                        const cls = t ? STATUS_BG[t.status] ?? "bg-slate-200" : "bg-transparent";
+                        return (
+                          <td key={k} className="px-1.5 py-1 text-center">
+                            <span className={`inline-block h-3 w-3 rounded-sm ${cls}`} title={t ? t.status : "not present"} />
+                          </td>
+                        );
+                      })}
+                    </tr>
+                  ))}
+                </Fragment>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+
+      <div className="mt-3 flex flex-wrap items-center gap-3 text-[10px] text-slate-400">
+        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-emerald-500" /> pass</span>
+        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-rose-500" /> fail</span>
+        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-amber-500" /> error</span>
+        <span className="flex items-center gap-1"><span className="h-2.5 w-2.5 rounded-sm bg-slate-300" /> skipped</span>
+        <span className="ml-2">Cell shows pass/total under the common final suite.</span>
+      </div>
+    </div>
+  );
+}

--- a/web/frontend/src/screens/ImprovementView.tsx
+++ b/web/frontend/src/screens/ImprovementView.tsx
@@ -17,6 +17,7 @@ import {
 } from "lucide-react";
 import * as api from "../api";
 import GapPanel from "./GapPanel";
+import CrossEvalTable from "./CrossEvalTable";
 import type {
   ImprovementRound, ImprovementUnit, IndicatorDelta, LLMCall,
 } from "../api";
@@ -355,6 +356,7 @@ export default function ImprovementView({ sessionId }: { sessionId: string }) {
   return (
     <div className="space-y-3">
       <GapPanel sessionId={sessionId} />
+      <CrossEvalTable sessionId={sessionId} />
       <div className="flex items-end justify-between gap-3">
         <div>
           <h2 className="text-xl font-semibold text-slate-800">Improvement audit</h2>


### PR DESCRIPTION
Renders the cross-evaluation matrix (variant x final suite) as a table: rows are functions, columns are rounds (baseline, accepted, abandoned), each cell coloured by outcome (green pass, red fail, amber error) showing pass/total under the common final suite. Clicking a function expands it into a per-test heat map: one row per test, one coloured square per variant, so a test's outcome across every variant is visible at a glance.

Backend: VariantCell now carries per-test detail (CellTest: name, status, origin_round) parsed from the executor's test_details via the nodeid provenance parser, so the heat map has per-test granularity. The cross-evaluation endpoint returns it; no change to the live judging loop.

Frontend: new CrossEvalTable component and getCrossEvaluation client, mounted above the Improvement audit. Type-checks and vite-builds clean.

Updates tests/test_cross_evaluation.py to assert per-test detail. 739 passed, ruff clean.