### PR TITLE
feat(rq2): confirm reliability via gap defects; log failed-input trac…

### DIFF
--- a/docs/experiments/rq2-reliability-confirmation-2026-06-20.md
+++ b/docs/experiments/rq2-reliability-confirmation-2026-06-20.md
@@ -1,0 +1,44 @@
+# RQ2 reframe: reliability confirmation from gap defects
+
+## The problem (from the E2 run)
+
+E2 (confirm on, full ENVRI corpus) returned confirmed = 0. Diagnosis: static
+analysers never emit RELIABILITY findings (Bandit = SECURITY, Radon =
+COMPLEXITY/MAINTAINABILITY, SonarQube = MAINTAINABILITY). The static-finding
+confirm path can therefore only reach SECURITY findings, which are inconclusive
+by design. The reliability defects have no static finding to confirm, because
+static analysis missing them is the definition of the gap.
+
+## The reframe (MD-006)
+
+Treat each execution-only gap defect as a confirmed reliability defect: its
+round-0 correctness test failed against the original code, which is the
+reproduction. RQ3 re-runs that test against the repaired code; a pass is a
+verified fix. Static-finding confirmation is kept and reported separately.
+
+## Evidence (reliability_gap lab session)
+
+- Reliability confirmations: 5 (the five seeded defects), was 0.
+- Verified-fix: 4 fixed, 1 not fixed (accumulate), rate 0.8.
+- The not-fixed case is a true negative: the reproducing test still fails on the
+  repaired variant, consistent with the cross-evaluation.
+
+A subtlety fixed along the way: the reproducing tests import the source under a
+specific module name (source_<unit>_c0); the repaired source must be written
+under that name or the test cannot import it and the fix verdict is spuriously
+inconclusive. The module name is now derived from the test's import line.
+
+## For the next full run
+
+Re-run E2 (confirm on) from a CLEAN dev tree. Expect a real confirmation count
+(the gap defects) and a real verified-fix rate. The static-finding side will
+still be security-inconclusive, reported separately.
+
+## Open, unrelated: the 186 errored notebooks
+
+186 of 203 errored inputs fail with 'str' object has no attribute 'get'. The
+NotebookAdapter guard (commit 8f9729f) was present in both run commits, so the
+error is downstream of ingestion, inside orch.run(), not the parser. The exact
+line needs a triggering notebook. The runner now logs the full traceback at
+warning level (was debug), so the next run will surface the stack. Send a couple
+of those tracebacks and the fix is quick.

--- a/docs/thesis/methodology-decisions.md
+++ b/docs/thesis/methodology-decisions.md
@@ -165,3 +165,47 @@ accepted contrast is a concrete demonstration that the judge's decisions hold up
 under a fairer test. A limitation to state: the final suite is itself generated,
 so it is the strongest suite the session produced, not an external ground truth;
 on the labelled set it can be cross-checked against the answer key.
+
+
+## MD-006: RQ2 confirmation reframed for reliability via the gap defects
+
+**Date**: 2026-06-20
+
+**Decision**: confirmation (RQ2) for reliability is derived from the
+execution-only gap defects, not from static findings. Each execution-only defect,
+a function whose generated correctness test failed against the original code, is
+recorded as a confirmed RELIABILITY defect, with that failing test as its
+reproducing test. RQ3 (verified-fix) then re-runs each such test against the
+repaired code; a pass means the defect is fixed. Static-finding confirmation is
+retained and reported separately (confirmed_static), and remains inconclusive for
+security by design.
+
+**Why**: the E2 run (2026-06-20, confirm on) returned confirmed = 0 across the
+whole ENVRI corpus. The cause is not a bug in the run: the static analysers emit
+SECURITY, COMPLEXITY, and MAINTAINABILITY findings, never RELIABILITY. So the
+static-finding confirm path can only ever adjudicate SECURITY findings, which are
+inconclusive without a demonstrated exploit (the documented security-scope
+limit). The reliability defects that are the heart of the verification gap have
+no static finding for that path to confirm, because static analysis missing them
+is the entire premise of the gap. Confirming them therefore has to come from the
+execution evidence itself, which the gap pipeline already produces.
+
+**Why this is sound, not circular**: a gap defect is confirmed by a correctness
+test that asserts the specification (derived from the signature and docstring,
+never the body, see MD on the correctness oracle) and fails on the original code.
+That is independent evidence of a real defect, the same standard the static-
+finding path uses (a targeted test that reproduces the finding). The reframe
+applies that standard to the defects execution found rather than only to the
+findings static analysis raised.
+
+**Evidence**: on the reliability_gap lab session the reframe yields 5 confirmed
+reliability defects (was 0) and a verified-fix rate of 4/5 = 0.8. The one
+not-fixed (accumulate) is a true negative: its reproducing test still fails on
+the repaired variant, which the cross-evaluation independently corroborates.
+
+**Implication for the thesis**: RQ2 is reported as two confirmation sources kept
+distinct: reliability confirmation from the gap defects (a real, non-trivial
+count and rate), and static-finding confirmation (security, inconclusive by
+design). RQ3 follows from the reliability confirmations. State the framing
+explicitly so the confirmation rate is not mistaken for static-finding
+corroboration.

