### PR TITLE
fix(mutation): derive source module name from tests so

### DIFF
--- a/docs/experiments/mutation-confidence-fix-2026-06-18.md
+++ b/docs/experiments/mutation-confidence-fix-2026-06-18.md
@@ -1,0 +1,57 @@
+# Mutation confidence: why it scored unknown, and the fix
+
+## Symptom
+
+With --mutation-confidence on, gap functions came back confidence=unknown
+(score=None, killed=0) for most functions, even seeded reliability bugs whose
+suites clearly detect the defect. On the reliability_gap lab session the
+distribution was {high: 1, unknown: 3}.
+
+## Cause
+
+The mutation scorer writes the code under test to a temporary module and runs
+the generated suite against each mutant. The generated tests import the function
+from a specific module name, for example:
+
+    from source_reliability_gap_c0 import inclusive_range_count
+
+The scorer wrote the source under a different filename (the default
+"source_module"), so every mutant run failed at import. With no test able to
+run, no mutant could be killed; the scorer correctly judged the run
+uninformative and returned unknown. A compounding bug in the scoring-source
+selection ran the same broken import check and fell back to the buggy ORIGINAL
+source, which has fewer mutable sites, so even the few scores produced were off.
+
+This is the same class of issue fixed earlier in cross-evaluation: the source
+must be written under the exact module name the tests import from.
+
+## Fix
+
+Derive the module name from the tests' import line and write the source under
+it. score_oracle now defaults module_name to the derived name (falling back to
+source_module when no import is present), and the scoring-source check in
+gap_confidence uses the same derivation. No change to mutant generation or the
+kill logic.
+
+## Result
+
+On the same lab session, all four gap functions now score high (1.0), every
+mutant killed: {high: 4}. The seeded reliability bugs have sensitive oracles, so
+their gap findings are high-confidence, which is the expected and correct
+outcome.
+
+## Why it matters for the thesis
+
+The headline gap rate can be reported twice: over all findings, and restricted
+to high-confidence findings. That restricted figure is the direct evidence the
+gap reflects real defects rather than weak-oracle artefacts. Before this fix the
+restricted figure was mostly unknown and unusable; now it is populated. This
+should be confirmed on the E1/E2 runs (the same code path), so it is worth
+fixing before those land rather than after.
+
+## Correction to the earlier calibration note
+
+The earlier calibration note attributed "confidence: null" to the scorer. The
+null seen in judge.json is a separate field (the judge LLM's own confidence) and
+is benign. The real mutation-confidence defect is the module-name mismatch
+described here.

--- a/src/qallm/experiments/gap_confidence.py
+++ b/src/qallm/experiments/gap_confidence.py
@@ -123,7 +123,12 @@ def _scoring_source(original: str, repaired: str | None,
         return original
     try:
         from qallm.verification.executor import run_tests
-        r = run_tests(repaired, test_code, "source_module.py")
+        from qallm.verification.mutation_score import _module_name_from_tests
+        # Write the source under the name the tests import from, else the suite
+        # cannot import it and the check spuriously fails (sending us back to
+        # the buggy original, which makes every mutant look uninformative).
+        mod = _module_name_from_tests(test_code) or "source_module"
+        r = run_tests(repaired, test_code, f"{mod}.py")
         if r.passed > 0 and r.failed == 0:
             return repaired
     except Exception:  # any execution issue: fall back to the original

--- a/src/qallm/verification/mutation_score.py
+++ b/src/qallm/verification/mutation_score.py
@@ -104,11 +104,26 @@ def _suite_kills(source: str, test_code: str, module_name: str,
     return "killed" if baseline_works else "not_viable"
 
 
+def _module_name_from_tests(test_code: str) -> str | None:
+    """The source module name the tests import from.
+
+    Generated tests import the function under test with a line like
+    ``from source_reliability_gap_c0 import inclusive_range_count``. The source
+    being mutated must be written to a file of that exact name or the import
+    fails, every mutant run errors, and the suite appears to detect nothing
+    (killed=0, confidence=unknown). Recover the name from the first matching
+    import so the scorer does not depend on the caller passing it.
+    """
+    import re
+    m = re.search(r"(?m)^\s*from\s+(source_\w+)\s+import\b", test_code)
+    return m.group(1) if m else None
+
+
 def score_oracle(
     source: str,
     func_name: str,
     test_code: str,
-    module_name: str = "source_module",
+    module_name: str | None = None,
     max_per_operator: int = 3,
 ) -> MutationScore:
     """Mutation-test ``test_code`` against ``func_name`` in ``source``.
@@ -116,10 +131,18 @@ def score_oracle(
     Generates mutants of the function, runs the suite against each, and
     aggregates kills. Cost is bounded by max_per_operator mutants per operator
     class. A suite that is empty or invalid trivially scores nothing.
+
+    ``module_name`` is the filename stem the source is written under for the
+    test run; it must match what the generated tests import from. When None
+    (the default), it is derived from the tests' import line, falling back to
+    ``source_module`` if no import is found.
     """
     score = MutationScore(function_name=func_name)
     if not test_code or not test_code.strip():
         return score
+
+    if module_name is None:
+        module_name = _module_name_from_tests(test_code) or "source_module"
 
     mutants: list[Mutant] = generate_mutants(source, func_name, max_per_operator)
     score.total_mutants = len(mutants)

--- a/tests/test_mutation_score.py
+++ b/tests/test_mutation_score.py
@@ -1,6 +1,10 @@
 """Tests for mutation-based oracle confidence scoring."""
 
-from qallm.verification.mutation_score import score_oracle, MutationScore
+from qallm.verification.mutation_score import (
+    MutationScore,
+    _module_name_from_tests,
+    score_oracle,
+)
 
 
 SRC = "def inc(start, end):\n    return end - start + 1\n"
@@ -79,3 +83,35 @@ def test_errored_mutant_counts_as_killed_when_baseline_works():
     assert s.total_mutants > 0
     assert s.viable > 0
     assert s.confidence in ("high", "medium", "low")
+
+
+# --- regression: module name must be derived from the tests' import line ---
+# A suite imports the function from a specific module (for example
+# `from source_foo_c0 import f`). If the scorer writes the source under a
+# different filename, the import fails, every mutant errors, and the suite
+# spuriously detects nothing (killed=0, confidence=unknown). These tests pin
+# that the derived name keeps the suite live so real kills are counted.
+
+
+def test_module_name_derived_from_import():
+    suite = "from source_reliability_gap_c0 import f\ndef test_x(): pass"
+    assert _module_name_from_tests(suite) == "source_reliability_gap_c0"
+
+
+def test_module_name_none_without_import():
+    assert _module_name_from_tests("def test_x(): pass") is None
+
+
+def test_suite_with_named_import_kills_mutants():
+    # The off-by-one is detected only if the suite can import the source under
+    # the name it expects. With the derivation, mutants of `f` are killed.
+    source = "def f(a, b):\n    return a + b\n"
+    suite = (
+        "from source_widget_c0 import f\n"
+        "def test_add(): assert f(2, 3) == 5\n"
+        "def test_zero(): assert f(0, 0) == 0\n"
+    )
+    score = score_oracle(source, "f", suite)  # module_name auto-derived
+    assert score.total_mutants > 0
+    assert score.killed > 0
+    assert score.confidence != "unknown"


### PR DESCRIPTION
 confidence scores

Mutation confidence returned unknown (killed=0) for most gap functions, even seeded reliability bugs whose suites clearly detect the defect. Cause: the generated tests import the function from a specific module name (for example 'from source_reliability_gap_c0 import f'), but score_oracle wrote the source under the default 'source_module', so every mutant run failed at import, no test ran, and no mutant could be killed. A compounding bug in gap_confidence._scoring_source ran the same broken import check and fell back to the buggy original source.

Fix: derive the module name from the tests' import line and write the source under it. score_oracle.module_name now defaults to the derived name (falling back to source_module when absent); gap_confidence uses the same derivation. No change to mutant generation or kill logic.

On the reliability_gap lab session the distribution goes from {high:1, unknown:3} to {high:4}: all seeded bugs now correctly score high. This restores the high-confidence gap figure the thesis headline relies on, and the same code path feeds E1/E2, so it matters before those runs.

Adds 3 regression tests; corrects the earlier calibration note. 742 passed, ruff clean.