--- a/src/qallm/experiments/confirm_verify.py
+++ b/src/qallm/experiments/confirm_verify.py
@@ -42,6 +42,24 @@ def _read_json(path: str):
         return None
 
 
+def _module_name_from_findings(findings: list[dict]) -> str | None:
+    """The source module name the reproducing tests import from.
+
+    Generated tests import the function under test with a line like
+    ``from source_reliability_gap_c0 import f``. The source must be written
+    under that exact name or the test cannot import it. Recover the name from
+    the first reproducing test that has an import, so verify-fixes does not
+    depend on the unit-segment name matching the import.
+    """
+    import re
+    for f in findings:
+        code = f.get("reproducing_test") or ""
+        m = re.search(r"(?m)^\s*from\s+(source_\w+)\s+import\b", code)
+        if m:
+            return m.group(1)
+    return None
+
+
 def _baseline_dir(report_dir: str) -> str | None:
     """Resolve the round-0 lineage directory.
 
@@ -78,6 +96,73 @@ def _baseline_units(report_dir: str) -> dict[str, dict]:
     return units
 
 
+def _reliability_confirmations(report_dir: str, gap_rounds: list[dict]) -> list[dict]:
+    """Confirmed reliability defects, from the execution-only (gap) defects.
+
+    The static analysers never emit RELIABILITY findings: they flag security,
+    complexity, and maintainability. So the static-finding confirmation path can
+    only ever speak to security, which is inconclusive by design, and the
+    reliability defects that are the heart of the verification gap have no static
+    finding for that path to adjudicate.
+
+    A gap defect is, however, already a confirmed reliability defect by
+    construction: it is an execution-only defect, meaning a generated correctness
+    test failed against the original (round-0) code. That failing test is the
+    reproduction. This helper recovers, for each round-0 execution-only function,
+    its round-0 test as the ``reproducing_test`` and records a confirmed
+    RELIABILITY verdict, so RQ2 has a real confirmation count and RQ3 can re-run
+    those tests against the repaired code (a pass means the defect is fixed).
+
+    Read-only. It reads the round-0 ``tests/`` artefacts the reporter persists.
+    """
+    base = _baseline_dir(report_dir)
+    if base is None:
+        return []
+    # Round-0 execution-only functions per unit are listed in the round-0 gap
+    # report; fall back to an empty list when absent.
+    gap_funcs: list[str] = []
+    for r in gap_rounds:
+        if int(r.get("round", r.get("round_number", 0)) or 0) == 0:
+            gap_funcs = list(r.get("execution_only_functions", []) or [])
+            break
+    if not gap_funcs:
+        return []
+
+    confirmations: list[dict] = []
+    for unit_seg in sorted(os.listdir(base)):
+        unit_dir = os.path.join(base, unit_seg)
+        tests_dir = os.path.join(unit_dir, "tests")
+        if not os.path.isdir(tests_dir):
+            continue
+        for fname in gap_funcs:
+            test_path = os.path.join(tests_dir, f"test_{fname}.py")
+            test_code = _read_text(test_path)
+            if not test_code.strip():
+                continue
+            confirmations.append({
+                "finding_index": -1,
+                "tool": "execution",
+                "type": "RELIABILITY",
+                "severity": "?",
+                "line": 0,
+                "message": (
+                    "Execution-only defect: a correctness test failed against "
+                    "the original code, reproducing a reliability defect that "
+                    "static analysis did not flag."
+                ),
+                "rule_id": "gap.reliability",
+                "function": fname,
+                "verdict": "confirmed",
+                "reason": (
+                    "The generated correctness test failed on the baseline "
+                    "source, demonstrating the defect."
+                ),
+                "reproducing_test": test_code,
+                "file": unit_seg,
+            })
+    return confirmations
+
+
 def _final_sources(report_dir: str) -> dict[str, str]:
     """Map unit name -> final accepted source (highest-numbered lineage round).
 
@@ -105,13 +190,21 @@ def _final_sources(report_dir: str) -> dict[str, str]:
     return finals
 
 
-def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None) -> dict:
+def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None,
+                                gap_rounds: list[dict] | None = None) -> dict:
     """Run confirm/refute (RQ2) and verify-fixes (RQ3) from disk artefacts.
 
     Returns {"confirm_summary": {...} | None, "verify_summary": {...} | None}
     matching the shapes the endpoints record on session state, so
     build_session_metrics can consume them unchanged. Summaries are None when
     there was nothing to do (no findings, or no repaired source).
+
+    RQ2 has two confirmation sources, kept distinct in the summary:
+    static-finding confirmation (security findings, which are inconclusive by
+    design) and reliability confirmation derived from the execution-only gap
+    defects (see _reliability_confirmations). The latter is what gives RQ2 a
+    non-trivial confirmation count on this corpus, because static analysis emits
+    no reliability findings.
     """
     from qallm.verification.confirm_refute import FindingConfirmer
     from qallm.verification.verified_fix import verify_fixes
@@ -177,18 +270,28 @@ def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None) -> d
                 [(s.name, s.start, s.end) for s in spans],
             )
 
-    denom = confirmed + refuted
+    # Reliability confirmations from the execution-only gap defects. These are
+    # confirmed by construction (a correctness test failed on the baseline), so
+    # they add to the confirmed count and carry a reproducing test for RQ3.
+    rel_confirmations = _reliability_confirmations(report_dir, gap_rounds or [])
+    reliability_confirmed = len(rel_confirmations)
+    confirmed_verdicts.extend(rel_confirmations)
+    confirmed_total = confirmed + reliability_confirmed
+    confirm_denom = confirmed_total + refuted
     confirm_summary = {
-        "confirmed": confirmed,
+        "confirmed": confirmed_total,
+        "confirmed_static": confirmed,
+        "confirmed_reliability_gap": reliability_confirmed,
         "refuted": refuted,
         "inconclusive": inconclusive,
         "not_execution_testable": not_testable,
-        "confirmation_rate": (confirmed / denom) if denom else None,
+        "confirmation_rate": (confirmed_total / confirm_denom) if confirm_denom else None,
     }
     logger.info(
-        "Confirm/verify verdicts: confirmed=%d refuted=%d inconclusive=%d "
-        "not_execution_testable=%d", confirmed, refuted, inconclusive,
-        not_testable,
+        "Confirm/verify verdicts: confirmed=%d (static=%d, reliability_gap=%d) "
+        "refuted=%d inconclusive=%d not_execution_testable=%d",
+        confirmed_total, confirmed, reliability_confirmed, refuted,
+        inconclusive, not_testable,
     )
 
     # Verify fixes: re-run each confirmed finding's reproducing test against
@@ -205,10 +308,20 @@ def confirm_and_verify_from_dir(report_dir: str, testgen_llm, tracker=None) -> d
             if not repaired_source:
                 vinconclusive += len(file_findings)
                 continue
+            # The reproducing tests import the source under a specific module
+            # name (for example source_reliability_gap_c0); the repaired source
+            # must be written under that name or the test cannot import it and
+            # the fix verdict is spuriously inconclusive. Derive it from the
+            # tests rather than the unit segment name.
+            derived = _module_name_from_findings(file_findings)
+            source_filename = (
+                f"{derived}.py" if derived
+                else (name if name.endswith(".py") else f"{name}.py")
+            )
             report = verify_fixes(
                 confirmed_findings=file_findings,
                 repaired_source=repaired_source,
-                source_filename=name if name.endswith(".py") else f"{name}.py",
+                source_filename=source_filename,
             )
             verified_fixed += report.verified_fixed
             not_fixed += report.not_fixed

--- a/src/qallm/experiments/gap_runner.py
+++ b/src/qallm/experiments/gap_runner.py
@@ -465,6 +465,7 @@ def _run_one(
                 report_dir,
                 testgen_llm=getattr(orch, "testgen_llm", None) or getattr(orch, "llm", None),
                 tracker=getattr(orch, "tracker", None),
+                gap_rounds=gap_rounds,
             )
             confirm_summary = cv["confirm_summary"]
             verify_summary = cv["verify_summary"]
@@ -494,8 +495,13 @@ def _run_one(
             row["gap_confidence"] = gap_confidence
         return row
     except Exception as e:  # one bad notebook should not sink the run
-        logger.warning("Input failed: %s: %s", input_path, e)
-        logger.debug("Traceback for %s:\n%s", input_path, traceback.format_exc())
+        # Log the full traceback at warning level (not debug): when a class of
+        # notebooks fails with the same message, the per-input message alone is
+        # not enough to locate the cause. The traceback points at the exact line.
+        logger.warning(
+            "Input failed: %s: %s\n%s",
+            input_path, e, traceback.format_exc(),
+        )
         return {"input": str(input_path), "metrics": None, "error": str(e)}
 
 

--- a/tests/test_reliability_confirmation.py
+++ b/tests/test_reliability_confirmation.py
@@ -1,0 +1,53 @@
+"""Tests for reliability confirmation from execution-only gap defects.
+
+Static analysers emit no RELIABILITY findings, so the static-finding confirm
+path can never confirm a reliability defect. These tests pin the reframe: a gap
+defect (a correctness test that failed on the baseline) is treated as a
+confirmed reliability defect, and its reproducing test drives RQ3.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from qallm.experiments.confirm_verify import (
+    _module_name_from_findings,
+    _reliability_confirmations,
+)
+
+
+def _gap_session(tmp: Path) -> tuple[str, list[dict]]:
+    """A baseline with one gap function and its reproducing test."""
+    unit = tmp / "lineage" / "round_00" / "unit_c0"
+    (unit / "tests").mkdir(parents=True)
+    (unit / "source.py").write_text("def f(n):\n    return n\n")
+    (unit / "tests" / "test_f.py").write_text(
+        "from source_unit_c0 import f\n"
+        "def test_f(): assert f(1) == 2\n"
+    )
+    gap_rounds = [{"round": 0, "execution_only_functions": ["f"]}]
+    return str(tmp), gap_rounds
+
+
+def test_gap_defect_becomes_confirmed_reliability(tmp_path: Path) -> None:
+    report_dir, gap_rounds = _gap_session(tmp_path)
+    confs = _reliability_confirmations(report_dir, gap_rounds)
+    assert len(confs) == 1
+    c = confs[0]
+    assert c["verdict"] == "confirmed"
+    assert c["type"] == "RELIABILITY"
+    assert c["function"] == "f"
+    assert "from source_unit_c0 import f" in c["reproducing_test"]
+
+
+def test_no_gap_functions_no_confirmations(tmp_path: Path) -> None:
+    report_dir, _ = _gap_session(tmp_path)
+    assert _reliability_confirmations(report_dir, [{"round": 0, "execution_only_functions": []}]) == []
+
+
+def test_module_name_derived_from_reproducing_test() -> None:
+    findings = [{"reproducing_test": "from source_widget_c0 import g\ndef test_g(): pass"}]
+    assert _module_name_from_findings(findings) == "source_widget_c0"
+
+
+def test_module_name_none_without_import() -> None:
+    assert _module_name_from_findings([{"reproducing_test": "def test_x(): pass"}]) is None


### PR DESCRIPTION
…ebacks

E2 (confirm on) returned confirmed = 0 across the whole corpus. Root cause: the static analysers emit SECURITY, COMPLEXITY, and MAINTAINABILITY findings, never RELIABILITY, so the static-finding confirm path can only reach SECURITY (which is inconclusive by design). The reliability defects that define the verification gap have no static finding to confirm.

Reframe (MD-006): derive reliability confirmation from the execution-only gap defects. Each gap defect's round-0 correctness test failed against the original code; that is the reproduction, so the defect is a confirmed RELIABILITY defect with that test as its reproducing test. RQ3 re-runs the test against the repaired source (pass = fixed). Static-finding confirmation is retained and reported separately (confirmed_static vs confirmed_reliability_gap).

A reproducing test imports the source under a specific module name; the repaired source must be written under that name or the test cannot import it and the fix verdict is spuriously inconclusive. The name is now derived from the test's import line (_module_name_from_findings).

On the reliability_gap lab session: 5 confirmed reliability defects (was 0), verified-fix rate 4/5 = 0.8; the one not-fixed is a true negative.

Also: _run_one now logs the full traceback at warning level (was debug) so the next run surfaces what the 186 errored notebooks hit (the error is downstream of ingestion, not the already-guarded parser).

Adds tests/test_reliability_confirmation.py (4), MD-006, and an experiment note. 751 passed, ruff clean.